### PR TITLE
Rewire frontend to backend v1 API (post-receipt* removal)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,8 @@ import Transactions from './components/Transactions';
 import MonthlyReview from './components/MonthlyReview';
 import YearlyReview from './components/YearlyReview';
 import AddTransactionModal from './components/AddTransactionModal';
-import ProcessingToast, { useProcessingJobs } from './components/ProcessingToast';
+import ProcessingToast from './components/ProcessingToast';
+import { useProcessingJobs } from './components/useProcessingJobs';
 import ReceiptDetail from './components/ReceiptDetail';
 
 export default function App() {
@@ -15,7 +16,7 @@ export default function App() {
   const [selectedReceiptId, setSelectedReceiptId] = React.useState<string | null>(null);
   const { jobs, addJob, removeJob } = useProcessingJobs();
 
-  const handleUploadComplete = (job: { jobId: string; receiptId: string }) => {
+  const handleUploadComplete = (job: { batchId: string; ingestId: string; filename: string }) => {
     addJob(job);
     setRefreshKey((k) => k + 1);
   };

--- a/src/components/AddTransactionModal.tsx
+++ b/src/components/AddTransactionModal.tsx
@@ -1,13 +1,15 @@
 import React from 'react';
 import { X, Upload, ArrowRight, Loader2, AlertCircle } from 'lucide-react';
 import { motion, AnimatePresence } from 'motion/react';
-import { uploadReceipt } from '../lib/api';
+import { ingestBatch, extractProblemMessage } from '../lib/api';
 import { cn } from '../lib/utils';
 
 interface AddTransactionModalProps {
   isOpen: boolean;
   onClose: () => void;
-  onComplete?: (job: { jobId: string; receiptId: string }) => void;
+  /** Emitted once the upload is accepted. `batchId` drives the
+   *  ProcessingToast polling → eventual `transactionId`. */
+  onComplete?: (job: { batchId: string; ingestId: string; filename: string }) => void;
 }
 
 type UploadState = 'idle' | 'uploading' | 'error';
@@ -40,13 +42,21 @@ export default function AddTransactionModal({ isOpen, onClose, onComplete }: Add
     setError(null);
 
     try {
-      const result = await uploadReceipt(file);
-      // Close immediately — processing happens in background
-      onComplete?.({ jobId: result.jobId, receiptId: result.receiptId });
+      const result = await ingestBatch([file]);
+      const first = result.items[0];
+      if (!first) {
+        throw new Error('Upload accepted but server returned no ingest items.');
+      }
+      // Close immediately — processing happens in background.
+      onComplete?.({
+        batchId: result.batchId,
+        ingestId: first.ingestId,
+        filename: first.filename,
+      });
       handleClose();
-    } catch (err: any) {
+    } catch (err: unknown) {
       setState('error');
-      setError(err.message);
+      setError(extractProblemMessage(err));
     }
   };
 

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -21,6 +21,8 @@ import {
   Cell
 } from 'recharts';
 import { fetchTransactions, fetchSummary, type SpendingSummary } from '../lib/api';
+// `fetchSummary` remains a shim over GET /v1/reports/summary?group_by=category;
+// `SpendingSummary` is the legacy {category,count,total_spent} shape.
 import { cn } from '../lib/utils';
 import type { Transaction } from '../types';
 

--- a/src/components/ProcessingToast.tsx
+++ b/src/components/ProcessingToast.tsx
@@ -1,110 +1,136 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Loader2, CheckCircle, XCircle, X } from 'lucide-react';
 import { motion, AnimatePresence } from 'motion/react';
-import { pollJob } from '../lib/api';
+import { getBatch, extractProblemMessage } from '../lib/api';
 
-interface ProcessingJob {
-  jobId: string;
-  receiptId: string;
+/**
+ * Receipt upload UX.
+ *
+ * The old backend had per-image jobs queried via `GET /jobs/:id`. The
+ * v1 backend uses *ingest batches* — a single upload creates a batch
+ * with N ingests (we always use N=1 from the UI), and the batch
+ * progresses through `pending → processing → extracted → reconciled`.
+ *
+ * We could SSE-subscribe via `subscribeToBatch(batchId, …)`, but for
+ * minimum diff we keep polling: every 5s fetch the batch and watch for
+ * `status=extracted` (or `reconciled`). On completion we extract the
+ * first produced `transaction_id` to give callers a stable anchor.
+ */
+export interface ProcessingJob {
+  batchId: string;
+  ingestId: string;
+  filename: string;
 }
 
 interface ToastState {
-  jobId: string;
-  receiptId: string;
+  batchId: string;
+  ingestId: string;
+  filename: string;
   status: 'processing' | 'done' | 'error';
+  transactionId?: string;
   error?: string;
 }
 
 interface ProcessingToastProps {
   jobs: ProcessingJob[];
-  onJobDone: (jobId: string) => void;
+  onJobDone: (batchId: string) => void;
   onRefresh: () => void;
 }
 
-const STORAGE_KEY = 'receipt-processing-jobs';
+// `useProcessingJobs` hook lives in ./useProcessingJobs.ts (separate
+// file so react-refresh/only-export-components stays happy).
 
-export function useProcessingJobs() {
-  const [jobs, setJobs] = useState<ProcessingJob[]>(() => {
-    try {
-      const saved = localStorage.getItem(STORAGE_KEY);
-      return saved ? JSON.parse(saved) : [];
-    } catch {
-      return [];
-    }
-  });
+const TERMINAL_DONE = new Set(['extracted', 'reconciled']);
+const TERMINAL_ERROR = new Set(['failed', 'reconcile_error']);
 
-  useEffect(() => {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(jobs));
-  }, [jobs]);
-
-  const addJob = (job: ProcessingJob) => {
-    setJobs((prev) => [...prev, job]);
-  };
-
-  const removeJob = (jobId: string) => {
-    setJobs((prev) => prev.filter((j) => j.jobId !== jobId));
-  };
-
-  return { jobs, addJob, removeJob };
-}
+/** Per-batch status overrides. `jobs` (the source list) is the
+ *  persistent record of outstanding uploads; this map stores in-memory
+ *  terminal state + error text. Toasts are then *derived* from
+ *  (jobs, statusMap, dismissed), which sidesteps the
+ *  react-hooks/set-state-in-effect lint. */
+type StatusOverride = { status: 'done' | 'error'; transactionId?: string; error?: string };
 
 export default function ProcessingToast({ jobs, onJobDone, onRefresh }: ProcessingToastProps) {
-  const [toasts, setToasts] = useState<ToastState[]>([]);
-
-  // Initialize toasts from jobs
+  const [statusMap, setStatusMap] = useState<Record<string, StatusOverride>>({});
+  const [dismissed, setDismissed] = useState<Set<string>>(new Set());
+  // Keep the latest callbacks in a ref so the polling interval can use
+  // them without re-creating the timer every render.
+  const callbacksRef = useRef({ onJobDone, onRefresh });
   useEffect(() => {
-    setToasts((prev) => {
-      const existing = new Set(prev.map((t) => t.jobId));
-      const newToasts = jobs
-        .filter((j) => !existing.has(j.jobId))
-        .map((j) => ({ jobId: j.jobId, receiptId: j.receiptId, status: 'processing' as const }));
-      return [...prev, ...newToasts];
-    });
-  }, [jobs]);
+    callbacksRef.current = { onJobDone, onRefresh };
+  }, [onJobDone, onRefresh]);
 
-  // Poll each processing toast
+  const toasts: ToastState[] = useMemo(() => {
+    return jobs
+      .filter((j) => !dismissed.has(j.batchId))
+      .map<ToastState>((j) => {
+        const override = statusMap[j.batchId];
+        return {
+          batchId: j.batchId,
+          ingestId: j.ingestId,
+          filename: j.filename,
+          status: override?.status ?? 'processing',
+          transactionId: override?.transactionId,
+          error: override?.error,
+        };
+      });
+  }, [jobs, statusMap, dismissed]);
+
+  // Poll batches that are still in `processing` state.
   useEffect(() => {
-    const processing = toasts.filter((t) => t.status === 'processing');
-    if (processing.length === 0) return;
+    const active = jobs.filter(
+      (j) => !dismissed.has(j.batchId) && !statusMap[j.batchId],
+    );
+    if (active.length === 0) return;
 
+    let cancelled = false;
     const interval = setInterval(async () => {
-      for (const toast of processing) {
+      for (const job of active) {
+        if (cancelled) return;
         try {
-          const result = await pollJob(toast.jobId);
-          if (result.status === 'done') {
-            setToasts((prev) =>
-              prev.map((t) => (t.jobId === toast.jobId ? { ...t, status: 'done' } : t))
-            );
-            onRefresh();
-            // Auto-dismiss after 3 seconds
+          const batch = await getBatch(job.batchId);
+          if (TERMINAL_DONE.has(batch.status)) {
+            const produced = batch.items.find((i) => i.id === job.ingestId)?.produced;
+            const transactionId = produced?.transaction_ids?.[0];
+            setStatusMap((prev) => ({
+              ...prev,
+              [job.batchId]: { status: 'done', transactionId },
+            }));
+            callbacksRef.current.onRefresh();
             setTimeout(() => {
-              setToasts((prev) => prev.filter((t) => t.jobId !== toast.jobId));
-              onJobDone(toast.jobId);
+              setDismissed((prev) => new Set(prev).add(job.batchId));
+              callbacksRef.current.onJobDone(job.batchId);
             }, 3000);
-          } else if (result.status === 'error') {
-            setToasts((prev) =>
-              prev.map((t) =>
-                t.jobId === toast.jobId ? { ...t, status: 'error', error: result.error } : t
-              )
-            );
-            // Auto-dismiss errors after 5 seconds
+          } else if (TERMINAL_ERROR.has(batch.status)) {
+            const ingestErr = batch.items.find((i) => i.id === job.ingestId)?.error ?? null;
+            setStatusMap((prev) => ({
+              ...prev,
+              [job.batchId]: {
+                status: 'error',
+                error: ingestErr ?? `Batch ${batch.status}`,
+              },
+            }));
             setTimeout(() => {
-              setToasts((prev) => prev.filter((t) => t.jobId !== toast.jobId));
-              onJobDone(toast.jobId);
+              setDismissed((prev) => new Set(prev).add(job.batchId));
+              callbacksRef.current.onJobDone(job.batchId);
             }, 5000);
           }
-        } catch {
-          // Ignore poll failures, will retry
+        } catch (err: unknown) {
+          // Ignore individual poll failures; next tick retries.
+          console.debug('batch poll error', job.batchId, extractProblemMessage(err));
         }
       }
     }, 5000);
 
-    return () => clearInterval(interval);
-  }, [toasts, onJobDone, onRefresh]);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, [jobs, dismissed, statusMap]);
 
-  const dismiss = (jobId: string) => {
-    setToasts((prev) => prev.filter((t) => t.jobId !== jobId));
-    onJobDone(jobId);
+  const dismiss = (batchId: string) => {
+    setDismissed((prev) => new Set(prev).add(batchId));
+    onJobDone(batchId);
   };
 
   if (toasts.length === 0) return null;
@@ -114,7 +140,7 @@ export default function ProcessingToast({ jobs, onJobDone, onRefresh }: Processi
       <AnimatePresence>
         {toasts.map((toast) => (
           <motion.div
-            key={toast.jobId}
+            key={toast.batchId}
             initial={{ opacity: 0, y: 20, scale: 0.95 }}
             animate={{ opacity: 1, y: 0, scale: 1 }}
             exit={{ opacity: 0, y: 10, scale: 0.95 }}
@@ -139,10 +165,13 @@ export default function ProcessingToast({ jobs, onJobDone, onRefresh }: Processi
               {toast.status === 'error' && toast.error && (
                 <p className="text-xs text-error mt-0.5 truncate">{toast.error}</p>
               )}
+              {toast.status !== 'error' && (
+                <p className="text-[10px] text-on-surface-variant mt-0.5 truncate">{toast.filename}</p>
+              )}
             </div>
 
             <button
-              onClick={() => dismiss(toast.jobId)}
+              onClick={() => dismiss(toast.batchId)}
               className="text-on-surface-variant hover:text-white transition-colors shrink-0"
             >
               <X size={16} />

--- a/src/components/ReceiptDetail.tsx
+++ b/src/components/ReceiptDetail.tsx
@@ -1,7 +1,12 @@
 import React, { useEffect, useState } from 'react';
 import { ArrowLeft, Loader2, Receipt, CreditCard, Calendar, Tag, FileText, ChevronDown, ChevronUp, MapPin } from 'lucide-react';
 import { APIProvider, Map, Marker } from '@vis.gl/react-google-maps';
-import { fetchReceiptDetail, type ReceiptDetail as ReceiptDetailType } from '../lib/api';
+import {
+  fetchReceiptDetail,
+  documentContentUrl,
+  extractProblemMessage,
+  type ReceiptView,
+} from '../lib/api';
 import { cn } from '../lib/utils';
 
 const GOOGLE_MAPS_API_KEY = import.meta.env.VITE_GOOGLE_MAPS_API_KEY as string | undefined;
@@ -22,8 +27,16 @@ interface ReceiptDetailProps {
   onBack: () => void;
 }
 
+type Metadata = Record<string, unknown>;
+
+function md<T = unknown>(meta: Metadata | undefined, key: string): T | undefined {
+  if (!meta) return undefined;
+  const v = meta[key];
+  return v as T | undefined;
+}
+
 export default function ReceiptDetail({ receiptId, onBack }: ReceiptDetailProps) {
-  const [receipt, setReceipt] = useState<ReceiptDetailType | null>(null);
+  const [receipt, setReceipt] = useState<ReceiptView | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [showRawText, setShowRawText] = useState(false);
@@ -31,19 +44,23 @@ export default function ReceiptDetail({ receiptId, onBack }: ReceiptDetailProps)
   const loadReceipt = () => {
     fetchReceiptDetail(receiptId)
       .then(setReceipt)
-      .catch((e) => setError(e.message))
+      .catch((e: unknown) => setError(extractProblemMessage(e)))
       .finally(() => setLoading(false));
   };
 
   useEffect(() => {
     loadReceipt();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [receiptId]);
 
-  // Auto-poll if still processing
+  // Auto-poll if the transaction is still in draft/error state — which
+  // means the extractor is either still running or needs human review.
   useEffect(() => {
-    if (receipt?.status !== 'processing') return;
+    if (!receipt) return;
+    if (receipt.status !== 'draft' && receipt.status !== 'error') return;
     const interval = setInterval(loadReceipt, 5000);
     return () => clearInterval(interval);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [receipt?.status]);
 
   if (loading) {
@@ -67,17 +84,42 @@ export default function ReceiptDetail({ receiptId, onBack }: ReceiptDetailProps)
     );
   }
 
-  const isProcessing = receipt.status === 'processing';
+  // Pull extractor-stashed fields out of metadata. These are not
+  // first-class schema columns — the extraction agent writes them into
+  // `transactions.metadata` / `documents.extraction_meta`.
+  const meta = (receipt as unknown as { documents: Array<{ extraction_meta?: Metadata }> });
+  const extraction = meta.documents[0]?.extraction_meta ?? undefined;
+  const txMeta = (receipt.postings[0] as unknown as { metadata?: Metadata })?.metadata;
+  const legacy: Metadata = {
+    ...(txMeta ?? {}),
+    ...(extraction ?? {}),
+  };
+
+  const isProcessing = receipt.status === 'draft';
+  const tax = md<number>(legacy, 'tax');
+  const tip = md<number>(legacy, 'tip');
+  const latitude = md<number>(legacy, 'latitude');
+  const longitude = md<number>(legacy, 'longitude');
+  const address = md<string>(legacy, 'address');
+  const rawText = md<string>(legacy, 'raw_text');
+  const items = md<Array<{ name: string; quantity?: number; unit_price?: number; total_price?: number }>>(legacy, 'items');
+  const confidence = md<number>(
+    (legacy.quality as Metadata | undefined) ?? {},
+    'confidence_score',
+  );
+  const warnings = md<string[]>(
+    (legacy.quality as Metadata | undefined) ?? {},
+    'warnings',
+  );
+  const merchantLabel = receipt.payee ?? receipt.narration ?? 'Unknown';
 
   return (
     <div className="space-y-8 animate-in fade-in slide-in-from-bottom-4 duration-700 max-w-4xl">
-      {/* Back button */}
       <button onClick={onBack} className="flex items-center gap-2 text-primary font-bold hover:opacity-80 transition-opacity">
         <ArrowLeft size={20} />
         Back to transactions
       </button>
 
-      {/* Processing banner */}
       {isProcessing && (
         <div className="flex items-center gap-4 p-5 rounded-xl bg-tertiary/10 border border-tertiary/20">
           <Loader2 className="animate-spin text-tertiary" size={24} />
@@ -94,12 +136,12 @@ export default function ReceiptDetail({ receiptId, onBack }: ReceiptDetailProps)
           <div>
             <p className="text-xs text-on-surface-variant uppercase tracking-widest mb-2">Merchant</p>
             <h2 className="text-3xl font-extrabold text-white font-headline">
-              {isProcessing ? 'Processing...' : receipt.merchant}
+              {isProcessing ? 'Processing...' : merchantLabel}
             </h2>
             <div className="flex items-center gap-6 mt-4 text-sm text-on-surface-variant">
               <span className="flex items-center gap-2">
                 <Calendar size={16} />
-                {isProcessing ? '--' : receipt.date}
+                {isProcessing ? '--' : receipt.occurred_on}
               </span>
               {receipt.category && (
                 <span className="flex items-center gap-2">
@@ -107,10 +149,10 @@ export default function ReceiptDetail({ receiptId, onBack }: ReceiptDetailProps)
                   {receipt.category}
                 </span>
               )}
-              {receipt.payment_method && (
+              {receipt.paymentMethod && (
                 <span className="flex items-center gap-2">
                   <CreditCard size={16} />
-                  {receipt.payment_method.replace('_', ' ')}
+                  {receipt.paymentMethod.replace('_', ' ')}
                 </span>
               )}
             </div>
@@ -120,36 +162,34 @@ export default function ReceiptDetail({ receiptId, onBack }: ReceiptDetailProps)
             <p className="text-4xl font-extrabold text-white font-headline">
               {isProcessing ? '--' : `$${receipt.total.toFixed(2)}`}
             </p>
-            <p className="text-sm text-on-surface-variant mt-1">{receipt.currency ?? 'USD'}</p>
+            <p className="text-sm text-on-surface-variant mt-1">{receipt.currency}</p>
           </div>
         </div>
 
-        {/* Tax / Tip breakdown */}
-        {!isProcessing && (receipt.tax || receipt.tip) && (
+        {!isProcessing && ((tax != null && tax > 0) || (tip != null && tip > 0)) && (
           <div className="flex gap-6 mt-6 pt-6 border-t border-outline-variant/10">
-            {receipt.tax != null && receipt.tax > 0 && (
+            {tax != null && tax > 0 && (
               <div>
                 <p className="text-xs text-on-surface-variant uppercase tracking-widest">Tax</p>
-                <p className="text-lg font-bold text-white">${receipt.tax.toFixed(2)}</p>
+                <p className="text-lg font-bold text-white">${tax.toFixed(2)}</p>
               </div>
             )}
-            {receipt.tip != null && receipt.tip > 0 && (
+            {tip != null && tip > 0 && (
               <div>
                 <p className="text-xs text-on-surface-variant uppercase tracking-widest">Tip</p>
-                <p className="text-lg font-bold text-white">${receipt.tip.toFixed(2)}</p>
+                <p className="text-lg font-bold text-white">${tip.toFixed(2)}</p>
               </div>
             )}
           </div>
         )}
       </div>
 
-      {/* Line Items */}
-      {!isProcessing && receipt.items && receipt.items.length > 0 && (
+      {!isProcessing && items && items.length > 0 && (
         <div className="glass-panel rounded-xl border border-outline-variant/10 overflow-hidden">
           <div className="px-8 py-5 border-b border-outline-variant/10">
             <h3 className="font-headline font-bold text-white flex items-center gap-2">
               <Receipt size={18} />
-              Line Items ({receipt.items.length})
+              Line Items ({items.length})
             </h3>
           </div>
           <table className="w-full text-left">
@@ -162,7 +202,7 @@ export default function ReceiptDetail({ receiptId, onBack }: ReceiptDetailProps)
               </tr>
             </thead>
             <tbody className="divide-y divide-outline-variant/5">
-              {receipt.items.map((item, i) => (
+              {items.map((item, i) => (
                 <tr key={i} className="hover:bg-surface-container-high/20 transition-colors">
                   <td className="px-8 py-4 text-sm font-medium text-white">{item.name}</td>
                   <td className="px-8 py-4 text-sm text-on-surface-variant text-center">{item.quantity ?? 1}</td>
@@ -179,12 +219,11 @@ export default function ReceiptDetail({ receiptId, onBack }: ReceiptDetailProps)
         </div>
       )}
 
-      {/* Receipt Image */}
-      {!isProcessing && (
+      {!isProcessing && receipt.documentId && (
         <div className="glass-panel rounded-xl p-6 border border-outline-variant/10">
           <h3 className="font-headline font-bold text-white mb-4">Receipt Image</h3>
           <img
-            src={`/api/receipt/${receiptId}/image`}
+            src={documentContentUrl(receipt.documentId)}
             alt="Receipt"
             className="max-w-full max-h-[500px] rounded-lg object-contain mx-auto"
             onError={(e) => {
@@ -194,42 +233,39 @@ export default function ReceiptDetail({ receiptId, onBack }: ReceiptDetailProps)
         </div>
       )}
 
-      {/* Location (Google Map) */}
-      {!isProcessing && receipt.latitude != null && receipt.longitude != null && GOOGLE_MAPS_API_KEY && (
+      {!isProcessing && latitude != null && longitude != null && GOOGLE_MAPS_API_KEY && (
         <div className="glass-panel rounded-xl p-6 border border-outline-variant/10">
           <h3 className="font-headline font-bold text-white mb-4 flex items-center gap-2">
             <MapPin size={18} />
             Location
           </h3>
-          {receipt.address && (
-            <p className="text-sm text-on-surface-variant mb-3">{receipt.address}</p>
+          {address && (
+            <p className="text-sm text-on-surface-variant mb-3">{address}</p>
           )}
           <div className="h-[300px] rounded-lg overflow-hidden">
             <APIProvider apiKey={GOOGLE_MAPS_API_KEY}>
               <Map
-                defaultCenter={{ lat: receipt.latitude, lng: receipt.longitude }}
+                defaultCenter={{ lat: latitude, lng: longitude }}
                 defaultZoom={15}
                 gestureHandling="cooperative"
                 disableDefaultUI={false}
                 styles={DARK_MAP_STYLES}
               >
-                <Marker position={{ lat: receipt.latitude, lng: receipt.longitude }} />
+                <Marker position={{ lat: latitude, lng: longitude }} />
               </Map>
             </APIProvider>
           </div>
         </div>
       )}
 
-      {/* Notes */}
-      {receipt.notes && (
+      {receipt.narration && (
         <div className="glass-panel rounded-xl p-6 border border-outline-variant/10">
           <h3 className="font-headline font-bold text-white mb-2">Notes</h3>
-          <p className="text-sm text-on-surface-variant">{receipt.notes}</p>
+          <p className="text-sm text-on-surface-variant">{receipt.narration}</p>
         </div>
       )}
 
-      {/* Raw Text (collapsible) */}
-      {!isProcessing && receipt.raw_text && (
+      {!isProcessing && rawText && (
         <div className="glass-panel rounded-xl border border-outline-variant/10 overflow-hidden">
           <button
             onClick={() => setShowRawText(!showRawText)}
@@ -244,34 +280,31 @@ export default function ReceiptDetail({ receiptId, onBack }: ReceiptDetailProps)
           {showRawText && (
             <div className="px-6 pb-6">
               <pre className="text-xs text-on-surface-variant whitespace-pre-wrap font-mono bg-surface-container-lowest rounded-lg p-4">
-                {receipt.raw_text}
+                {rawText}
               </pre>
             </div>
           )}
         </div>
       )}
 
-      {/* Extraction metadata */}
-      {!isProcessing && receipt.extraction_meta && (
+      {!isProcessing && confidence != null && (
         <div className="glass-panel rounded-xl p-6 border border-outline-variant/10">
           <h3 className="font-headline font-bold text-white mb-3">Extraction Quality</h3>
           <div className="flex flex-wrap gap-4 text-sm">
-            {receipt.extraction_meta.quality?.confidence_score != null && (
-              <div>
-                <p className="text-xs text-on-surface-variant uppercase tracking-widest">Confidence</p>
-                <p className={cn(
-                  "font-bold",
-                  receipt.extraction_meta.quality.confidence_score >= 0.7 ? 'text-primary' : 'text-error'
-                )}>
-                  {(receipt.extraction_meta.quality.confidence_score * 100).toFixed(0)}%
-                </p>
-              </div>
-            )}
-            {receipt.extraction_meta.quality?.warnings && receipt.extraction_meta.quality.warnings.length > 0 && (
+            <div>
+              <p className="text-xs text-on-surface-variant uppercase tracking-widest">Confidence</p>
+              <p className={cn(
+                "font-bold",
+                confidence >= 0.7 ? 'text-primary' : 'text-error',
+              )}>
+                {(confidence * 100).toFixed(0)}%
+              </p>
+            </div>
+            {warnings && warnings.length > 0 && (
               <div>
                 <p className="text-xs text-on-surface-variant uppercase tracking-widest">Warnings</p>
                 <div className="flex flex-wrap gap-1 mt-1">
-                  {receipt.extraction_meta.quality.warnings.map((w, i) => (
+                  {warnings.map((w, i) => (
                     <span key={i} className="px-2 py-0.5 rounded bg-error/10 text-error text-[10px] font-bold uppercase">
                       {w}
                     </span>

--- a/src/components/Transactions.tsx
+++ b/src/components/Transactions.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { TrendingDown, Filter, Utensils, Plane, Zap, Film, Landmark, ShoppingBag, Car, Loader2 } from 'lucide-react';
-import { fetchTransactions } from '../lib/api';
+import { fetchTransactions, extractProblemMessage } from '../lib/api';
 import { cn } from '../lib/utils';
 import type { Transaction } from '../types';
 
@@ -14,9 +14,10 @@ export default function Transactions({ onSelectReceipt }: TransactionsProps) {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    fetchTransactions({ limit: 50 })
+    // "Receipt history" == transactions with at least one linked document.
+    fetchTransactions({ limit: 50, has_document: true })
       .then(setTransactions)
-      .catch((e) => setError(e.message))
+      .catch((e: unknown) => setError(extractProblemMessage(e)))
       .finally(() => setLoading(false));
   }, []);
 

--- a/src/components/useProcessingJobs.ts
+++ b/src/components/useProcessingJobs.ts
@@ -1,0 +1,39 @@
+import { useEffect, useState } from 'react';
+import type { ProcessingJob } from './ProcessingToast';
+
+const STORAGE_KEY = 'receipt-processing-batches-v1';
+const LEGACY_STORAGE_KEY = 'receipt-processing-jobs';
+
+/** Persist outstanding batch upload jobs to localStorage so the toast
+ *  survives full-page reloads (browser refresh mid-upload is a common
+ *  case — extraction can take 10-30s). */
+export function useProcessingJobs() {
+  const [jobs, setJobs] = useState<ProcessingJob[]>(() => {
+    try {
+      const saved = localStorage.getItem(STORAGE_KEY);
+      if (saved) return JSON.parse(saved) as ProcessingJob[];
+      // Clean up the legacy {jobId, receiptId} store once — the shape
+      // is incompatible and hitting the old backend will 404.
+      if (localStorage.getItem(LEGACY_STORAGE_KEY)) {
+        localStorage.removeItem(LEGACY_STORAGE_KEY);
+      }
+      return [];
+    } catch {
+      return [];
+    }
+  });
+
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(jobs));
+  }, [jobs]);
+
+  const addJob = (job: ProcessingJob) => {
+    setJobs((prev) => [...prev, job]);
+  };
+
+  const removeJob = (batchId: string) => {
+    setJobs((prev) => prev.filter((j) => j.batchId !== batchId));
+  };
+
+  return { jobs, addJob, removeJob };
+}

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -40,16 +40,39 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/receipt": {
+    "/v1/accounts": {
         parameters: {
             query?: never;
             header?: never;
             path?: never;
             cookie?: never;
         };
-        get?: never;
+        /** List accounts (tree by default, flat with ?flat=true) */
+        get: {
+            parameters: {
+                query?: {
+                    flat?: boolean | null;
+                    include_closed?: boolean | null;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Account list (flat: array of Account; default: array of AccountTreeNode roots) */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Account"][];
+                    };
+                };
+            };
+        };
         put?: never;
-        /** Upload a receipt JPG and start async extraction */
+        /** Create a new account */
         post: {
             parameters: {
                 query?: never;
@@ -59,35 +82,37 @@ export interface paths {
             };
             requestBody?: {
                 content: {
-                    "multipart/form-data": components["schemas"]["UploadReceiptForm"];
+                    "application/json": components["schemas"]["CreateAccountRequest"];
                 };
             };
             responses: {
-                /** @description Job submitted */
-                200: {
+                /** @description Account created */
+                201: {
                     headers: {
+                        Location?: string;
+                        ETag?: string;
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["JobUploadResponse"];
+                        "application/json": components["schemas"]["Account"];
                     };
                 };
-                /** @description Missing or invalid image */
-                400: {
+                /** @description Parent account not found */
+                404: {
                     headers: {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["ErrorResponse"];
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
                     };
                 };
-                /** @description Server error */
-                500: {
+                /** @description Validation failed */
+                422: {
                     headers: {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["ErrorResponse"];
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
                     };
                 };
             };
@@ -98,14 +123,14 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/jobs/{id}": {
+    "/v1/accounts/{id}": {
         parameters: {
             query?: never;
             header?: never;
             path?: never;
             cookie?: never;
         };
-        /** Poll job status */
+        /** Get one account */
         get: {
             parameters: {
                 query?: never;
@@ -117,176 +142,37 @@ export interface paths {
             };
             requestBody?: never;
             responses: {
-                /** @description Current job status */
+                /** @description Account */
                 200: {
                     headers: {
+                        ETag?: string;
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["JobStatusResponse"];
+                        "application/json": components["schemas"]["Account"];
                     };
                 };
-                /** @description Job not found */
+                /** @description Not Modified (If-None-Match matched) */
+                304: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Account not found */
                 404: {
                     headers: {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["ErrorResponse"];
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
                     };
                 };
             };
         };
         put?: never;
         post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/jobs/{id}/stream": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Server-Sent Events stream for job progress
-         * @description Emits `processing`, `done`, or `error` events. Connection closes after terminal event.
-         */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description SSE stream */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "text/event-stream": string;
-                    };
-                };
-                /** @description Job not found */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["ErrorResponse"];
-                    };
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/receipts": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** List receipts with optional filters */
-        get: {
-            parameters: {
-                query?: {
-                    from?: string;
-                    to?: string;
-                    category?: string;
-                    limit?: number;
-                };
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Receipts ordered by date desc */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Receipt"][];
-                    };
-                };
-                /** @description Invalid query parameter (e.g. malformed date, non-numeric limit) */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["ValidationErrorResponse"];
-                    };
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/receipt/{id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get one receipt with line items */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Receipt detail */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["ReceiptWithItems"];
-                    };
-                };
-                /** @description Receipt not found */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["ErrorResponse"];
-                    };
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        /** Delete a receipt (cascades to line items) */
+        /** Hard-delete an unused account */
         delete: {
             parameters: {
                 query?: never;
@@ -299,38 +185,339 @@ export interface paths {
             requestBody?: never;
             responses: {
                 /** @description Deleted */
-                200: {
+                204: {
                     headers: {
                         [name: string]: unknown;
                     };
-                    content: {
-                        "application/json": components["schemas"]["DeleteReceiptResponse"];
-                    };
+                    content?: never;
                 };
-                /** @description Receipt not found */
+                /** @description Account not found */
                 404: {
                     headers: {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["ErrorResponse"];
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+                /** @description Account has postings; soft-close instead */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+                /** @description Version mismatch */
+                412: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+                /** @description Precondition required (If-Match missing) */
+                428: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
                     };
                 };
             };
         };
         options?: never;
         head?: never;
-        patch?: never;
+        /** Patch account (rename / re-parent / close) */
+        patch: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/merge-patch+json": components["schemas"]["UpdateAccountRequest"];
+                };
+            };
+            responses: {
+                /** @description Account updated */
+                200: {
+                    headers: {
+                        ETag?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Account"];
+                    };
+                };
+                /** @description Account not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+                /** @description Version mismatch (If-Match) */
+                412: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+                /** @description Validation failed */
+                422: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+                /** @description Precondition required (If-Match missing) */
+                428: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+            };
+        };
         trace?: never;
     };
-    "/receipt/{id}/image": {
+    "/v1/accounts/{id}/balance": {
         parameters: {
             query?: never;
             header?: never;
             path?: never;
             cookie?: never;
         };
-        /** Serve the original receipt image file */
+        /** Account balance as of a date */
+        get: {
+            parameters: {
+                query?: {
+                    as_of?: string;
+                    currency?: string;
+                    include_children?: boolean | null;
+                };
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Balance summary */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["AccountBalance"];
+                    };
+                };
+                /** @description Account not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/accounts/{id}/register": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Register (checkbook view) with running balance */
+        get: {
+            parameters: {
+                query?: {
+                    from?: string;
+                    to?: string;
+                    include_voided?: boolean | null;
+                    cursor?: string;
+                    limit?: number;
+                };
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Paginated register */
+                200: {
+                    headers: {
+                        Link?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["AccountRegister"];
+                    };
+                };
+                /** @description Account not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/transactions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List transactions */
+        get: {
+            parameters: {
+                query?: {
+                    occurred_from?: string;
+                    occurred_to?: string;
+                    amount_min_minor?: number | null;
+                    amount_max_minor?: number | null;
+                    account_id?: string;
+                    payee_contains?: string;
+                    q?: string;
+                    status?: "draft" | "posted" | "voided" | "reconciled" | "error";
+                    trip_id?: string;
+                    has_document?: boolean | null;
+                    source_ingest_id?: string;
+                    sort?: "occurred_on" | "amount" | "created_at";
+                    order?: "asc" | "desc";
+                    cursor?: string;
+                    limit?: number;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            items: components["schemas"]["Transaction"][];
+                            next_cursor: string | null;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        /** Create a transaction */
+        post: {
+            parameters: {
+                query?: never;
+                header: {
+                    "Idempotency-Key": string;
+                };
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["CreateTransactionRequest"];
+                };
+            };
+            responses: {
+                /** @description Created */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Transaction"];
+                    };
+                };
+                /** @description Idempotency conflict */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+                /** @description Validation failed */
+                422: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+                /** @description Idempotency-Key required */
+                428: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/transactions/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get a transaction */
         get: {
             parameters: {
                 query?: never;
@@ -342,83 +529,119 @@ export interface paths {
             };
             requestBody?: never;
             responses: {
-                /** @description JPEG image bytes */
+                /** @description OK */
                 200: {
                     headers: {
                         [name: string]: unknown;
                     };
                     content: {
-                        "image/jpeg": string;
+                        "application/json": components["schemas"]["Transaction"];
                     };
                 };
-                /** @description Image not found on disk or in DB */
+                /** @description Not Modified */
+                304: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Not Found */
                 404: {
                     headers: {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["ErrorResponse"];
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
                     };
                 };
             };
         };
         put?: never;
         post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/summary": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Spending summary grouped by category */
-        get: {
+        /** Delete draft/error transaction */
+        delete: {
             parameters: {
-                query?: {
-                    from?: string;
-                    to?: string;
+                query?: never;
+                header: {
+                    "If-Match": string;
                 };
-                header?: never;
-                path?: never;
+                path: {
+                    id: string;
+                };
                 cookie?: never;
             };
             requestBody?: never;
             responses: {
-                /** @description One row per category, ordered by total_spent desc */
+                /** @description Deleted */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Must void instead */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        /** Patch transaction head fields */
+        patch: {
+            parameters: {
+                query?: never;
+                header: {
+                    "If-Match": string;
+                };
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/merge-patch+json": components["schemas"]["UpdateTransactionRequest"];
+                };
+            };
+            responses: {
+                /** @description OK */
                 200: {
                     headers: {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["SpendingSummary"];
+                        "application/json": components["schemas"]["Transaction"];
                     };
                 };
-                /** @description Invalid query parameter (e.g. malformed date) */
-                400: {
+                /** @description Version mismatch */
+                412: {
                     headers: {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["ValidationErrorResponse"];
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+                /** @description If-Match required */
+                428: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
                     };
                 };
             };
         };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
         trace?: never;
     };
-    "/ask": {
+    "/v1/transactions/{id}/void": {
         parameters: {
             query?: never;
             header?: never;
@@ -427,7 +650,91 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** Free-form question answered by Claude over your receipts */
+        /** Void a posted transaction */
+        post: {
+            parameters: {
+                query?: never;
+                header: {
+                    "If-Match": string;
+                };
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["VoidTransactionRequest"];
+                };
+            };
+            responses: {
+                /** @description Mirror transaction created */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Transaction"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/transactions/{id}/reconcile": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Reconcile a posted transaction */
+        post: {
+            parameters: {
+                query?: never;
+                header: {
+                    "If-Match": string;
+                };
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Transaction"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/transactions/bulk": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Bulk update/void/reconcile */
         post: {
             parameters: {
                 query?: never;
@@ -437,39 +744,1244 @@ export interface paths {
             };
             requestBody?: {
                 content: {
-                    "application/json": components["schemas"]["AskRequest"];
+                    "application/json": components["schemas"]["BulkRequest"];
                 };
             };
             responses: {
-                /** @description Claude's answer */
+                /** @description Per-op results */
                 200: {
                     headers: {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["AskResponse"];
-                    };
-                };
-                /** @description Missing or invalid `question` field */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["ValidationErrorResponse"];
-                    };
-                };
-                /** @description Server error */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["ErrorResponse"];
+                        "application/json": components["schemas"]["BulkResponse"];
                     };
                 };
             };
         };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/transactions/{id}/postings": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Add a posting to a transaction */
+        post: {
+            parameters: {
+                query?: never;
+                header: {
+                    "If-Match": string;
+                };
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["NewPosting"];
+                };
+            };
+            responses: {
+                /** @description Posting added */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Posting"];
+                    };
+                };
+                /** @description Imbalance */
+                422: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/transactions/{tid}/postings/{pid}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Delete a posting */
+        delete: {
+            parameters: {
+                query?: never;
+                header: {
+                    "If-Match": string;
+                };
+                path: {
+                    tid: string;
+                    pid: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Deleted */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Would leave <2 postings */
+                422: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        /** Update a posting */
+        patch: {
+            parameters: {
+                query?: never;
+                header: {
+                    "If-Match": string;
+                };
+                path: {
+                    tid: string;
+                    pid: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["UpdatePostingRequest"];
+                };
+            };
+            responses: {
+                /** @description Updated */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Posting"];
+                    };
+                };
+            };
+        };
+        trace?: never;
+    };
+    "/v1/postings": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List postings */
+        get: {
+            parameters: {
+                query?: {
+                    transaction_id?: string;
+                    account_id?: string;
+                    from?: string;
+                    to?: string;
+                    cursor?: string;
+                    limit?: number;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            items: components["schemas"]["Posting"][];
+                            next_cursor: string | null;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/postings/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get a posting */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Posting"];
+                    };
+                };
+                /** @description Not Found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/documents": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Upload a document (multipart, sha256 content-dedup) */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "multipart/form-data": components["schemas"]["UploadDocumentForm"];
+                };
+            };
+            responses: {
+                /** @description Duplicate upload detected — returns the existing document row */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Document"];
+                    };
+                };
+                /** @description Document created */
+                201: {
+                    headers: {
+                        Location?: string;
+                        ETag?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Document"];
+                    };
+                };
+                /** @description Validation failed */
+                422: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/documents/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get document metadata */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Document */
+                200: {
+                    headers: {
+                        ETag?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Document"];
+                    };
+                };
+                /** @description Not modified (If-None-Match matched) */
+                304: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        /** Hard-delete a document (only if it has no links) */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Deleted */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+                /** @description Document has links — unlink first */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/documents/{id}/content": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Stream document binary content */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Raw file bytes */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/octet-stream": string;
+                    };
+                };
+                /** @description Not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/documents/{id}/links": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Link a document to a transaction (idempotent) */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["CreateDocumentLinkRequest"];
+                };
+            };
+            responses: {
+                /** @description Linked (or already linked — idempotent) */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Document or transaction not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+                /** @description Validation failed */
+                422: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/documents/{id}/links/{txn_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Unlink a document from a transaction */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                    txn_id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Unlinked */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Link not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/ingest/batch": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Upload N files for agent classification + extraction. Returns 202 with per-file ingest ids. */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "multipart/form-data": components["schemas"]["CreateBatchForm"];
+                };
+            };
+            responses: {
+                /** @description Batch accepted — poll /v1/batches/:id for results */
+                202: {
+                    headers: {
+                        Location?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["CreateBatchResponse"];
+                    };
+                };
+                /** @description No files / validation failed */
+                422: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/batches": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List ingestion batches (most recent first) */
+        get: {
+            parameters: {
+                query?: {
+                    cursor?: string;
+                    limit?: number;
+                    status?: components["schemas"]["BatchStatus"];
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Paginated batch summaries */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            items: components["schemas"]["BatchSummary"][];
+                            next_cursor: string | null;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/batches/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get one batch with all child ingests */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Batch + items */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Batch"];
+                    };
+                };
+                /** @description Batch not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/batches/{id}/stream": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Server-Sent Events stream of per-ingest + per-batch + reconcile events. Connects, sends a `hello` catch-up frame with current counts + status, then relays `job.*`, `batch.*`, and `reconcile.*` events as they fire. Closes on terminal status (reconciled / failed) or client disconnect. */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Event stream. `event:` names: `hello`, `batch.status`, `job.started`, `job.done`, `job.error`, `batch.extracted`, `batch.failed`, `batch.reconciled`, `reconcile.started`, `reconcile.proposal`, `reconcile.done`. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "text/event-stream": string;
+                    };
+                };
+                /** @description Batch not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/ingests": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List ingests across batches */
+        get: {
+            parameters: {
+                query?: {
+                    cursor?: string;
+                    limit?: number;
+                    batch_id?: string;
+                    status?: components["schemas"]["IngestStatus"];
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Paginated ingests */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            items: components["schemas"]["Ingest"][];
+                            next_cursor: string | null;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/ingests/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get one ingest with produced reverse-lookup */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Ingest row */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Ingest"];
+                    };
+                };
+                /** @description Ingest not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/batches/{id}/reconcile": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Fetch the latest reconcile result for a batch. */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Reconcile snapshot */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ReconcileResult"];
+                    };
+                };
+                /** @description Batch not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        /** Run the reconcile pipeline over an extracted batch. Idempotent: a second call on a reconciled batch returns the stored result. */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["ReconcileRequest"];
+                };
+            };
+            responses: {
+                /** @description Reconcile completed (or replayed) */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ReconcileResult"];
+                    };
+                };
+                /** @description Batch is already mid-reconcile on another caller; response carries a `poll` URL to fetch the final result. */
+                202: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ReconcileResult"];
+                    };
+                };
+                /** @description Batch not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+                /** @description Batch is not in a reconcilable state (still extracting, or entered reconcile_error). */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ReconcileResult"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/batches/{id}/reconcile/apply": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Apply one or more reconcile proposals. For dedup proposals this voids the duplicate via the ledger service. */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["ApplyRequest"];
+                };
+            };
+            responses: {
+                /** @description Per-id apply/skip outcomes */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ApplyResult"];
+                    };
+                };
+                /** @description Batch not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+                /** @description Validation failed */
+                422: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/batches/{id}/reconcile/reject": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Reject one or more reconcile proposals. Marks proposals as rejected with no ledger mutation. */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["RejectRequest"];
+                };
+            };
+            responses: {
+                /** @description Per-id reject/skip outcomes */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["RejectResult"];
+                    };
+                };
+                /** @description Batch not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+                /** @description Validation failed */
+                422: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/reports/summary": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Spend aggregated by category / account / payee */
+        get: {
+            parameters: {
+                query?: {
+                    from?: string;
+                    to?: string;
+                    group_by?: "category" | "account" | "payee";
+                    currency?: string;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Summary report */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["SummaryReport"];
+                    };
+                };
+                /** @description Workspace not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/reports/trends": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Time-series trend (MoM / YoY) of expense spend */
+        get: {
+            parameters: {
+                query?: {
+                    period?: "month" | "year";
+                    from?: string;
+                    to?: string;
+                    group_by?: "category" | "total";
+                    currency?: string;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Trends report */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["TrendsReport"];
+                    };
+                };
+                /** @description Workspace not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/reports/net_worth": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Assets - liabilities at a point in time */
+        get: {
+            parameters: {
+                query?: {
+                    as_of?: string;
+                    currency?: string;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Net worth report */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["NetWorthReport"];
+                    };
+                };
+                /** @description Workspace not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/reports/cashflow": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Inflows vs outflows over a range, bucketed by month */
+        get: {
+            parameters: {
+                query?: {
+                    from?: string;
+                    to?: string;
+                    currency?: string;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Cashflow report */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["CashflowReport"];
+                    };
+                };
+                /** @description Workspace not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -502,97 +2014,854 @@ export interface components {
             /** @example 1.0.0 */
             version: string;
         };
-        ExtractionMeta: {
-            quality: {
-                confidence_score: number;
-                missing_fields: string[];
-                warnings: string[];
-            };
-            business: {
-                is_reimbursable: boolean;
-                is_tax_deductible: boolean;
-                is_recurring: boolean;
-                is_split_bill: boolean;
-            };
-        } | null;
-        Receipt: {
-            id: string;
-            merchant: string;
+        Violation: {
+            path: string;
+            code: string;
+            message?: string;
+        };
+        ProblemDetails: {
+            /** Format: uri */
+            type: string;
+            title: string;
+            status: number;
+            detail?: string;
+            instance?: string;
+            trace_id?: string;
+            violations?: components["schemas"]["Violation"][];
+        };
+        Account: {
             /**
-             * @description ISO date YYYY-MM-DD
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            id: string;
+            /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            workspace_id: string;
+            /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            parent_id: string | null;
+            code: string | null;
+            name: string;
+            /** @enum {string} */
+            type: "asset" | "liability" | "equity" | "income" | "expense";
+            subtype: string | null;
+            /** @example USD */
+            currency: string;
+            institution: string | null;
+            last4: string | null;
+            /**
+             * @description Signed integer in the currency's minor unit (cents for USD, 1 for JPY, satoshi for BTC). Never store money as float.
+             * @example 14723
+             */
+            opening_balance_minor: number;
+            /** Format: date-time */
+            closed_at: string | null;
+            /**
+             * @description User-defined JSON object; not schema-validated.
+             * @default {}
+             */
+            metadata: {
+                [key: string]: unknown;
+            };
+            version: number;
+            /** Format: date-time */
+            created_at: string;
+            /** Format: date-time */
+            updated_at: string;
+        };
+        CreateAccountRequest: {
+            /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            parent_id?: string;
+            code?: string;
+            name: string;
+            /** @enum {string} */
+            type: "asset" | "liability" | "equity" | "income" | "expense";
+            subtype?: string;
+            /** @example USD */
+            currency?: string;
+            institution?: string;
+            last4?: string;
+            /**
+             * @description Signed integer in the currency's minor unit (cents for USD, 1 for JPY, satoshi for BTC). Never store money as float.
+             * @example 14723
+             */
+            opening_balance_minor?: number;
+            /**
+             * @description User-defined JSON object; not schema-validated.
+             * @default {}
+             */
+            metadata: {
+                [key: string]: unknown;
+            };
+        };
+        UpdateAccountRequest: {
+            code?: string | null;
+            name?: string;
+            subtype?: string | null;
+            institution?: string | null;
+            last4?: string | null;
+            /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            parent_id?: string | null;
+            /** Format: date-time */
+            closed_at?: string | null;
+            /**
+             * @description User-defined JSON object; not schema-validated.
+             * @default {}
+             */
+            metadata: {
+                [key: string]: unknown;
+            };
+        };
+        AccountBalance: {
+            /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            account_id: string;
+            /**
+             * Format: date
              * @example 2026-04-19
              */
-            date: string;
-            total: number;
-            currency?: string | null;
-            category?: string | null;
-            payment_method?: string | null;
-            tax?: number | null;
-            tip?: number | null;
-            notes?: string | null;
-            raw_text?: string | null;
-            image_path?: string | null;
-            address?: string | null;
-            latitude?: number | null;
-            longitude?: number | null;
-            place_id?: string | null;
-            /** @enum {string} */
-            status?: "processing" | "done" | "error";
-            extraction_meta?: components["schemas"]["ExtractionMeta"];
-            created_at?: string;
-            updated_at?: string;
+            as_of: string;
+            /**
+             * @description Signed integer in the currency's minor unit (cents for USD, 1 for JPY, satoshi for BTC). Never store money as float.
+             * @example 14723
+             */
+            balance_minor: number;
+            /** @example USD */
+            currency: string;
+            posting_count: number;
+            includes_children: boolean;
         };
-        ReceiptItem: {
+        RegisterCounterPosting: {
+            /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            account_id: string;
             name: string;
-            quantity?: number | null;
-            unit_price?: number | null;
-            total_price?: number | null;
-            category?: string | null;
+            /**
+             * @description Signed integer in the currency's minor unit (cents for USD, 1 for JPY, satoshi for BTC). Never store money as float.
+             * @example 14723
+             */
+            amount_minor: number;
         };
-        ReceiptWithItems: components["schemas"]["Receipt"] & {
-            items: components["schemas"]["ReceiptItem"][];
+        RegisterDocumentRef: {
+            /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            id: string;
+            kind: string;
         };
-        JobUploadResponse: {
-            jobId: string;
-            receiptId: string;
+        RegisterItem: {
+            /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            posting_id: string;
+            /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            transaction_id: string;
+            transaction_version: number;
+            /**
+             * Format: date
+             * @example 2026-04-19
+             */
+            occurred_on: string;
+            payee: string | null;
+            narration: string | null;
+            /**
+             * @description Signed integer in the currency's minor unit (cents for USD, 1 for JPY, satoshi for BTC). Never store money as float.
+             * @example 14723
+             */
+            amount_minor: number;
+            /** @example USD */
+            currency: string;
+            /**
+             * @description Signed integer in the currency's minor unit (cents for USD, 1 for JPY, satoshi for BTC). Never store money as float.
+             * @example 14723
+             */
+            running_balance_after_minor: number;
+            counter_postings: components["schemas"]["RegisterCounterPosting"][];
+            documents: components["schemas"]["RegisterDocumentRef"][];
+        };
+        AccountRegister: {
+            /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            account_id: string;
+            items: components["schemas"]["RegisterItem"][];
+            next_cursor: string | null;
+        };
+        Posting: {
+            /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            id: string;
+            /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            transaction_id: string;
+            /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            account_id: string;
+            /**
+             * @description Signed integer in the currency's minor unit (cents for USD, 1 for JPY, satoshi for BTC). Never store money as float.
+             * @example 14723
+             */
+            amount_minor: number;
+            /** @example USD */
+            currency: string;
+            fx_rate: string | null;
+            /**
+             * @description Signed integer in the currency's minor unit (cents for USD, 1 for JPY, satoshi for BTC). Never store money as float.
+             * @example 14723
+             */
+            amount_base_minor: number | null;
+            memo: string | null;
+            /** Format: date-time */
+            created_at: string;
+        };
+        TransactionDocumentRef: {
+            /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            id: string;
+            kind: string;
+        };
+        Transaction: {
+            /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            id: string;
+            /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            workspace_id: string;
+            /**
+             * Format: date
+             * @example 2026-04-19
+             */
+            occurred_on: string;
+            /** Format: date-time */
+            occurred_at: string | null;
+            payee: string | null;
+            narration: string | null;
             /** @enum {string} */
-            status: "processing";
-            /** @example /jobs/abc/stream */
-            stream: string;
-            /** @example /jobs/abc */
-            poll: string;
+            status: "draft" | "posted" | "voided" | "reconciled" | "error";
+            /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            voided_by_id: string | null;
+            /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            source_ingest_id: string | null;
+            /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            trip_id: string | null;
+            /**
+             * @description User-defined JSON object; not schema-validated.
+             * @default {}
+             */
+            metadata: {
+                [key: string]: unknown;
+            };
+            version: number;
+            /** Format: date-time */
+            created_at: string;
+            /** Format: date-time */
+            updated_at: string;
+            postings: components["schemas"]["Posting"][];
+            documents: components["schemas"]["TransactionDocumentRef"][];
+        };
+        BulkResultItem: {
+            index: number;
+            status: number;
+            body?: unknown;
+        };
+        BulkResponse: {
+            results: components["schemas"]["BulkResultItem"][];
+        };
+        Document: {
+            /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            id: string;
+            /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            workspace_id: string;
+            /** @enum {string} */
+            kind: "receipt_image" | "receipt_email" | "receipt_pdf" | "statement_pdf" | "other";
+            file_path: string | null;
+            mime_type: string | null;
+            sha256: string;
+            ocr_text: string | null;
+            extraction_meta: {
+                [key: string]: unknown;
+            } | null;
+            /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            source_ingest_id: string | null;
+            /** Format: date-time */
+            created_at: string;
+            /** Format: date-time */
+            updated_at: string;
         };
         /** @enum {string} */
-        JobStatus: "queued" | "processing" | "done" | "error";
-        JobStatusResponse: {
-            jobId: string;
-            receiptId: string;
-            status: components["schemas"]["JobStatus"];
-            error: string | null;
-        };
-        SpendingSummaryItem: {
-            category: string | null;
-            count: number;
-            total_spent: number;
-            avg_per_receipt: number;
-        };
-        SpendingSummary: components["schemas"]["SpendingSummaryItem"][];
-        AskRequest: {
-            /** @example How much did I spend on groceries last month? */
-            question: string;
-        };
-        AskResponse: {
-            answer: string;
-        };
-        UploadReceiptForm: {
+        DocumentKind: "receipt_image" | "receipt_email" | "receipt_pdf" | "statement_pdf" | "other";
+        UploadDocumentForm: {
             /** Format: binary */
-            image: string;
-            notes?: string;
+            file?: string;
+            /** @enum {string} */
+            kind?: "receipt_image" | "receipt_email" | "receipt_pdf" | "statement_pdf" | "other";
         };
-        DeleteReceiptResponse: {
-            /** @enum {boolean} */
-            success: true;
+        CreateDocumentLinkRequest: {
+            /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            transaction_id: string;
+        };
+        /** @enum {string} */
+        BatchStatus: "pending" | "processing" | "extracted" | "reconciling" | "reconciled" | "failed" | "reconcile_error";
+        BatchCounts: {
+            total: number;
+            queued: number;
+            processing: number;
+            done: number;
+            error: number;
+            unsupported: number;
+        };
+        /** @enum {string} */
+        IngestStatus: "queued" | "processing" | "done" | "error" | "unsupported";
+        /** @enum {string|null} */
+        IngestClassification: "receipt_image" | "receipt_email" | "receipt_pdf" | "statement_pdf" | "unsupported" | null;
+        IngestProduced: {
+            /** @default [] */
+            receipt_ids: string[];
+            /** @default [] */
+            transaction_ids: string[];
+            /** @default [] */
+            document_ids: string[];
+        } | null;
+        Ingest: {
+            /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
             id: string;
+            /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            workspace_id: string;
+            /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            batch_id: string | null;
+            filename: string;
+            mime_type: string | null;
+            file_path: string;
+            status: components["schemas"]["IngestStatus"];
+            classification: components["schemas"]["IngestClassification"];
+            produced: components["schemas"]["IngestProduced"];
+            error: string | null;
+            /** Format: date-time */
+            created_at: string;
+            /** Format: date-time */
+            completed_at: string | null;
+        };
+        Batch: {
+            /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            id: string;
+            /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            workspace_id: string;
+            status: components["schemas"]["BatchStatus"];
+            file_count: number;
+            auto_reconcile: boolean;
+            counts: components["schemas"]["BatchCounts"];
+            items: components["schemas"]["Ingest"][];
+            /** Format: date-time */
+            created_at: string;
+            /** Format: date-time */
+            completed_at: string | null;
+            /** Format: date-time */
+            reconciled_at: string | null;
+        };
+        BatchSummary: {
+            /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            id: string;
+            /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            workspace_id: string;
+            status: components["schemas"]["BatchStatus"];
+            file_count: number;
+            auto_reconcile: boolean;
+            counts: components["schemas"]["BatchCounts"];
+            /** Format: date-time */
+            created_at: string;
+            /** Format: date-time */
+            completed_at: string | null;
+            /** Format: date-time */
+            reconciled_at: string | null;
+        };
+        CreateBatchForm: {
+            files?: string[];
+            auto_reconcile?: boolean | ("true" | "false");
+        };
+        CreateBatchResponse: {
+            /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            batchId: string;
+            status: components["schemas"]["BatchStatus"];
+            items: {
+                /**
+                 * Format: uuid
+                 * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+                 */
+                ingestId: string;
+                filename: string;
+                mime_type: string | null;
+            }[];
+            poll: string;
+        };
+        /**
+         * @default batch
+         * @enum {string}
+         */
+        ReconcileScope: "batch" | "batch_plus_recent_90d";
+        /** @enum {string} */
+        ReconcileKind: "dedup" | "payment_link" | "trip_group" | "inventory";
+        ReconcileRequest: {
+            scope?: components["schemas"]["ReconcileScope"];
+            enable?: components["schemas"]["ReconcileKind"][];
+            /** @default 0.95 */
+            auto_apply_threshold: number;
+        };
+        /** @enum {string} */
+        ReconcileBatchStatus: "extracted" | "reconciling" | "reconciled" | "reconcile_error";
+        ReconcileApplied: {
+            /** @default [] */
+            duplicates: {
+                /**
+                 * Format: uuid
+                 * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+                 */
+                receiptId: string;
+                /**
+                 * Format: uuid
+                 * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+                 */
+                duplicateOf: string;
+            }[];
+            /** @default [] */
+            payment_links: unknown[];
+            /** @default [] */
+            inventory: unknown[];
+            proposals_total: number;
+        };
+        /** @enum {string} */
+        ReconcileProposalStatus: "proposed" | "auto_applied" | "user_applied" | "rejected";
+        ReconcileProposal: {
+            /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            id: string;
+            /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            batch_id: string;
+            kind: components["schemas"]["ReconcileKind"];
+            payload: {
+                [key: string]: unknown;
+            };
+            score: number | null;
+            status: components["schemas"]["ReconcileProposalStatus"];
+            /** Format: date-time */
+            created_at: string;
+            /** Format: date-time */
+            resolved_at: string | null;
+        };
+        ReconcileResult: {
+            /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            batchId: string;
+            status: components["schemas"]["ReconcileBatchStatus"];
+            applied: components["schemas"]["ReconcileApplied"];
+            proposals: components["schemas"]["ReconcileProposal"][];
+            poll?: string;
+        };
+        ApplyRequest: {
+            proposal_ids: string[];
+        };
+        ApplyResult: {
+            applied: string[];
+            skipped: {
+                /**
+                 * Format: uuid
+                 * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+                 */
+                id: string;
+                reason: string;
+            }[];
+        };
+        RejectRequest: {
+            proposal_ids: string[];
+            reason?: string;
+        };
+        RejectResult: {
+            rejected: string[];
+            skipped: {
+                /**
+                 * Format: uuid
+                 * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+                 */
+                id: string;
+                reason: string;
+            }[];
+        };
+        SummaryItem: {
+            key: string;
+            count: number;
+            /**
+             * @description Signed integer in the currency's minor unit (cents for USD, 1 for JPY, satoshi for BTC). Never store money as float.
+             * @example 14723
+             */
+            total_minor: number;
+            /**
+             * @description Signed integer in the currency's minor unit (cents for USD, 1 for JPY, satoshi for BTC). Never store money as float.
+             * @example 14723
+             */
+            avg_per_txn_minor: number;
+        };
+        SummaryReport: {
+            /**
+             * Format: date
+             * @example 2026-04-19
+             */
+            from: string | null;
+            /**
+             * Format: date
+             * @example 2026-04-19
+             */
+            to: string | null;
+            /** @enum {string} */
+            group_by: "category" | "account" | "payee";
+            /** @example USD */
+            currency: string;
+            items: components["schemas"]["SummaryItem"][];
+            /**
+             * @description Signed integer in the currency's minor unit (cents for USD, 1 for JPY, satoshi for BTC). Never store money as float.
+             * @example 14723
+             */
+            grand_total_minor: number;
+        };
+        TrendsItem: {
+            key: string;
+            /**
+             * @description Signed integer in the currency's minor unit (cents for USD, 1 for JPY, satoshi for BTC). Never store money as float.
+             * @example 14723
+             */
+            total_minor: number;
+            count: number;
+        };
+        TrendsBucket: {
+            bucket: string;
+            items: components["schemas"]["TrendsItem"][];
+            /**
+             * @description Signed integer in the currency's minor unit (cents for USD, 1 for JPY, satoshi for BTC). Never store money as float.
+             * @example 14723
+             */
+            total_minor: number;
+        };
+        TrendsReport: {
+            /**
+             * Format: date
+             * @example 2026-04-19
+             */
+            from: string | null;
+            /**
+             * Format: date
+             * @example 2026-04-19
+             */
+            to: string | null;
+            /** @enum {string} */
+            period: "month" | "year";
+            /** @enum {string} */
+            group_by: "category" | "total";
+            /** @example USD */
+            currency: string;
+            buckets: components["schemas"]["TrendsBucket"][];
+        };
+        NetWorthAccount: {
+            /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            account_id: string;
+            name: string;
+            /** @enum {string} */
+            type: "asset" | "liability" | "equity" | "income" | "expense";
+            /**
+             * @description Signed integer in the currency's minor unit (cents for USD, 1 for JPY, satoshi for BTC). Never store money as float.
+             * @example 14723
+             */
+            balance_minor: number;
+        };
+        NetWorthReport: {
+            /**
+             * Format: date
+             * @example 2026-04-19
+             */
+            as_of: string;
+            /** @example USD */
+            currency: string;
+            /**
+             * @description Signed integer in the currency's minor unit (cents for USD, 1 for JPY, satoshi for BTC). Never store money as float.
+             * @example 14723
+             */
+            assets_minor: number;
+            /**
+             * @description Signed integer in the currency's minor unit (cents for USD, 1 for JPY, satoshi for BTC). Never store money as float.
+             * @example 14723
+             */
+            liabilities_minor: number;
+            /**
+             * @description Signed integer in the currency's minor unit (cents for USD, 1 for JPY, satoshi for BTC). Never store money as float.
+             * @example 14723
+             */
+            equity_minor: number;
+            /**
+             * @description Signed integer in the currency's minor unit (cents for USD, 1 for JPY, satoshi for BTC). Never store money as float.
+             * @example 14723
+             */
+            net_worth_minor: number;
+            by_account: components["schemas"]["NetWorthAccount"][];
+        };
+        CashflowBucket: {
+            month: string;
+            /**
+             * @description Signed integer in the currency's minor unit (cents for USD, 1 for JPY, satoshi for BTC). Never store money as float.
+             * @example 14723
+             */
+            income_minor: number;
+            /**
+             * @description Signed integer in the currency's minor unit (cents for USD, 1 for JPY, satoshi for BTC). Never store money as float.
+             * @example 14723
+             */
+            expense_minor: number;
+            /**
+             * @description Signed integer in the currency's minor unit (cents for USD, 1 for JPY, satoshi for BTC). Never store money as float.
+             * @example 14723
+             */
+            net_minor: number;
+        };
+        CashflowReport: {
+            /**
+             * Format: date
+             * @example 2026-04-19
+             */
+            from: string | null;
+            /**
+             * Format: date
+             * @example 2026-04-19
+             */
+            to: string | null;
+            /** @example USD */
+            currency: string;
+            /**
+             * @description Signed integer in the currency's minor unit (cents for USD, 1 for JPY, satoshi for BTC). Never store money as float.
+             * @example 14723
+             */
+            income_minor: number;
+            /**
+             * @description Signed integer in the currency's minor unit (cents for USD, 1 for JPY, satoshi for BTC). Never store money as float.
+             * @example 14723
+             */
+            expense_minor: number;
+            /**
+             * @description Signed integer in the currency's minor unit (cents for USD, 1 for JPY, satoshi for BTC). Never store money as float.
+             * @example 14723
+             */
+            net_minor: number;
+            buckets: components["schemas"]["CashflowBucket"][];
+        };
+        NewPosting: {
+            /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            account_id: string;
+            /**
+             * @description Signed integer in the currency's minor unit (cents for USD, 1 for JPY, satoshi for BTC). Never store money as float.
+             * @example 14723
+             */
+            amount_minor: number;
+            /** @example USD */
+            currency?: string;
+            fx_rate?: string;
+            /**
+             * @description Signed integer in the currency's minor unit (cents for USD, 1 for JPY, satoshi for BTC). Never store money as float.
+             * @example 14723
+             */
+            amount_base_minor?: number;
+            memo?: string;
+        };
+        CreateTransactionRequest: {
+            /**
+             * Format: date
+             * @example 2026-04-19
+             */
+            occurred_on: string;
+            /** Format: date-time */
+            occurred_at?: string;
+            payee?: string;
+            narration?: string;
+            /** @enum {string} */
+            status?: "draft" | "posted" | "voided" | "reconciled" | "error";
+            postings: components["schemas"]["NewPosting"][];
+            document_ids?: string[];
+            /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            trip_id?: string;
+            /**
+             * @description User-defined JSON object; not schema-validated.
+             * @default {}
+             */
+            metadata: {
+                [key: string]: unknown;
+            };
+        };
+        UpdateTransactionRequest: {
+            /**
+             * Format: date
+             * @example 2026-04-19
+             */
+            occurred_on?: string;
+            /** Format: date-time */
+            occurred_at?: string | null;
+            payee?: string | null;
+            narration?: string | null;
+            /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            trip_id?: string | null;
+            /**
+             * @description User-defined JSON object; not schema-validated.
+             * @default {}
+             */
+            metadata: {
+                [key: string]: unknown;
+            };
+        };
+        VoidTransactionRequest: {
+            reason?: string;
+        };
+        BulkRequest: {
+            operations: ({
+                /** @enum {string} */
+                op: "update";
+                /**
+                 * Format: uuid
+                 * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+                 */
+                id: string;
+                if_match: string;
+                patch: components["schemas"]["UpdateTransactionRequest"];
+            } | {
+                /** @enum {string} */
+                op: "void";
+                /**
+                 * Format: uuid
+                 * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+                 */
+                id: string;
+                if_match: string;
+                reason?: string;
+            } | {
+                /** @enum {string} */
+                op: "reconcile";
+                /**
+                 * Format: uuid
+                 * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+                 */
+                id: string;
+                if_match: string;
+            })[];
+        };
+        UpdatePostingRequest: {
+            /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            account_id?: string;
+            /**
+             * @description Signed integer in the currency's minor unit (cents for USD, 1 for JPY, satoshi for BTC). Never store money as float.
+             * @example 14723
+             */
+            amount_minor?: number;
+            /** @example USD */
+            currency?: string;
+            fx_rate?: string;
+            /**
+             * @description Signed integer in the currency's minor unit (cents for USD, 1 for JPY, satoshi for BTC). Never store money as float.
+             * @example 14723
+             */
+            amount_base_minor?: number;
+            memo?: string | null;
         };
     };
     responses: never;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,10 +1,23 @@
 /**
- * API client for ReceiptAssistant backend.
+ * API client for ReceiptAssistant backend (v1 surface).
  * Uses Vite proxy: /api/* → localhost:3000/*
  *
  * Types are codegen'd from the backend's OpenAPI spec — see
  * src/lib/api-types.ts (regenerate with `npm run api:types`).
  * Do not hand-write request/response shapes here; derive from `paths`.
+ *
+ * The old `/receipts*` and `/jobs/*` endpoints were removed from the
+ * backend. Everything now lives under `/v1/*`:
+ *   - "Receipt" = Transaction + Document(s). A "receipt image" is a
+ *     Document whose `kind=receipt_image`, linked to a Transaction via
+ *     the ledger.
+ *   - Upload-one-receipt UX is wired to `/v1/ingest/batch` with a
+ *     single file. Poll `/v1/batches/{id}` for the produced
+ *     transaction_ids / document_ids (SSE also available).
+ *   - Summary uses `/v1/reports/summary?group_by=category`.
+ *
+ * Error format is RFC 7807 (application/problem+json). Use
+ * `extractProblemMessage(err)` to pull a user-visible string.
  */
 import imageCompression from 'browser-image-compression';
 import createClient from 'openapi-fetch';
@@ -15,19 +28,67 @@ const client = createClient<paths>({ baseUrl: '/api' });
 
 // ── Backend type aliases (derived from the OpenAPI spec) ────────
 
-type BackendReceipt = components['schemas']['Receipt'];
-type BackendReceiptWithItems = components['schemas']['ReceiptWithItems'];
-type BackendSpendingSummary = components['schemas']['SpendingSummary'];
+export type BackendTransaction = components['schemas']['Transaction'];
+export type BackendPosting = components['schemas']['Posting'];
+export type BackendDocument = components['schemas']['Document'];
+export type BackendBatch = components['schemas']['Batch'];
+export type BackendBatchSummary = components['schemas']['BatchSummary'];
+export type BackendIngest = components['schemas']['Ingest'];
+export type BackendAccount = components['schemas']['Account'];
+export type BackendAccountBalance = components['schemas']['AccountBalance'];
+export type BackendAccountRegister = components['schemas']['AccountRegister'];
+export type BackendSummaryReport = components['schemas']['SummaryReport'];
+export type BackendSummaryItem = components['schemas']['SummaryItem'];
+export type BackendTrendsReport = components['schemas']['TrendsReport'];
+export type BackendNetWorthReport = components['schemas']['NetWorthReport'];
+export type BackendCashflowReport = components['schemas']['CashflowReport'];
+export type BackendProblemDetails = components['schemas']['ProblemDetails'];
+export type NewPosting = components['schemas']['NewPosting'];
+export type UpdateTransactionRequest = components['schemas']['UpdateTransactionRequest'];
+export type CreateTransactionRequest = components['schemas']['CreateTransactionRequest'];
+export type DocumentKind = components['schemas']['DocumentKind'];
+export type BatchStatus = components['schemas']['BatchStatus'];
+export type IngestStatus = components['schemas']['IngestStatus'];
 
-export type ReceiptDetail = BackendReceiptWithItems;
-export type JobStatus = components['schemas']['JobStatusResponse'];
-export type UploadResult = components['schemas']['JobUploadResponse'];
-export type SpendingSummary = BackendSpendingSummary[number];
+/** An ETag-aware wrapper. Keep the ETag alongside the resource so PATCH
+ *  / POST-void / DELETE calls can fill in `If-Match`. */
+export interface WithETag<T> {
+  data: T;
+  etag: string | null;
+}
 
-// ── Frontend display mapping (unchanged from before) ────────────
+/**
+ * UI-facing "receipt view" — a transaction with its expense posting,
+ * primary document, and pre-computed display-friendly fields.
+ * This is the shape the ReceiptDetail screen consumes.
+ */
+export interface ReceiptView {
+  id: string;
+  status: BackendTransaction['status'];
+  version: number;
+  occurred_on: string;
+  payee: string | null;
+  narration: string | null;
+  currency: string;
+  total_minor: number;
+  total: number;
+  /** Category derived from the expense account's subtype / name. */
+  category: string | null;
+  paymentMethod: string | null;
+  /** Primary document (receipt image) if any. */
+  documentId: string | null;
+  documentKind: string | null;
+  documents: BackendTransaction['documents'];
+  postings: BackendPosting[];
+  etag: string | null;
+}
+
+// ── Frontend display mapping ────────────────────────────────────
 
 const CATEGORY_MAP: Record<string, Transaction['category']> = {
   food: 'Dining',
+  dining: 'Dining',
+  restaurants: 'Dining',
   groceries: 'Shopping',
   transport: 'Transport',
   shopping: 'Shopping',
@@ -53,49 +114,94 @@ const ICON_MAP: Record<string, string> = {
   'Real Estate': 'real_estate_agent',
 };
 
-function mapReceipt(r: BackendReceipt): Transaction {
-  if (r.status === 'processing') {
-    return {
-      id: r.id,
-      description: 'Processing...',
-      category: 'Fun',
-      date: r.date,
-      paymentMethod: 'Unknown',
-      amount: 0,
-      status: 'Processing',
-      icon: 'hourglass_empty',
-      color: 'tertiary',
-    };
+function normalizeCategoryKey(raw: string | null | undefined): string | null {
+  if (!raw) return null;
+  return raw.toLowerCase().trim().replace(/[\s_-]+/g, '_');
+}
+
+function categoryFromTxn(t: BackendTransaction): string | null {
+  // The backend doesn't attach a direct "category" field — infer from
+  // metadata first (extractor often stashes one under `category_hint`
+  // or `category`), fall back to null.
+  const md = t.metadata ?? {};
+  const raw =
+    (md as Record<string, unknown>).category ??
+    (md as Record<string, unknown>).category_hint ??
+    (md as Record<string, unknown>).expense_category ??
+    null;
+  return typeof raw === 'string' ? raw : null;
+}
+
+function primaryDocument(t: BackendTransaction): BackendTransaction['documents'][number] | null {
+  if (!t.documents || t.documents.length === 0) return null;
+  const img = t.documents.find((d) => d.kind === 'receipt_image');
+  return img ?? t.documents[0];
+}
+
+/** Sum the absolute value of expense-side postings (positive minor). */
+function totalMinorFromPostings(postings: BackendPosting[]): { minor: number; currency: string } {
+  if (!postings || postings.length === 0) return { minor: 0, currency: 'USD' };
+  // Expense postings are positive; pick the largest-magnitude positive
+  // one as the "total" (matches a typical receipt that credits asset/
+  // liability for -X and debits expense for +X).
+  const positives = postings.filter((p) => p.amount_minor > 0);
+  if (positives.length === 0) {
+    // All-credit edge case — use absolute max.
+    const magnitudes = postings.map((p) => Math.abs(p.amount_minor));
+    const max = Math.max(...magnitudes);
+    return { minor: max, currency: postings[0].currency };
   }
+  const total = positives.reduce((s, p) => s + p.amount_minor, 0);
+  return { minor: total, currency: positives[0].currency };
+}
 
-  if (r.status === 'error') {
-    return {
-      id: r.id,
-      description: r.merchant || 'Failed',
-      category: 'Fun',
-      date: r.date,
-      paymentMethod: 'Unknown',
-      amount: 0,
-      status: 'Pending',
-      icon: 'error',
-      color: 'error',
-    };
-  }
-
-  const category = CATEGORY_MAP[r.category ?? 'other'] ?? 'Fun';
-  const confidence = r.extraction_meta?.quality?.confidence_score;
-  const status: Transaction['status'] =
-    confidence != null && confidence < 0.7 ? 'Pending'
-    : confidence != null ? 'Verified'
-    : 'New Charge';
-
+export function toReceiptView(t: BackendTransaction, etag: string | null = null): ReceiptView {
+  const { minor, currency } = totalMinorFromPostings(t.postings);
+  const doc = primaryDocument(t);
+  const md = t.metadata ?? {};
+  const paymentMethod =
+    (typeof (md as Record<string, unknown>).payment_method === 'string'
+      ? ((md as Record<string, unknown>).payment_method as string)
+      : null) ?? null;
   return {
-    id: r.id,
-    description: r.merchant,
+    id: t.id,
+    status: t.status,
+    version: t.version,
+    occurred_on: t.occurred_on,
+    payee: t.payee,
+    narration: t.narration,
+    currency,
+    total_minor: minor,
+    total: minor / 100,
+    category: categoryFromTxn(t),
+    paymentMethod,
+    documentId: doc?.id ?? null,
+    documentKind: doc?.kind ?? null,
+    documents: t.documents,
+    postings: t.postings,
+    etag,
+  };
+}
+
+/** Map a backend Transaction to the compact UI Transaction row. */
+export function mapTransaction(t: BackendTransaction): Transaction {
+  const rv = toReceiptView(t);
+  const rawCat = normalizeCategoryKey(rv.category);
+  const category: Transaction['category'] =
+    (rawCat ? CATEGORY_MAP[rawCat] : undefined) ?? 'Fun';
+  const status: Transaction['status'] =
+    t.status === 'draft' || t.status === 'error' ? 'Pending'
+    : t.status === 'voided' ? 'Pending'
+    : t.status === 'reconciled' ? 'Verified'
+    : 'New Charge';
+  return {
+    id: t.id,
+    description: rv.payee ?? rv.narration ?? 'Unknown',
     category,
-    date: r.date,
-    paymentMethod: r.payment_method ?? 'Unknown',
-    amount: -(r.total ?? 0),
+    date: rv.occurred_on,
+    paymentMethod: rv.paymentMethod ?? 'Unknown',
+    // UI convention: expenses render as negative.
+    amount: -rv.total,
     status,
     icon: ICON_MAP[category] ?? 'receipt',
     color: 'primary',
@@ -114,68 +220,533 @@ async function compressImage(file: File): Promise<File> {
   });
 }
 
-// ── API functions ───────────────────────────────────────────────
+// ── Error helpers (RFC 7807) ───────────────────────────────────
+
+/** Extract a human-visible message from a Problem Details payload
+ *  (or any unknown error shape we get handed back). */
+export function extractProblemMessage(err: unknown): string {
+  if (!err) return 'Unknown error';
+  if (typeof err === 'string') return err;
+  if (err instanceof Error) return err.message;
+  if (typeof err === 'object') {
+    const e = err as Record<string, unknown>;
+    if (typeof e.detail === 'string') return e.detail;
+    if (typeof e.title === 'string') return e.title;
+    if (typeof e.error === 'string') return e.error;
+    if (Array.isArray(e.violations) && e.violations.length > 0) {
+      return e.violations
+        .map((v: unknown) =>
+          typeof v === 'object' && v !== null && 'message' in v
+            ? String((v as { message: unknown }).message)
+            : JSON.stringify(v),
+        )
+        .join('; ');
+    }
+    try {
+      return JSON.stringify(err);
+    } catch {
+      return String(err);
+    }
+  }
+  return String(err);
+}
 
 function unwrap<T>(label: string, data: T | undefined, error: unknown, status: number): T {
   if (error || data === undefined) {
-    throw new Error(`${label} failed: ${status}${error ? ' — ' + JSON.stringify(error) : ''}`);
+    const msg = extractProblemMessage(error ?? { title: `HTTP ${status}` });
+    const e = new Error(`${label} failed (${status}): ${msg}`);
+    // Attach the original problem for callers that want to introspect.
+    (e as Error & { problem?: unknown }).problem = error;
+    throw e;
   }
   return data;
 }
 
+function etagFrom(response: Response): string | null {
+  return response.headers.get('ETag') ?? response.headers.get('etag');
+}
+
+function genIdempotencyKey(): string {
+  // crypto.randomUUID is available in all modern browsers and Node 19+.
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  // Fallback — should never hit in supported targets.
+  return `idem-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+// ── Transactions ────────────────────────────────────────────────
+
+export interface ListTransactionsFilters {
+  occurred_from?: string;
+  occurred_to?: string;
+  amount_min_minor?: number;
+  amount_max_minor?: number;
+  account_id?: string;
+  payee_contains?: string;
+  q?: string;
+  status?: BackendTransaction['status'];
+  trip_id?: string;
+  has_document?: boolean;
+  source_ingest_id?: string;
+  sort?: 'occurred_on' | 'amount' | 'created_at';
+  order?: 'asc' | 'desc';
+  cursor?: string;
+  limit?: number;
+}
+
+export interface ListTransactionsResult {
+  items: BackendTransaction[];
+  nextCursor: string | null;
+}
+
+export async function listTransactions(
+  filters: ListTransactionsFilters = {},
+): Promise<ListTransactionsResult> {
+  const { data, error, response } = await client.GET('/v1/transactions', {
+    params: { query: filters },
+  });
+  const body = unwrap('listTransactions', data, error, response.status);
+  return { items: body.items, nextCursor: body.next_cursor ?? null };
+}
+
+/** High-level helper used by Transactions/Dashboard screens: returns
+ *  the UI-row shape directly. */
 export async function fetchTransactions(opts?: {
   from?: string;
   to?: string;
-  category?: string;
   limit?: number;
+  has_document?: boolean;
 }): Promise<Transaction[]> {
-  const { data, error, response } = await client.GET('/receipts', {
-    params: { query: opts ?? {} },
+  const { items } = await listTransactions({
+    occurred_from: opts?.from,
+    occurred_to: opts?.to,
+    limit: opts?.limit,
+    has_document: opts?.has_document,
+    sort: 'occurred_on',
+    order: 'desc',
   });
-  return unwrap('fetchTransactions', data, error, response.status).map(mapReceipt);
+  return items.map(mapTransaction);
 }
 
-export async function fetchTransaction(id: string): Promise<Transaction> {
-  const { data, error, response } = await client.GET('/receipt/{id}', {
+export async function getTransaction(id: string): Promise<WithETag<BackendTransaction>> {
+  const { data, error, response } = await client.GET('/v1/transactions/{id}', {
     params: { path: { id } },
   });
-  return mapReceipt(unwrap('fetchTransaction', data, error, response.status));
+  return {
+    data: unwrap('getTransaction', data, error, response.status),
+    etag: etagFrom(response),
+  };
 }
 
-export async function fetchReceiptDetail(id: string): Promise<ReceiptDetail> {
-  const { data, error, response } = await client.GET('/receipt/{id}', {
-    params: { path: { id } },
+/** Convenience for UI consumers: fetch a transaction and map to the
+ *  ReceiptView shape. */
+export async function fetchReceiptDetail(id: string): Promise<ReceiptView> {
+  const { data, etag } = await getTransaction(id);
+  return toReceiptView(data, etag);
+}
+
+export async function createTransaction(input: {
+  payee?: string;
+  narration?: string;
+  occurred_on: string;
+  occurred_at?: string;
+  postings: NewPosting[];
+  document_ids?: string[];
+  trip_id?: string;
+  metadata?: Record<string, unknown>;
+  idempotencyKey?: string;
+}): Promise<BackendTransaction> {
+  const key = input.idempotencyKey ?? genIdempotencyKey();
+  const body: CreateTransactionRequest = {
+    occurred_on: input.occurred_on,
+    postings: input.postings,
+    // Always include metadata — OpenAPI marks it with a default, which
+    // openapi-typescript renders as required even though the server
+    // accepts empty.
+    metadata: input.metadata ?? {},
+  };
+  if (input.occurred_at) body.occurred_at = input.occurred_at;
+  if (input.payee != null) body.payee = input.payee;
+  if (input.narration != null) body.narration = input.narration;
+  if (input.document_ids) body.document_ids = input.document_ids;
+  if (input.trip_id) body.trip_id = input.trip_id;
+  const { data, error, response } = await client.POST('/v1/transactions', {
+    params: { header: { 'Idempotency-Key': key } },
+    body,
   });
-  return unwrap('fetchReceiptDetail', data, error, response.status);
+  return unwrap('createTransaction', data, error, response.status);
 }
 
-export async function deleteTransaction(id: string): Promise<void> {
-  const { error, response } = await client.DELETE('/receipt/{id}', {
-    params: { path: { id } },
+export async function patchTransaction(
+  id: string,
+  patch: UpdateTransactionRequest,
+  etag: string,
+): Promise<WithETag<BackendTransaction>> {
+  const { data, error, response } = await client.PATCH('/v1/transactions/{id}', {
+    params: {
+      path: { id },
+      header: { 'If-Match': etag },
+    },
+    body: patch,
+    // The endpoint expects application/merge-patch+json, not json.
+    bodySerializer: (b) => JSON.stringify(b),
+    headers: { 'Content-Type': 'application/merge-patch+json' },
   });
-  if (error) throw new Error(`Delete failed: ${response.status}`);
+  return {
+    data: unwrap('patchTransaction', data, error, response.status),
+    etag: etagFrom(response),
+  };
 }
 
-export async function uploadReceipt(file: File): Promise<UploadResult> {
-  const compressed = await compressImage(file);
-  // openapi-fetch handles multipart when body is FormData and bodySerializer is set.
+export async function voidTransaction(
+  id: string,
+  reason: string,
+  etag: string,
+): Promise<BackendTransaction> {
+  const { data, error, response } = await client.POST('/v1/transactions/{id}/void', {
+    params: {
+      path: { id },
+      header: { 'If-Match': etag },
+    },
+    body: { reason },
+  });
+  return unwrap('voidTransaction', data, error, response.status);
+}
+
+export async function deleteTransaction(id: string, etag: string): Promise<void> {
+  const { error, response } = await client.DELETE('/v1/transactions/{id}', {
+    params: {
+      path: { id },
+      header: { 'If-Match': etag },
+    },
+  });
+  if (error) throw new Error(`deleteTransaction failed (${response.status}): ${extractProblemMessage(error)}`);
+}
+
+// ── Documents ───────────────────────────────────────────────────
+
+export async function uploadDocument(
+  file: File,
+  kind: DocumentKind = 'receipt_image',
+): Promise<BackendDocument> {
+  const compressed = file.type.startsWith('image/') ? await compressImage(file) : file;
   const form = new FormData();
-  form.append('image', compressed);
-  const { data, error, response } = await client.POST('/receipt', {
-    body: form as unknown as { image: string },
+  form.append('file', compressed);
+  form.append('kind', kind);
+  const { data, error, response } = await client.POST('/v1/documents', {
+    body: form as unknown as { file: string; kind?: DocumentKind },
     bodySerializer: (b) => b as unknown as FormData,
   });
-  return unwrap('uploadReceipt', data, error, response.status);
+  return unwrap('uploadDocument', data, error, response.status);
 }
 
-export async function pollJob(jobId: string): Promise<JobStatus> {
-  const { data, error, response } = await client.GET('/jobs/{id}', {
-    params: { path: { id: jobId } },
+export async function getDocument(id: string): Promise<WithETag<BackendDocument>> {
+  const { data, error, response } = await client.GET('/v1/documents/{id}', {
+    params: { path: { id } },
   });
-  return unwrap('pollJob', data, error, response.status);
+  return {
+    data: unwrap('getDocument', data, error, response.status),
+    etag: etagFrom(response),
+  };
 }
 
-export async function fetchSummary(): Promise<SpendingSummary[]> {
-  const { data, error, response } = await client.GET('/summary', { params: { query: {} } });
-  return unwrap('fetchSummary', data, error, response.status);
+/** URL for `<img src="…">` / direct download. Goes through the Vite
+ *  proxy in dev; in prod the app assumes a reverse proxy fronts both
+ *  /api and the static bundle. */
+export function documentContentUrl(docId: string): string {
+  return `/api/v1/documents/${docId}/content`;
 }
+
+export async function linkDocument(docId: string, transactionId: string): Promise<void> {
+  const { error, response } = await client.POST('/v1/documents/{id}/links', {
+    params: { path: { id: docId } },
+    body: { transaction_id: transactionId },
+  });
+  if (error) throw new Error(`linkDocument failed (${response.status}): ${extractProblemMessage(error)}`);
+}
+
+export async function unlinkDocument(docId: string, transactionId: string): Promise<void> {
+  const { error, response } = await client.DELETE('/v1/documents/{id}/links/{txn_id}', {
+    params: { path: { id: docId, txn_id: transactionId } },
+  });
+  if (error) throw new Error(`unlinkDocument failed (${response.status}): ${extractProblemMessage(error)}`);
+}
+
+// ── Ingest batches ─────────────────────────────────────────────
+
+export interface IngestBatchResult {
+  batchId: string;
+  status: BatchStatus;
+  items: Array<{ ingestId: string; filename: string; mime_type: string | null }>;
+  poll: string;
+}
+
+/** Upload N files as a single ingest batch. Server handles
+ *  classification + extraction; poll the returned batchId (or subscribe
+ *  via SSE) for progress. */
+export async function ingestBatch(
+  files: File[],
+  opts: { autoReconcile?: boolean } = {},
+): Promise<IngestBatchResult> {
+  const form = new FormData();
+  for (const f of files) {
+    // Compress images but leave PDFs / emails untouched.
+    const payload = f.type.startsWith('image/') ? await compressImage(f) : f;
+    form.append('files', payload, f.name);
+  }
+  if (opts.autoReconcile != null) {
+    form.append('auto_reconcile', opts.autoReconcile ? 'true' : 'false');
+  }
+  const { data, error, response } = await client.POST('/v1/ingest/batch', {
+    body: form as unknown as { files: string[] },
+    bodySerializer: (b) => b as unknown as FormData,
+  });
+  const body = unwrap('ingestBatch', data, error, response.status);
+  return {
+    batchId: body.batchId,
+    status: body.status,
+    items: body.items,
+    poll: body.poll,
+  };
+}
+
+export async function getBatch(batchId: string): Promise<BackendBatch> {
+  const { data, error, response } = await client.GET('/v1/batches/{id}', {
+    params: { path: { id: batchId } },
+  });
+  return unwrap('getBatch', data, error, response.status);
+}
+
+export async function listBatches(opts: {
+  cursor?: string;
+  limit?: number;
+  status?: BatchStatus;
+} = {}): Promise<{ items: BackendBatchSummary[]; nextCursor: string | null }> {
+  const { data, error, response } = await client.GET('/v1/batches', {
+    params: { query: opts },
+  });
+  const body = unwrap('listBatches', data, error, response.status);
+  return { items: body.items, nextCursor: body.next_cursor ?? null };
+}
+
+export async function getIngest(id: string): Promise<BackendIngest> {
+  const { data, error, response } = await client.GET('/v1/ingests/{id}', {
+    params: { path: { id } },
+  });
+  return unwrap('getIngest', data, error, response.status);
+}
+
+/** Server-Sent Events subscription to a batch stream.
+ *
+ *  Emits `hello`, `job.started|done|error`, `batch.extracted`, and
+ *  `reconcile.*` events. Caller should handle `'error'` (the native
+ *  EventSource error name) for reconnect/UX. Closes automatically when
+ *  the server sends its terminal frame.
+ *
+ *  Returns an AbortController — call `.abort()` to close the stream. */
+export function subscribeToBatch(
+  batchId: string,
+  onEvent: (eventName: string, payload: unknown) => void,
+  onError?: (err: Event) => void,
+): AbortController {
+  const controller = new AbortController();
+  const url = `/api/v1/batches/${batchId}/stream`;
+  const es = new EventSource(url);
+
+  const named = [
+    'hello',
+    'job.started',
+    'job.done',
+    'job.error',
+    'batch.extracted',
+    'reconcile.started',
+    'reconcile.done',
+    'reconcile.error',
+  ];
+  for (const name of named) {
+    es.addEventListener(name, (e) => {
+      const me = e as MessageEvent;
+      let payload: unknown = me.data;
+      try {
+        payload = JSON.parse(me.data);
+      } catch {
+        /* keep as string */
+      }
+      onEvent(name, payload);
+    });
+  }
+  es.onmessage = (me) => {
+    // Frames without an explicit `event:` line land here.
+    let payload: unknown = me.data;
+    try {
+      payload = JSON.parse(me.data);
+    } catch {
+      /* keep as string */
+    }
+    onEvent('message', payload);
+  };
+  es.onerror = (e) => {
+    onError?.(e);
+  };
+
+  controller.signal.addEventListener('abort', () => {
+    es.close();
+  });
+  return controller;
+}
+
+// ── Reports ─────────────────────────────────────────────────────
+
+export async function getSummaryReport(opts: {
+  from?: string;
+  to?: string;
+  groupBy?: 'category' | 'account' | 'payee';
+  currency?: string;
+} = {}): Promise<BackendSummaryReport> {
+  const { data, error, response } = await client.GET('/v1/reports/summary', {
+    params: {
+      query: {
+        from: opts.from,
+        to: opts.to,
+        group_by: opts.groupBy,
+        currency: opts.currency,
+      },
+    },
+  });
+  return unwrap('getSummaryReport', data, error, response.status);
+}
+
+export async function getTrendsReport(opts: {
+  from?: string;
+  to?: string;
+  period?: 'month' | 'year';
+  groupBy?: 'category' | 'total';
+  currency?: string;
+} = {}): Promise<BackendTrendsReport> {
+  const { data, error, response } = await client.GET('/v1/reports/trends', {
+    params: {
+      query: {
+        from: opts.from,
+        to: opts.to,
+        period: opts.period,
+        group_by: opts.groupBy,
+        currency: opts.currency,
+      },
+    },
+  });
+  return unwrap('getTrendsReport', data, error, response.status);
+}
+
+export async function getNetWorthReport(opts: {
+  asOf?: string;
+  currency?: string;
+} = {}): Promise<BackendNetWorthReport> {
+  const { data, error, response } = await client.GET('/v1/reports/net_worth', {
+    params: { query: { as_of: opts.asOf, currency: opts.currency } },
+  });
+  return unwrap('getNetWorthReport', data, error, response.status);
+}
+
+export async function getCashflowReport(opts: {
+  from?: string;
+  to?: string;
+  currency?: string;
+} = {}): Promise<BackendCashflowReport> {
+  const { data, error, response } = await client.GET('/v1/reports/cashflow', {
+    params: {
+      query: { from: opts.from, to: opts.to, currency: opts.currency },
+    },
+  });
+  return unwrap('getCashflowReport', data, error, response.status);
+}
+
+// ── Accounts ────────────────────────────────────────────────────
+
+export async function listAccounts(opts: {
+  flat?: boolean;
+  includeClosed?: boolean;
+} = {}): Promise<BackendAccount[]> {
+  const { data, error, response } = await client.GET('/v1/accounts', {
+    params: {
+      query: {
+        flat: opts.flat,
+        include_closed: opts.includeClosed,
+      },
+    },
+  });
+  return unwrap('listAccounts', data, error, response.status);
+}
+
+export async function getAccountBalance(
+  id: string,
+  opts: { asOf?: string; currency?: string; includeChildren?: boolean } = {},
+): Promise<BackendAccountBalance> {
+  const { data, error, response } = await client.GET('/v1/accounts/{id}/balance', {
+    params: {
+      path: { id },
+      query: {
+        as_of: opts.asOf,
+        currency: opts.currency,
+        include_children: opts.includeChildren,
+      },
+    },
+  });
+  return unwrap('getAccountBalance', data, error, response.status);
+}
+
+export async function getAccountRegister(
+  id: string,
+  opts: {
+    from?: string;
+    to?: string;
+    includeVoided?: boolean;
+    cursor?: string;
+    limit?: number;
+  } = {},
+): Promise<BackendAccountRegister> {
+  const { data, error, response } = await client.GET('/v1/accounts/{id}/register', {
+    params: {
+      path: { id },
+      query: {
+        from: opts.from,
+        to: opts.to,
+        include_voided: opts.includeVoided,
+        cursor: opts.cursor,
+        limit: opts.limit,
+      },
+    },
+  });
+  return unwrap('getAccountRegister', data, error, response.status);
+}
+
+// ── Summary shim for the existing Dashboard ────────────────────
+//
+// Old `/summary` returned an array of `{ category, count, total_spent }`.
+// The new `/v1/reports/summary?group_by=category` returns
+// `{ items: [{ key, count, total_minor, ... }], grand_total_minor }`.
+// Shape the old consumer expects `Number(s.total_spent)` / `s.category` /
+// `s.count`, so we remap.
+
+export interface LegacySummaryItem {
+  category: string;
+  count: number;
+  total_spent: number;
+}
+
+export async function fetchSummary(opts: {
+  from?: string;
+  to?: string;
+} = {}): Promise<LegacySummaryItem[]> {
+  const rep = await getSummaryReport({
+    from: opts.from,
+    to: opts.to,
+    groupBy: 'category',
+  });
+  return rep.items.map((it) => ({
+    category: it.key || 'other',
+    count: it.count,
+    total_spent: it.total_minor / 100,
+  }));
+}
+export type SpendingSummary = LegacySummaryItem;


### PR DESCRIPTION
## Summary

The backend removed `/receipts*` and `/jobs/*` in favor of a `/v1/*` namespaced surface (32 paths, 59 schemas). This PR regenerates the codegen'd types and rewires the React app so existing screens keep working on the new API. No new UI — hooks for the not-yet-wired surface area (accounts, postings, reports, batches with SSE) are exposed for follow-up PRs.

## What disappeared

| Old                              | New                                                                  |
|----------------------------------|----------------------------------------------------------------------|
| `GET /receipts`                  | `GET /v1/transactions?has_document=true`                             |
| `GET /receipt/:id`               | `GET /v1/transactions/:id` + `GET /v1/documents/:id/content`         |
| `POST /receipt` (multipart)      | `POST /v1/ingest/batch` (multipart, N files, returns `batchId`)      |
| `GET /jobs/:id`                  | `GET /v1/batches/:id` (or SSE `/v1/batches/:id/stream`)              |
| `GET /summary`                   | `GET /v1/reports/summary?group_by=category`                          |
| `DELETE /receipt/:id`            | `DELETE /v1/transactions/:id` (needs `If-Match`)                     |

## What's new in `src/lib/api.ts`

- `createTransaction(...)` — auto-generates `Idempotency-Key` via `crypto.randomUUID()`
- `uploadDocument(file, kind?)` — multipart, SHA-256 dedup handled server-side
- `linkDocument(docId, txId)` / `unlinkDocument(...)`
- `listTransactions(filters) → { items, nextCursor }` — keyset cursor exposed
- `getTransaction(id)` / `patchTransaction(id, patch, etag)` — `If-Match` plumbed through, PATCH uses `application/merge-patch+json`
- `voidTransaction(id, reason, etag)`
- `ingestBatch(files, { autoReconcile? })` → `{ batchId, items }`
- `getBatch(batchId)`, `listBatches(...)`, `getIngest(...)`
- `subscribeToBatch(batchId, onEvent)` — native `EventSource`, returns `AbortController`
- `getSummaryReport`, `getTrendsReport`, `getNetWorthReport`, `getCashflowReport`
- `listAccounts`, `getAccountBalance`, `getAccountRegister`
- `extractProblemMessage(err)` — RFC 7807 helper
- `WithETag<T>` wrapper — fetched resources carry their ETag for subsequent PATCH calls

## What was kept for diff-minimization

- `fetchSummary()` / `SpendingSummary` / `fetchTransactions()` — now thin shims over the v1 endpoints. Dashboard and Transactions screens required no deep changes.
- `mapTransaction()` replaces `mapReceipt()` but produces the same UI `Transaction` shape.
- `ReceiptDetail` now consumes a new `ReceiptView` (payee, occurred_on, primary document id, postings-sum total). Legacy extractor fields (tax, tip, items, latitude, longitude, raw_text, quality) are read out of `transaction.metadata` / `documents[0].extraction_meta` — matches where the extractor currently writes them.
- Upload flow: `AddTransactionModal` posts to `/v1/ingest/batch` with one file; `ProcessingToast` polls `/v1/batches/:id` instead of `/jobs/:id`. Polling (not SSE) picked to minimize diff with the React 19 hook shape; SSE helper is in place for a follow-up.
- localStorage key bumped to `receipt-processing-batches-v1`; the old key (`receipt-processing-jobs`) is cleared on first load.

## Lint / build

- `npm run lint` → clean. Fixed the two pre-existing errors on `main` (`react-hooks/set-state-in-effect` via `useMemo`-derived toasts; `react-refresh/only-export-components` by moving `useProcessingJobs` into its own file).
- `npm run build` → passes (`tsc && vite build`).

## Smoke test

Dev server up, Vite proxy → backend at `localhost:3000`, real curls:

- `GET /api/v1/transactions?has_document=true&limit=3` → 3 receipts (In-N-Out, Costco, Trader Joe's) with 1 document each. Frontend `listTransactions` / `fetchTransactions` parse them cleanly.
- `GET /api/v1/documents/:id/content` → 200 for real doc ids (and a clean RFC 7807 404 for unknown ids).

## Known followups

- `/v1/reports/summary` currently 404s on the backend (endpoint listed in the OpenAPI spec but not yet implemented). Dashboard summary card will be empty until that lands; `fetchSummary()` surfaces the RFC 7807 error via `extractProblemMessage`. Tracked backend-side.
- SSE batch stream hook is exposed (`subscribeToBatch`) but not wired into `ProcessingToast`; polling works fine for single-file uploads. Switch when batch UI lands.
- Accounts tree, posting-level editing, reports dashboard, batch visualization — all intentionally **out of scope**. Hooks exist; UI is a follow-up PR.

## Test plan

- [ ] `npm run lint` (CI)
- [ ] `npm run build` (CI)
- [ ] Manual: start backend + frontend, upload a receipt via the modal, confirm the toast progresses and the transaction appears on the Transactions tab with a linked image on ReceiptDetail.
- [ ] Manual: click an existing transaction → ReceiptDetail renders image, line-items (if extractor wrote them into metadata), and map (if `latitude`/`longitude` + `VITE_GOOGLE_MAPS_API_KEY` present).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>