### PR TITLE
Async upload UX + Google Maps location on receipt detail

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@google/genai": "^1.29.0",
         "@tailwindcss/vite": "^4.1.14",
+        "@vis.gl/react-google-maps": "^1.8.3",
         "@vitejs/plugin-react": "^5.0.4",
         "browser-image-compression": "^2.0.2",
         "clsx": "^2.1.1",
@@ -995,6 +996,15 @@
         }
       }
     },
+    "node_modules/@googlemaps/js-api-loader": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@googlemaps/js-api-loader/-/js-api-loader-2.0.2.tgz",
+      "integrity": "sha512-bKVuTqatS8Jven5aFqVB7rCHF1VFEzpzyi0ruzO0GUR+A7m9oMqMgtnmpANj7kMYEvvhty8Fk7TnJ1MKjWHu+Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/google.maps": "^3.53.1"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1901,6 +1911,12 @@
         "@types/send": "*"
       }
     },
+    "node_modules/@types/google.maps": {
+      "version": "3.58.1",
+      "resolved": "https://registry.npmjs.org/@types/google.maps/-/google.maps-3.58.1.tgz",
+      "integrity": "sha512-X9QTSvGJ0nCfMzYOnaVs/k6/4L+7F5uCS+4iUmkLEls6J9S/Phv+m/i3mDeyc49ZBgwab3EFO1HEoBY7k98EGQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/http-errors": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
@@ -2250,6 +2266,21 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@vis.gl/react-google-maps": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@vis.gl/react-google-maps/-/react-google-maps-1.8.3.tgz",
+      "integrity": "sha512-DW7nEuvOJ299DmdBnvGiUARrgS/+sTEO1iJgG9J8YaErZqLoq7S4TJ22f3EjJvR4dti4L4gft43JEK77nnKXDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@googlemaps/js-api-loader": "^2.0.2",
+        "@types/google.maps": "^3.54.10",
+        "fast-deep-equal": "^3.1.3"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": ">=16.8.0 || ^19.0 || ^19.0.0-rc"
       }
     },
     "node_modules/@vitejs/plugin-react": {
@@ -3442,7 +3473,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-equals": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@google/genai": "^1.29.0",
         "@tailwindcss/vite": "^4.1.14",
         "@vitejs/plugin-react": "^5.0.4",
+        "browser-image-compression": "^2.0.2",
         "clsx": "^2.1.1",
         "dotenv": "^17.2.3",
         "express": "^4.21.2",
@@ -68,6 +69,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -319,6 +321,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -335,6 +338,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -351,6 +355,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -367,6 +372,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -383,6 +389,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -399,6 +406,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -415,6 +423,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -431,6 +440,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -447,6 +457,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -463,6 +474,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -479,6 +491,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -495,6 +508,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -511,6 +525,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -527,6 +542,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -543,6 +559,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -559,6 +576,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -575,6 +593,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -591,6 +610,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -607,6 +627,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -623,6 +644,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -639,6 +661,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -655,6 +678,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -671,6 +695,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -687,6 +712,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -703,6 +729,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -719,6 +746,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1923,6 +1951,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2011,6 +2040,7 @@
       "integrity": "sha512-gGkiNMPqerb2cJSVcruigx9eHBlLG14fSdPdqMoOcBfh+vvn4iCq2C8MzUB89PrxOXk0y3GZ1yIWb9aOzL93bw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.1",
         "@typescript-eslint/types": "8.58.1",
@@ -2261,6 +2291,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2473,6 +2504,15 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/browser-image-compression": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/browser-image-compression/-/browser-image-compression-2.0.2.tgz",
+      "integrity": "sha512-pBLlQyUf6yB8SmmngrcOw3EoS4RpQ1BcylI3T9Yqn7+4nrQTXJD4sJDe5ODnJdrvNMaio5OicFo75rDyJD2Ucw==",
+      "license": "MIT",
+      "dependencies": {
+        "uzip": "0.20201231.0"
+      }
+    },
     "node_modules/browserslist": {
       "version": "4.28.2",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
@@ -2492,6 +2532,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -3069,6 +3110,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4829,6 +4871,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -4963,6 +5006,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4972,6 +5016,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -5455,6 +5500,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -5501,6 +5547,7 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5597,6 +5644,12 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/uzip": {
+      "version": "0.20201231.0",
+      "resolved": "https://registry.npmjs.org/uzip/-/uzip-0.20201231.0.tgz",
+      "integrity": "sha512-OZeJfZP+R0z9D6TmBgLq2LHzSSptGMGDGigGiEe0pr8UBe/7fdflgHlHBNDASTXB5jnFuxHpNaJywSg8YFeGng==",
+      "license": "MIT"
+    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -5633,6 +5686,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
       "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -6240,6 +6294,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@google/genai": "^1.29.0",
     "@tailwindcss/vite": "^4.1.14",
+    "@vis.gl/react-google-maps": "^1.8.3",
     "@vitejs/plugin-react": "^5.0.4",
     "browser-image-compression": "^2.0.2",
     "clsx": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@google/genai": "^1.29.0",
     "@tailwindcss/vite": "^4.1.14",
     "@vitejs/plugin-react": "^5.0.4",
+    "browser-image-compression": "^2.0.2",
     "clsx": "^2.1.1",
     "dotenv": "^17.2.3",
     "express": "^4.21.2",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,18 +5,40 @@ import Transactions from './components/Transactions';
 import MonthlyReview from './components/MonthlyReview';
 import YearlyReview from './components/YearlyReview';
 import AddTransactionModal from './components/AddTransactionModal';
+import ProcessingToast, { useProcessingJobs } from './components/ProcessingToast';
+import ReceiptDetail from './components/ReceiptDetail';
 
 export default function App() {
   const [activeTab, setActiveTab] = React.useState('dashboard');
   const [isModalOpen, setIsModalOpen] = React.useState(false);
   const [refreshKey, setRefreshKey] = React.useState(0);
+  const [selectedReceiptId, setSelectedReceiptId] = React.useState<string | null>(null);
+  const { jobs, addJob, removeJob } = useProcessingJobs();
+
+  const handleUploadComplete = (job: { jobId: string; receiptId: string }) => {
+    addJob(job);
+    setRefreshKey((k) => k + 1);
+  };
+
+  const handleSelectReceipt = (receiptId: string) => {
+    setSelectedReceiptId(receiptId);
+  };
+
+  const handleBackFromDetail = () => {
+    setSelectedReceiptId(null);
+  };
 
   const renderContent = () => {
+    // Receipt detail view takes priority
+    if (selectedReceiptId) {
+      return <ReceiptDetail receiptId={selectedReceiptId} onBack={handleBackFromDetail} />;
+    }
+
     switch (activeTab) {
       case 'dashboard':
-        return <Dashboard key={refreshKey} />;
+        return <Dashboard key={refreshKey} onSelectReceipt={handleSelectReceipt} />;
       case 'transactions':
-        return <Transactions key={refreshKey} />;
+        return <Transactions key={refreshKey} onSelectReceipt={handleSelectReceipt} />;
       case 'monthly':
         return <MonthlyReview />;
       case 'yearly':
@@ -35,24 +57,33 @@ export default function App() {
           </div>
         );
       default:
-        return <Dashboard />;
+        return <Dashboard key={refreshKey} onSelectReceipt={handleSelectReceipt} />;
     }
   };
 
   return (
     <>
-      <Layout 
-        activeTab={activeTab} 
-        onTabChange={setActiveTab} 
+      <Layout
+        activeTab={activeTab}
+        onTabChange={(tab) => {
+          setSelectedReceiptId(null);
+          setActiveTab(tab);
+        }}
         onAddTransaction={() => setIsModalOpen(true)}
       >
         {renderContent()}
       </Layout>
-      
+
       <AddTransactionModal
         isOpen={isModalOpen}
         onClose={() => setIsModalOpen(false)}
-        onComplete={() => setRefreshKey((k) => k + 1)}
+        onComplete={handleUploadComplete}
+      />
+
+      <ProcessingToast
+        jobs={jobs}
+        onJobDone={removeJob}
+        onRefresh={() => setRefreshKey((k) => k + 1)}
       />
     </>
   );

--- a/src/components/AddTransactionModal.tsx
+++ b/src/components/AddTransactionModal.tsx
@@ -1,28 +1,26 @@
 import React from 'react';
-import { X, Upload, ArrowRight, Loader2, CheckCircle, AlertCircle } from 'lucide-react';
+import { X, Upload, ArrowRight, Loader2, AlertCircle } from 'lucide-react';
 import { motion, AnimatePresence } from 'motion/react';
-import { uploadReceipt, pollJob, type JobStatus } from '../lib/api';
+import { uploadReceipt } from '../lib/api';
 import { cn } from '../lib/utils';
 
 interface AddTransactionModalProps {
   isOpen: boolean;
   onClose: () => void;
-  onComplete?: () => void;
+  onComplete?: (job: { jobId: string; receiptId: string }) => void;
 }
 
-type UploadState = 'idle' | 'uploading' | 'processing' | 'quick_done' | 'done' | 'error';
+type UploadState = 'idle' | 'uploading' | 'error';
 
 export default function AddTransactionModal({ isOpen, onClose, onComplete }: AddTransactionModalProps) {
   const [file, setFile] = React.useState<File | null>(null);
   const [state, setState] = React.useState<UploadState>('idle');
-  const [jobStatus, setJobStatus] = React.useState<JobStatus | null>(null);
   const [error, setError] = React.useState<string | null>(null);
   const fileInputRef = React.useRef<HTMLInputElement>(null);
 
   const reset = () => {
     setFile(null);
     setState('idle');
-    setJobStatus(null);
     setError(null);
   };
 
@@ -43,27 +41,9 @@ export default function AddTransactionModal({ isOpen, onClose, onComplete }: Add
 
     try {
       const result = await uploadReceipt(file);
-      setState('processing');
-
-      // Poll for completion
-      const poll = async () => {
-        const status = await pollJob(result.jobId);
-        setJobStatus(status);
-
-        if (status.status === 'quick_done' || status.status === 'processing_full') {
-          setState('quick_done');
-          setTimeout(poll, 2000);
-        } else if (status.status === 'done') {
-          setState('done');
-          onComplete?.();
-        } else if (status.status === 'error') {
-          setState('error');
-          setError(status.error ?? 'Extraction failed');
-        } else {
-          setTimeout(poll, 2000);
-        }
-      };
-      poll();
+      // Close immediately — processing happens in background
+      onComplete?.({ jobId: result.jobId, receiptId: result.receiptId });
+      handleClose();
     } catch (err: any) {
       setState('error');
       setError(err.message);
@@ -110,7 +90,7 @@ export default function AddTransactionModal({ isOpen, onClose, onComplete }: Add
                 <input
                   ref={fileInputRef}
                   type="file"
-                  accept="image/*,.heic,.heif"
+                  accept="image/jpeg,.jpg,.jpeg"
                   onChange={handleFileChange}
                   className="hidden"
                 />
@@ -124,36 +104,18 @@ export default function AddTransactionModal({ isOpen, onClose, onComplete }: Add
                   <div className="space-y-2">
                     <Upload className="mx-auto text-on-surface-variant" size={32} />
                     <p className="text-sm text-on-surface-variant">Click to select a receipt image</p>
-                    <p className="text-xs text-on-surface-variant/50">JPG, PNG, HEIC up to 20MB</p>
+                    <p className="text-xs text-on-surface-variant/50">JPG only, up to 20MB</p>
                   </div>
                 )}
               </div>
 
-              {/* Progress / Status */}
-              {state !== 'idle' && (
-                <div className="space-y-3">
-                  <div className="flex items-center gap-3 p-4 rounded-xl bg-surface-container-lowest">
-                    {state === 'uploading' && <Loader2 className="animate-spin text-primary" size={20} />}
-                    {state === 'processing' && <Loader2 className="animate-spin text-tertiary" size={20} />}
-                    {state === 'quick_done' && <Loader2 className="animate-spin text-secondary" size={20} />}
-                    {state === 'done' && <CheckCircle className="text-primary" size={20} />}
-                    {state === 'error' && <AlertCircle className="text-error" size={20} />}
-
-                    <div className="flex-1">
-                      <p className="text-sm font-bold text-white">
-                        {state === 'uploading' && 'Uploading...'}
-                        {state === 'processing' && 'AI is reading the receipt...'}
-                        {state === 'quick_done' && 'Extracting details...'}
-                        {state === 'done' && 'Receipt processed!'}
-                        {state === 'error' && 'Error'}
-                      </p>
-                      {state === 'quick_done' && jobStatus?.quickResult && (
-                        <p className="text-xs text-on-surface-variant mt-1">
-                          {jobStatus.quickResult.merchant} — ${jobStatus.quickResult.total}
-                        </p>
-                      )}
-                      {state === 'error' && <p className="text-xs text-error mt-1">{error}</p>}
-                    </div>
+              {/* Error state */}
+              {state === 'error' && (
+                <div className="flex items-center gap-3 p-4 rounded-xl bg-surface-container-lowest">
+                  <AlertCircle className="text-error" size={20} />
+                  <div className="flex-1">
+                    <p className="text-sm font-bold text-white">Error</p>
+                    <p className="text-xs text-error mt-1">{error}</p>
                   </div>
                 </div>
               )}
@@ -175,12 +137,13 @@ export default function AddTransactionModal({ isOpen, onClose, onComplete }: Add
                     <ArrowRight size={20} />
                   </button>
                 )}
-                {state === 'done' && (
+                {state === 'uploading' && (
                   <button
-                    onClick={handleClose}
-                    className="w-full py-4 rounded-xl bg-primary text-on-primary font-bold text-lg hover:scale-[1.02] active:scale-95 transition-all shadow-lg shadow-primary/20"
+                    disabled
+                    className="w-full py-4 rounded-xl bg-primary/50 text-on-primary font-bold text-lg flex items-center justify-center gap-2"
                   >
-                    Done
+                    <Loader2 className="animate-spin" size={20} />
+                    Uploading...
                   </button>
                 )}
                 {state === 'error' && (

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -26,7 +26,11 @@ import type { Transaction } from '../types';
 
 const CHART_COLORS = ['#4edea3', '#d0bcff', '#7bd0ff', '#ffb4ab', '#a8c7fa'];
 
-export default function Dashboard() {
+interface DashboardProps {
+  onSelectReceipt?: (receiptId: string) => void;
+}
+
+export default function Dashboard({ onSelectReceipt }: DashboardProps) {
   const [transactions, setTransactions] = useState<Transaction[]>([]);
   const [summary, setSummary] = useState<SpendingSummary[]>([]);
   const [loading, setLoading] = useState(true);
@@ -193,21 +197,41 @@ export default function Dashboard() {
           ) : (
             <div className="space-y-4">
               {transactions.slice(0, 5).map((tx) => (
-                <div key={tx.id} className="flex items-center justify-between p-3 rounded-xl hover:bg-surface-container-high transition-colors group cursor-pointer">
+                <div
+                  key={tx.id}
+                  onClick={() => tx.status !== 'Processing' && onSelectReceipt?.(tx.id)}
+                  className={cn(
+                    "flex items-center justify-between p-3 rounded-xl transition-colors group",
+                    tx.status === 'Processing' ? 'cursor-default opacity-70' : 'cursor-pointer hover:bg-surface-container-high'
+                  )}
+                >
                   <div className="flex items-center gap-4">
-                    <div className="w-10 h-10 rounded-full bg-surface-container-highest flex items-center justify-center text-primary group-hover:bg-primary group-hover:text-on-primary transition-all">
-                      {getIcon(tx.category)}
+                    <div className={cn(
+                      "w-10 h-10 rounded-full bg-surface-container-highest flex items-center justify-center transition-all",
+                      tx.status === 'Processing'
+                        ? 'text-tertiary animate-pulse'
+                        : 'text-primary group-hover:bg-primary group-hover:text-on-primary'
+                    )}>
+                      {tx.status === 'Processing' ? <Loader2 className="animate-spin" size={18} /> : getIcon(tx.category)}
                     </div>
                     <div>
                       <p className="text-sm font-bold text-white">{tx.description}</p>
-                      <p className="text-xs text-on-surface-variant">{tx.category} • {tx.date}</p>
+                      <p className="text-xs text-on-surface-variant">
+                        {tx.status === 'Processing' ? 'Processing...' : `${tx.category} • ${tx.date}`}
+                      </p>
                     </div>
                   </div>
                   <div className="text-right">
-                    <p className={cn("text-sm font-bold", tx.amount > 0 ? "text-primary" : "text-white")}>
-                      {tx.amount > 0 ? '+' : ''}{tx.amount.toLocaleString('en-US', { style: 'currency', currency: 'USD' })}
+                    <p className={cn("text-sm font-bold",
+                      tx.status === 'Processing' ? 'text-on-surface-variant' :
+                      tx.amount > 0 ? "text-primary" : "text-white"
+                    )}>
+                      {tx.status === 'Processing' ? '--' : (
+                        <>{tx.amount > 0 ? '+' : ''}{tx.amount.toLocaleString('en-US', { style: 'currency', currency: 'USD' })}</>
+                      )}
                     </p>
                     <p className={cn("text-[10px]",
+                      tx.status === 'Processing' ? 'text-tertiary animate-pulse' :
                       tx.status === 'Verified' ? 'text-primary' :
                       tx.status === 'Pending' ? 'text-error' : 'text-tertiary'
                     )}>{tx.status}</p>

--- a/src/components/ProcessingToast.tsx
+++ b/src/components/ProcessingToast.tsx
@@ -1,0 +1,155 @@
+import React, { useEffect, useState } from 'react';
+import { Loader2, CheckCircle, XCircle, X } from 'lucide-react';
+import { motion, AnimatePresence } from 'motion/react';
+import { pollJob } from '../lib/api';
+
+interface ProcessingJob {
+  jobId: string;
+  receiptId: string;
+}
+
+interface ToastState {
+  jobId: string;
+  receiptId: string;
+  status: 'processing' | 'done' | 'error';
+  error?: string;
+}
+
+interface ProcessingToastProps {
+  jobs: ProcessingJob[];
+  onJobDone: (jobId: string) => void;
+  onRefresh: () => void;
+}
+
+const STORAGE_KEY = 'receipt-processing-jobs';
+
+export function useProcessingJobs() {
+  const [jobs, setJobs] = useState<ProcessingJob[]>(() => {
+    try {
+      const saved = localStorage.getItem(STORAGE_KEY);
+      return saved ? JSON.parse(saved) : [];
+    } catch {
+      return [];
+    }
+  });
+
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(jobs));
+  }, [jobs]);
+
+  const addJob = (job: ProcessingJob) => {
+    setJobs((prev) => [...prev, job]);
+  };
+
+  const removeJob = (jobId: string) => {
+    setJobs((prev) => prev.filter((j) => j.jobId !== jobId));
+  };
+
+  return { jobs, addJob, removeJob };
+}
+
+export default function ProcessingToast({ jobs, onJobDone, onRefresh }: ProcessingToastProps) {
+  const [toasts, setToasts] = useState<ToastState[]>([]);
+
+  // Initialize toasts from jobs
+  useEffect(() => {
+    setToasts((prev) => {
+      const existing = new Set(prev.map((t) => t.jobId));
+      const newToasts = jobs
+        .filter((j) => !existing.has(j.jobId))
+        .map((j) => ({ jobId: j.jobId, receiptId: j.receiptId, status: 'processing' as const }));
+      return [...prev, ...newToasts];
+    });
+  }, [jobs]);
+
+  // Poll each processing toast
+  useEffect(() => {
+    const processing = toasts.filter((t) => t.status === 'processing');
+    if (processing.length === 0) return;
+
+    const interval = setInterval(async () => {
+      for (const toast of processing) {
+        try {
+          const result = await pollJob(toast.jobId);
+          if (result.status === 'done') {
+            setToasts((prev) =>
+              prev.map((t) => (t.jobId === toast.jobId ? { ...t, status: 'done' } : t))
+            );
+            onRefresh();
+            // Auto-dismiss after 3 seconds
+            setTimeout(() => {
+              setToasts((prev) => prev.filter((t) => t.jobId !== toast.jobId));
+              onJobDone(toast.jobId);
+            }, 3000);
+          } else if (result.status === 'error') {
+            setToasts((prev) =>
+              prev.map((t) =>
+                t.jobId === toast.jobId ? { ...t, status: 'error', error: result.error } : t
+              )
+            );
+            // Auto-dismiss errors after 5 seconds
+            setTimeout(() => {
+              setToasts((prev) => prev.filter((t) => t.jobId !== toast.jobId));
+              onJobDone(toast.jobId);
+            }, 5000);
+          }
+        } catch {
+          // Ignore poll failures, will retry
+        }
+      }
+    }, 5000);
+
+    return () => clearInterval(interval);
+  }, [toasts, onJobDone, onRefresh]);
+
+  const dismiss = (jobId: string) => {
+    setToasts((prev) => prev.filter((t) => t.jobId !== jobId));
+    onJobDone(jobId);
+  };
+
+  if (toasts.length === 0) return null;
+
+  return (
+    <div className="fixed bottom-6 right-6 z-50 flex flex-col gap-3">
+      <AnimatePresence>
+        {toasts.map((toast) => (
+          <motion.div
+            key={toast.jobId}
+            initial={{ opacity: 0, y: 20, scale: 0.95 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            exit={{ opacity: 0, y: 10, scale: 0.95 }}
+            className="glass-panel border border-outline-variant/20 rounded-xl px-5 py-4 shadow-2xl flex items-center gap-3 min-w-[280px]"
+          >
+            {toast.status === 'processing' && (
+              <Loader2 className="animate-spin text-tertiary shrink-0" size={20} />
+            )}
+            {toast.status === 'done' && (
+              <CheckCircle className="text-primary shrink-0" size={20} />
+            )}
+            {toast.status === 'error' && (
+              <XCircle className="text-error shrink-0" size={20} />
+            )}
+
+            <div className="flex-1 min-w-0">
+              <p className="text-sm font-bold text-white">
+                {toast.status === 'processing' && 'Processing receipt...'}
+                {toast.status === 'done' && 'Receipt ready'}
+                {toast.status === 'error' && 'Processing failed'}
+              </p>
+              {toast.status === 'error' && toast.error && (
+                <p className="text-xs text-error mt-0.5 truncate">{toast.error}</p>
+              )}
+            </div>
+
+            <button
+              onClick={() => dismiss(toast.jobId)}
+              className="text-on-surface-variant hover:text-white transition-colors shrink-0"
+            >
+              <X size={16} />
+            </button>
+          </motion.div>
+        ))}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/src/components/ReceiptDetail.tsx
+++ b/src/components/ReceiptDetail.tsx
@@ -1,7 +1,21 @@
 import React, { useEffect, useState } from 'react';
-import { ArrowLeft, Loader2, Receipt, CreditCard, Calendar, DollarSign, Tag, FileText, ChevronDown, ChevronUp } from 'lucide-react';
+import { ArrowLeft, Loader2, Receipt, CreditCard, Calendar, Tag, FileText, ChevronDown, ChevronUp, MapPin } from 'lucide-react';
+import { APIProvider, Map, Marker } from '@vis.gl/react-google-maps';
 import { fetchReceiptDetail, type ReceiptDetail as ReceiptDetailType } from '../lib/api';
 import { cn } from '../lib/utils';
+
+const GOOGLE_MAPS_API_KEY = import.meta.env.VITE_GOOGLE_MAPS_API_KEY as string | undefined;
+
+const DARK_MAP_STYLES: google.maps.MapTypeStyle[] = [
+  { elementType: 'geometry', stylers: [{ color: '#1f2937' }] },
+  { elementType: 'labels.text.stroke', stylers: [{ color: '#1f2937' }] },
+  { elementType: 'labels.text.fill', stylers: [{ color: '#9ca3af' }] },
+  { featureType: 'road', elementType: 'geometry', stylers: [{ color: '#374151' }] },
+  { featureType: 'road', elementType: 'labels.text.fill', stylers: [{ color: '#d1d5db' }] },
+  { featureType: 'water', elementType: 'geometry', stylers: [{ color: '#111827' }] },
+  { featureType: 'poi', elementType: 'labels.text.fill', stylers: [{ color: '#6b7280' }] },
+  { featureType: 'administrative', elementType: 'geometry.stroke', stylers: [{ color: '#4b5563' }] },
+];
 
 interface ReceiptDetailProps {
   receiptId: string;
@@ -177,6 +191,32 @@ export default function ReceiptDetail({ receiptId, onBack }: ReceiptDetailProps)
               (e.target as HTMLImageElement).style.display = 'none';
             }}
           />
+        </div>
+      )}
+
+      {/* Location (Google Map) */}
+      {!isProcessing && receipt.latitude != null && receipt.longitude != null && GOOGLE_MAPS_API_KEY && (
+        <div className="glass-panel rounded-xl p-6 border border-outline-variant/10">
+          <h3 className="font-headline font-bold text-white mb-4 flex items-center gap-2">
+            <MapPin size={18} />
+            Location
+          </h3>
+          {receipt.address && (
+            <p className="text-sm text-on-surface-variant mb-3">{receipt.address}</p>
+          )}
+          <div className="h-[300px] rounded-lg overflow-hidden">
+            <APIProvider apiKey={GOOGLE_MAPS_API_KEY}>
+              <Map
+                defaultCenter={{ lat: receipt.latitude, lng: receipt.longitude }}
+                defaultZoom={15}
+                gestureHandling="cooperative"
+                disableDefaultUI={false}
+                styles={DARK_MAP_STYLES}
+              >
+                <Marker position={{ lat: receipt.latitude, lng: receipt.longitude }} />
+              </Map>
+            </APIProvider>
+          </div>
         </div>
       )}
 

--- a/src/components/ReceiptDetail.tsx
+++ b/src/components/ReceiptDetail.tsx
@@ -1,0 +1,247 @@
+import React, { useEffect, useState } from 'react';
+import { ArrowLeft, Loader2, Receipt, CreditCard, Calendar, DollarSign, Tag, FileText, ChevronDown, ChevronUp } from 'lucide-react';
+import { fetchReceiptDetail, type ReceiptDetail as ReceiptDetailType } from '../lib/api';
+import { cn } from '../lib/utils';
+
+interface ReceiptDetailProps {
+  receiptId: string;
+  onBack: () => void;
+}
+
+export default function ReceiptDetail({ receiptId, onBack }: ReceiptDetailProps) {
+  const [receipt, setReceipt] = useState<ReceiptDetailType | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [showRawText, setShowRawText] = useState(false);
+
+  const loadReceipt = () => {
+    fetchReceiptDetail(receiptId)
+      .then(setReceipt)
+      .catch((e) => setError(e.message))
+      .finally(() => setLoading(false));
+  };
+
+  useEffect(() => {
+    loadReceipt();
+  }, [receiptId]);
+
+  // Auto-poll if still processing
+  useEffect(() => {
+    if (receipt?.status !== 'processing') return;
+    const interval = setInterval(loadReceipt, 5000);
+    return () => clearInterval(interval);
+  }, [receipt?.status]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-[60vh]">
+        <Loader2 className="animate-spin text-primary" size={32} />
+        <span className="ml-3 text-on-surface-variant">Loading receipt...</span>
+      </div>
+    );
+  }
+
+  if (error || !receipt) {
+    return (
+      <div className="space-y-6 animate-in fade-in duration-500">
+        <button onClick={onBack} className="flex items-center gap-2 text-primary font-bold hover:opacity-80 transition-opacity">
+          <ArrowLeft size={20} />
+          Back
+        </button>
+        <div className="text-center py-20 text-error">{error || 'Receipt not found'}</div>
+      </div>
+    );
+  }
+
+  const isProcessing = receipt.status === 'processing';
+
+  return (
+    <div className="space-y-8 animate-in fade-in slide-in-from-bottom-4 duration-700 max-w-4xl">
+      {/* Back button */}
+      <button onClick={onBack} className="flex items-center gap-2 text-primary font-bold hover:opacity-80 transition-opacity">
+        <ArrowLeft size={20} />
+        Back to transactions
+      </button>
+
+      {/* Processing banner */}
+      {isProcessing && (
+        <div className="flex items-center gap-4 p-5 rounded-xl bg-tertiary/10 border border-tertiary/20">
+          <Loader2 className="animate-spin text-tertiary" size={24} />
+          <div>
+            <p className="text-sm font-bold text-white">Still processing...</p>
+            <p className="text-xs text-on-surface-variant mt-1">Claude is reading your receipt. This page will update automatically.</p>
+          </div>
+        </div>
+      )}
+
+      {/* Header */}
+      <div className="glass-panel rounded-xl p-8 border border-outline-variant/10">
+        <div className="flex items-start justify-between">
+          <div>
+            <p className="text-xs text-on-surface-variant uppercase tracking-widest mb-2">Merchant</p>
+            <h2 className="text-3xl font-extrabold text-white font-headline">
+              {isProcessing ? 'Processing...' : receipt.merchant}
+            </h2>
+            <div className="flex items-center gap-6 mt-4 text-sm text-on-surface-variant">
+              <span className="flex items-center gap-2">
+                <Calendar size={16} />
+                {isProcessing ? '--' : receipt.date}
+              </span>
+              {receipt.category && (
+                <span className="flex items-center gap-2">
+                  <Tag size={16} />
+                  {receipt.category}
+                </span>
+              )}
+              {receipt.payment_method && (
+                <span className="flex items-center gap-2">
+                  <CreditCard size={16} />
+                  {receipt.payment_method.replace('_', ' ')}
+                </span>
+              )}
+            </div>
+          </div>
+          <div className="text-right">
+            <p className="text-xs text-on-surface-variant uppercase tracking-widest mb-2">Total</p>
+            <p className="text-4xl font-extrabold text-white font-headline">
+              {isProcessing ? '--' : `$${receipt.total.toFixed(2)}`}
+            </p>
+            <p className="text-sm text-on-surface-variant mt-1">{receipt.currency ?? 'USD'}</p>
+          </div>
+        </div>
+
+        {/* Tax / Tip breakdown */}
+        {!isProcessing && (receipt.tax || receipt.tip) && (
+          <div className="flex gap-6 mt-6 pt-6 border-t border-outline-variant/10">
+            {receipt.tax != null && receipt.tax > 0 && (
+              <div>
+                <p className="text-xs text-on-surface-variant uppercase tracking-widest">Tax</p>
+                <p className="text-lg font-bold text-white">${receipt.tax.toFixed(2)}</p>
+              </div>
+            )}
+            {receipt.tip != null && receipt.tip > 0 && (
+              <div>
+                <p className="text-xs text-on-surface-variant uppercase tracking-widest">Tip</p>
+                <p className="text-lg font-bold text-white">${receipt.tip.toFixed(2)}</p>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Line Items */}
+      {!isProcessing && receipt.items && receipt.items.length > 0 && (
+        <div className="glass-panel rounded-xl border border-outline-variant/10 overflow-hidden">
+          <div className="px-8 py-5 border-b border-outline-variant/10">
+            <h3 className="font-headline font-bold text-white flex items-center gap-2">
+              <Receipt size={18} />
+              Line Items ({receipt.items.length})
+            </h3>
+          </div>
+          <table className="w-full text-left">
+            <thead>
+              <tr className="bg-surface-container-low/50">
+                <th className="px-8 py-3 text-xs font-bold text-on-surface-variant uppercase tracking-widest">Item</th>
+                <th className="px-8 py-3 text-xs font-bold text-on-surface-variant uppercase tracking-widest text-center">Qty</th>
+                <th className="px-8 py-3 text-xs font-bold text-on-surface-variant uppercase tracking-widest text-right">Unit Price</th>
+                <th className="px-8 py-3 text-xs font-bold text-on-surface-variant uppercase tracking-widest text-right">Total</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-outline-variant/5">
+              {receipt.items.map((item, i) => (
+                <tr key={i} className="hover:bg-surface-container-high/20 transition-colors">
+                  <td className="px-8 py-4 text-sm font-medium text-white">{item.name}</td>
+                  <td className="px-8 py-4 text-sm text-on-surface-variant text-center">{item.quantity ?? 1}</td>
+                  <td className="px-8 py-4 text-sm text-on-surface-variant text-right">
+                    {item.unit_price != null ? `$${item.unit_price.toFixed(2)}` : '--'}
+                  </td>
+                  <td className="px-8 py-4 text-sm font-bold text-white text-right">
+                    {item.total_price != null ? `$${item.total_price.toFixed(2)}` : '--'}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {/* Receipt Image */}
+      {!isProcessing && (
+        <div className="glass-panel rounded-xl p-6 border border-outline-variant/10">
+          <h3 className="font-headline font-bold text-white mb-4">Receipt Image</h3>
+          <img
+            src={`/api/receipt/${receiptId}/image`}
+            alt="Receipt"
+            className="max-w-full max-h-[500px] rounded-lg object-contain mx-auto"
+            onError={(e) => {
+              (e.target as HTMLImageElement).style.display = 'none';
+            }}
+          />
+        </div>
+      )}
+
+      {/* Notes */}
+      {receipt.notes && (
+        <div className="glass-panel rounded-xl p-6 border border-outline-variant/10">
+          <h3 className="font-headline font-bold text-white mb-2">Notes</h3>
+          <p className="text-sm text-on-surface-variant">{receipt.notes}</p>
+        </div>
+      )}
+
+      {/* Raw Text (collapsible) */}
+      {!isProcessing && receipt.raw_text && (
+        <div className="glass-panel rounded-xl border border-outline-variant/10 overflow-hidden">
+          <button
+            onClick={() => setShowRawText(!showRawText)}
+            className="w-full px-6 py-4 flex items-center justify-between hover:bg-surface-container-high/30 transition-colors"
+          >
+            <span className="font-headline font-bold text-white flex items-center gap-2">
+              <FileText size={18} />
+              Raw Text
+            </span>
+            {showRawText ? <ChevronUp size={18} className="text-on-surface-variant" /> : <ChevronDown size={18} className="text-on-surface-variant" />}
+          </button>
+          {showRawText && (
+            <div className="px-6 pb-6">
+              <pre className="text-xs text-on-surface-variant whitespace-pre-wrap font-mono bg-surface-container-lowest rounded-lg p-4">
+                {receipt.raw_text}
+              </pre>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Extraction metadata */}
+      {!isProcessing && receipt.extraction_meta && (
+        <div className="glass-panel rounded-xl p-6 border border-outline-variant/10">
+          <h3 className="font-headline font-bold text-white mb-3">Extraction Quality</h3>
+          <div className="flex flex-wrap gap-4 text-sm">
+            {receipt.extraction_meta.quality?.confidence_score != null && (
+              <div>
+                <p className="text-xs text-on-surface-variant uppercase tracking-widest">Confidence</p>
+                <p className={cn(
+                  "font-bold",
+                  receipt.extraction_meta.quality.confidence_score >= 0.7 ? 'text-primary' : 'text-error'
+                )}>
+                  {(receipt.extraction_meta.quality.confidence_score * 100).toFixed(0)}%
+                </p>
+              </div>
+            )}
+            {receipt.extraction_meta.quality?.warnings && receipt.extraction_meta.quality.warnings.length > 0 && (
+              <div>
+                <p className="text-xs text-on-surface-variant uppercase tracking-widest">Warnings</p>
+                <div className="flex flex-wrap gap-1 mt-1">
+                  {receipt.extraction_meta.quality.warnings.map((w, i) => (
+                    <span key={i} className="px-2 py-0.5 rounded bg-error/10 text-error text-[10px] font-bold uppercase">
+                      {w}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/Transactions.tsx
+++ b/src/components/Transactions.tsx
@@ -4,7 +4,11 @@ import { fetchTransactions } from '../lib/api';
 import { cn } from '../lib/utils';
 import type { Transaction } from '../types';
 
-export default function Transactions() {
+interface TransactionsProps {
+  onSelectReceipt?: (receiptId: string) => void;
+}
+
+export default function Transactions({ onSelectReceipt }: TransactionsProps) {
   const [transactions, setTransactions] = useState<Transaction[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -120,31 +124,46 @@ export default function Transactions() {
             </thead>
             <tbody className="divide-y divide-outline-variant/5">
               {transactions.map((tx) => (
-                <tr key={tx.id} className="hover:bg-surface-container-high/30 transition-colors cursor-pointer group">
+                <tr
+                  key={tx.id}
+                  onClick={() => tx.status !== 'Processing' && onSelectReceipt?.(tx.id)}
+                  className={cn(
+                    "hover:bg-surface-container-high/30 transition-colors group",
+                    tx.status === 'Processing' ? 'cursor-default opacity-70' : 'cursor-pointer'
+                  )}
+                >
                   <td className="px-8 py-6">
                     <div className="flex items-center gap-4">
                       <div className={cn(
                         "w-10 h-10 rounded-xl bg-surface-container-highest flex items-center justify-center border",
-                        getColorClass(tx.category)
+                        tx.status === 'Processing' ? 'text-tertiary border-tertiary/20 animate-pulse' : getColorClass(tx.category)
                       )}>
-                        {getIcon(tx.category)}
+                        {tx.status === 'Processing' ? <Loader2 className="animate-spin" size={18} /> : getIcon(tx.category)}
                       </div>
-                      <span className="font-bold text-white group-hover:text-primary transition-colors">{tx.description}</span>
+                      <span className={cn(
+                        "font-bold transition-colors",
+                        tx.status === 'Processing' ? 'text-on-surface-variant' : 'text-white group-hover:text-primary'
+                      )}>
+                        {tx.description}
+                      </span>
                     </div>
                   </td>
                   <td className="px-8 py-6">
-                    <span className={cn(
-                      "px-3 py-1 rounded-full text-[11px] font-bold uppercase tracking-wider",
-                      getBadgeClass(tx.category)
-                    )}>
-                      {tx.category}
-                    </span>
+                    {tx.status !== 'Processing' && (
+                      <span className={cn(
+                        "px-3 py-1 rounded-full text-[11px] font-bold uppercase tracking-wider",
+                        getBadgeClass(tx.category)
+                      )}>
+                        {tx.category}
+                      </span>
+                    )}
                   </td>
-                  <td className="px-8 py-6 text-sm text-on-surface-variant">{tx.date}</td>
-                  <td className="px-8 py-6 text-sm text-on-surface-variant">{tx.paymentMethod}</td>
+                  <td className="px-8 py-6 text-sm text-on-surface-variant">{tx.status === 'Processing' ? '--' : tx.date}</td>
+                  <td className="px-8 py-6 text-sm text-on-surface-variant">{tx.status === 'Processing' ? '--' : tx.paymentMethod}</td>
                   <td className="px-8 py-6">
                     <span className={cn(
                       "px-2 py-0.5 rounded text-[10px] font-bold uppercase",
+                      tx.status === 'Processing' ? 'bg-tertiary/10 text-tertiary animate-pulse' :
                       tx.status === 'Verified' ? 'bg-primary/10 text-primary' :
                       tx.status === 'Pending' ? 'bg-error/10 text-error' :
                       'bg-tertiary/10 text-tertiary'
@@ -154,9 +173,12 @@ export default function Transactions() {
                   </td>
                   <td className={cn(
                     "px-8 py-6 text-right font-headline font-bold",
+                    tx.status === 'Processing' ? 'text-on-surface-variant' :
                     tx.amount > 0 ? "text-primary neon-glow-primary" : "text-white"
                   )}>
-                    {tx.amount > 0 ? '+' : ''}{tx.amount.toLocaleString('en-US', { style: 'currency', currency: 'USD' })}
+                    {tx.status === 'Processing' ? '--' : (
+                      <>{tx.amount > 0 ? '+' : ''}{tx.amount.toLocaleString('en-US', { style: 'currency', currency: 'USD' })}</>
+                    )}
                   </td>
                 </tr>
               ))}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -21,6 +21,10 @@ interface BackendReceipt {
   tip?: number;
   notes?: string;
   image_path?: string;
+  address?: string;
+  latitude?: number;
+  longitude?: number;
+  place_id?: string;
   status?: string;
   extraction_meta?: {
     quality?: {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -2,6 +2,7 @@
  * API client for ReceiptAssistant backend.
  * Uses Vite proxy: /api/* → localhost:3000/*
  */
+import imageCompression from 'browser-image-compression';
 import type { Transaction } from '@/types';
 
 const API = '/api';
@@ -20,13 +21,21 @@ interface BackendReceipt {
   tip?: number;
   notes?: string;
   image_path?: string;
+  status?: string;
   extraction_meta?: {
     quality?: {
       confidence_score?: number;
       warnings?: string[];
     };
   };
-  items?: { name: string; quantity?: number; total_price?: number }[];
+  items?: { name: string; quantity?: number; unit_price?: number; total_price?: number }[];
+}
+
+export interface ReceiptDetail extends BackendReceipt {
+  raw_text?: string;
+  items: { name: string; quantity?: number; unit_price?: number; total_price?: number; category?: string }[];
+  created_at?: string;
+  updated_at?: string;
 }
 
 const CATEGORY_MAP: Record<string, Transaction['category']> = {
@@ -57,6 +66,35 @@ const ICON_MAP: Record<string, string> = {
 };
 
 function mapReceipt(r: BackendReceipt): Transaction {
+  // Processing receipts show as "Processing" status
+  if (r.status === 'processing') {
+    return {
+      id: r.id,
+      description: 'Processing...',
+      category: 'Fun',
+      date: r.date,
+      paymentMethod: 'Unknown',
+      amount: 0,
+      status: 'Processing',
+      icon: 'hourglass_empty',
+      color: 'tertiary',
+    };
+  }
+
+  if (r.status === 'error') {
+    return {
+      id: r.id,
+      description: r.merchant || 'Failed',
+      category: 'Fun',
+      date: r.date,
+      paymentMethod: 'Unknown',
+      amount: 0,
+      status: 'Pending',
+      icon: 'error',
+      color: 'error',
+    };
+  }
+
   const category = CATEGORY_MAP[r.category ?? 'other'] ?? 'Fun';
   const confidence = r.extraction_meta?.quality?.confidence_score;
   const status: Transaction['status'] =
@@ -75,6 +113,18 @@ function mapReceipt(r: BackendReceipt): Transaction {
     icon: ICON_MAP[category] ?? 'receipt',
     color: 'primary',
   };
+}
+
+// ── Image compression ──────────────────────────────────────────
+
+async function compressImage(file: File): Promise<File> {
+  if (file.size <= 500 * 1024) return file; // skip if already small
+  return imageCompression(file, {
+    maxSizeMB: 1,
+    maxWidthOrHeight: 2048,
+    useWebWorker: true,
+    fileType: 'image/jpeg',
+  });
 }
 
 // ── API functions ───────────────────────────────────────────────
@@ -105,6 +155,12 @@ export async function fetchTransaction(id: string): Promise<Transaction> {
   return mapReceipt(data);
 }
 
+export async function fetchReceiptDetail(id: string): Promise<ReceiptDetail> {
+  const res = await fetch(`${API}/receipt/${id}`);
+  if (!res.ok) throw new Error(`Failed to fetch receipt: ${res.status}`);
+  return res.json();
+}
+
 export async function deleteTransaction(id: string): Promise<void> {
   const res = await fetch(`${API}/receipt/${id}`, { method: 'DELETE' });
   if (!res.ok) throw new Error(`Delete failed: ${res.status}`);
@@ -117,8 +173,9 @@ export interface UploadResult {
 }
 
 export async function uploadReceipt(file: File): Promise<UploadResult> {
+  const compressed = await compressImage(file);
   const form = new FormData();
-  form.append('image', file);
+  form.append('image', compressed);
   const res = await fetch(`${API}/receipt`, { method: 'POST', body: form });
   if (!res.ok) throw new Error(`Upload failed: ${res.status}`);
   return res.json();
@@ -127,8 +184,7 @@ export async function uploadReceipt(file: File): Promise<UploadResult> {
 export interface JobStatus {
   jobId: string;
   receiptId: string;
-  status: 'queued' | 'quick_done' | 'processing_full' | 'done' | 'error';
-  quickResult?: { merchant: string; date: string; total: number };
+  status: 'queued' | 'done' | 'error';
   error?: string;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,7 @@ export interface Transaction {
   date: string;
   paymentMethod: string;
   amount: number;
-  status: 'Verified' | 'Pending' | 'New Charge' | 'Surplus' | 'Peak';
+  status: 'Verified' | 'Pending' | 'New Charge' | 'Surplus' | 'Peak' | 'Processing';
   icon: string;
   color: string;
 }

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
Paired with TINKPA/receipt-assistant#15 (backend geocoding).

## What's in this PR

Two commits that ship together:

### 1. `af00151` — Async upload UX

The frontend counterpart to backend PR #11 (which collapsed the 3-call extraction pipeline into a single agent call).

- `lib/api.ts` — `uploadReceipt()` now runs `browser-image-compression` (maxSizeMB 1, maxWidthOrHeight 2048, JPEG). New `fetchReceiptDetail()` + `ReceiptDetail` type. `mapReceipt()` handles `status='processing'` and `status='error'` rows.
- `AddTransactionModal` — strip the polling loop; state machine simplified from 5 states to 3 (idle → uploading → close/error). Accept attribute JPG-only.
- `ProcessingToast` (new) — floating bottom-right notification per in-flight job. Polls every 5s. Persists job IDs to `localStorage` so they survive page refresh. Auto-dismisses on done/error.
- `ReceiptDetail` (new) — full-page view with merchant/date/total header, line items table, receipt image, collapsible raw text, extraction quality metadata.

### 2. `c95e037` — Google Maps location

Renders a Google Map with a marker inside `ReceiptDetail.tsx` when the backend has populated `latitude`/`longitude`. Placed between Receipt Image and Notes.

- `ReceiptDetail.tsx` — imports `APIProvider`, `Map`, `Marker` from `@vis.gl/react-google-maps`. Dark map styles inlined to match the app aesthetic. Map section gated on `latitude != null && longitude != null && GOOGLE_MAPS_API_KEY` — no error state when any of those are missing.
- `api.ts` — `BackendReceipt` extended with `address`, `latitude`, `longitude`, `place_id`.
- `package.json` — adds `@vis.gl/react-google-maps ^1.8.3`.
- `vite-env.d.ts` (new) — `/// <reference types=\"vite/client\" />` so `import.meta.env.VITE_GOOGLE_MAPS_API_KEY` is typed.

## New environment variable

| Name | Required | Description |
|---|---|---|
| `VITE_GOOGLE_MAPS_API_KEY` | No, but the map is hidden without it | Client-side Maps JavaScript key. Should be HTTP-referrer-restricted. |

Goes in `.env.local` (already gitignored by `.env*`).

## Depends on

The paired backend PR (TINKPA/receipt-assistant#15) adds `latitude`/`longitude`/`place_id`/`address` to the `receipts` table. This PR is **safe to land first** — without the backend changes, `fetchReceiptDetail` returns \`null\` for those fields and the map section is hidden cleanly.

## Testing

- [x] Dev server builds and runs (\`npm run dev\`)
- [x] TypeScript type-checks with the new fields
- [x] Receipt with lat/lng renders the map with marker + address above
- [x] Receipt without lat/lng hides the map section without errors
- [ ] Production build (\`npm run build\`) — not tested yet

## Out of scope

- Map tab showing all receipts
- Spending-by-location heatmap
- Retroactive geocoding for existing receipts
- Location bias on Places fallback