### PR TITLE
Dockerize frontend (independent stack, nginx + /api proxy)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,25 @@
+# Keep the build context small and prevent stale host artifacts from
+# leaking into the image. Anything the Dockerfile doesn't COPY can be
+# excluded here — and critically, `dist/` must stay out so that we can
+# never accidentally ship a host-built bundle (see project CLAUDE.md).
+
+node_modules
+dist
+.git
+.gitignore
+.env
+.env.*
+!.env.example
+
+# Editor / OS noise
+.vscode
+.idea
+.DS_Store
+*.swp
+
+# Docs — not needed inside the image.
+*.md
+
+# Local data
+coverage
+.nyc_output

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,52 @@
+# syntax=docker/dockerfile:1.6
+#
+# Multi-stage build for receipt-assistant-frontend.
+#
+#   builder  — installs full deps, runs `vite build` → /app/dist/
+#   runtime  — nginx:alpine serving /usr/share/nginx/html with a
+#              /api/* → $BACKEND_URL proxy. SPA fallback to index.html.
+#
+# Build artifacts are produced INSIDE the image (no `COPY dist/` from
+# host). See project CLAUDE.md — a stale host `dist/` once shipped
+# pre-PR code to production.
+
+# ---- Stage 1: builder ----
+FROM node:22-bookworm AS builder
+
+WORKDIR /app
+
+# Install deps first (cached layer as long as package*.json is unchanged)
+COPY package.json package-lock.json ./
+RUN npm ci
+
+# Copy everything the build needs. Keep this list explicit so that the
+# build context stays predictable (see .dockerignore for the blocklist).
+COPY tsconfig.json vite.config.ts eslint.config.js index.html ./
+COPY src/ ./src/
+
+RUN npm run build
+
+# ---- Stage 2: runtime ----
+FROM nginx:1.27-alpine AS runtime
+
+# `wget` is already in the base image (busybox applet); used by HEALTHCHECK.
+# `envsubst` ships via `gettext` so we can template $BACKEND_URL at start.
+RUN apk add --no-cache gettext
+
+# Static bundle from the builder stage.
+COPY --from=builder /app/dist/ /usr/share/nginx/html/
+
+# nginx template — $BACKEND_URL is substituted at container start by the
+# default nginx entrypoint (/docker-entrypoint.d/20-envsubst-on-templates.sh).
+COPY nginx.conf /etc/nginx/templates/default.conf.template
+
+ENV BACKEND_URL=http://host.docker.internal:3000
+# Only expand our var — otherwise nginx directives like $uri / $scheme
+# would be stripped.
+ENV NGINX_ENVSUBST_TEMPLATE_SUFFIX=.template
+ENV NGINX_ENVSUBST_FILTER=BACKEND_URL
+
+EXPOSE 80
+
+HEALTHCHECK --interval=15s --timeout=5s --start-period=5s --retries=3 \
+  CMD wget -qO- http://127.0.0.1/ | grep -qi '<!DOCTYPE' || exit 1

--- a/README.md
+++ b/README.md
@@ -44,6 +44,24 @@ npm run dev
 
 The Vite dev server proxies `/api/*` to `localhost:3000` automatically. No env vars needed for local dev.
 
+## Running with Docker
+
+An independent nginx-based stack is provided for self-hosting. It does **not** share a network with the backend — the two stacks communicate at the HTTP level, via the browser.
+
+```bash
+docker compose up -d --build
+# frontend → http://localhost:8080
+# expects backend at http://localhost:3000 (see receipt-assistant)
+```
+
+The container proxies `/api/*` to the backend URL configured via `BACKEND_URL` (default `http://host.docker.internal:3000`, which resolves to the host on Docker Desktop and — thanks to the `extra_hosts: host-gateway` line — on Linux too). To point at a remote backend instead:
+
+```bash
+BACKEND_URL=https://receipts.example.com docker compose up -d --build
+```
+
+`npm run dev` / `npm run build` continue to work unchanged for host development — the container is purely for production-style serving.
+
 ## Project Structure
 
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,31 @@
+# receipt-assistant-frontend — standalone Docker stack.
+#
+#   docker compose up -d --build
+#
+# Independent of the backend stack: no shared network, no shared
+# volumes. Connection is HTTP-only, made at runtime by the browser
+# through the nginx /api proxy defined in nginx.conf.
+#
+# BACKEND_URL is the address the CONTAINER (not the browser) uses to
+# reach the backend. Default targets a backend running on the host via
+# Docker Desktop's `host.docker.internal`. Override for remote backends:
+#
+#   BACKEND_URL=https://receipts.example.com docker compose up -d --build
+
+services:
+  frontend:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: receipt-assistant-frontend:local
+    container_name: receipt-assistant-frontend
+    ports:
+      - "8080:80"
+    environment:
+      BACKEND_URL: ${BACKEND_URL:-http://host.docker.internal:3000}
+    # Linux doesn't know `host.docker.internal` by default; this line is
+    # a no-op on Docker Desktop (Mac/Win) and resolves it to the host
+    # gateway on Linux.
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    restart: unless-stopped

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,56 @@
+# receipt-assistant-frontend — nginx SPA + /api proxy.
+#
+# Rendered from /etc/nginx/templates/default.conf.template by the
+# official nginx entrypoint (envsubst), which expands ${BACKEND_URL}
+# at container start. Every other `$...` is a real nginx variable and
+# must survive templating — see NGINX_ENVSUBST_FILTER=BACKEND_URL in
+# the Dockerfile.
+
+server {
+    listen      80;
+    server_name _;
+
+    # Reasonable upload ceiling for receipt images (the multipart
+    # /v1/ingest/batch endpoint accepts several files at once).
+    client_max_body_size 25m;
+
+    # ── /api/* → backend ─────────────────────────────────────────────
+    # The Vite dev proxy strips the /api prefix; we mirror that here so
+    # the frontend code can stay identical between `npm run dev` and the
+    # container build.
+    location /api/ {
+        proxy_pass ${BACKEND_URL}/;
+
+        proxy_http_version 1.1;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # SSE: /v1/batches/:id/stream is long-lived. Buffering would
+        # collapse events into chunks and break the live progress UI.
+        proxy_buffering     off;
+        proxy_cache         off;
+        proxy_read_timeout  24h;
+        proxy_send_timeout  24h;
+
+        # Let the browser receive chunked responses as they arrive.
+        chunked_transfer_encoding on;
+    }
+
+    # ── SPA fallback ─────────────────────────────────────────────────
+    root  /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Long-cache the immutable hashed asset bundles Vite emits.
+    location /assets/ {
+        access_log off;
+        expires    30d;
+        add_header Cache-Control "public, max-age=2592000, immutable";
+        try_files  $uri =404;
+    }
+}


### PR DESCRIPTION
## Summary

Adds a standalone Docker stack for the frontend so it can be self-hosted without coupling to the backend's compose file. The two stacks remain **truly independent** — no shared network, no shared volumes, no compose include. They talk only at the HTTP level, through the browser, via an nginx `/api` proxy inside the frontend container.

- **Dockerfile** — multi-stage: `node:22-bookworm` builder → `nginx:1.27-alpine` runtime. Bundle built inside the image; **no `COPY dist/` from host** (stale-artifact time bomb rule).
- **nginx.conf** — SPA fallback (`try_files $uri $uri/ /index.html`) + `/api/` proxy with `proxy_buffering off`, `proxy_read_timeout 24h` (SSE-safe for `/v1/batches/:id/stream`), forwarded headers incl. `X-Forwarded-Proto`. Templated so `$BACKEND_URL` is resolved at container start via `envsubst` (no rebuild needed to repoint).
- **docker-compose.yml** — single `frontend` service publishing `8080:80`. Default `BACKEND_URL=http://host.docker.internal:3000`. Linux users get an `extra_hosts: host-gateway` line so the same name works there.
- **.dockerignore** — blocks `node_modules/`, `dist/`, `.git/`, `.env*` (keeps `!.env.example`).
- **README** — short "Running with Docker" section pointing at the new stack.

No `src/` changes. Host-side `npm run dev` / `npm run build` continue to work unchanged.

## Running

```bash
docker compose up -d --build                     # → http://localhost:8080
BACKEND_URL=https://receipts.example.com \
  docker compose up -d --build                   # point at a remote backend
```

The browser hits `http://localhost:8080/api/*` and nginx (inside the container) rewrites `/api/` → `/` and proxies to `$BACKEND_URL`. Mirrors what the Vite dev proxy does for `npm run dev`.

## Dependency / caveat

The default `BACKEND_URL` relies on `host.docker.internal`, which Docker Desktop (Mac/Win) resolves automatically. For Linux hosts the `extra_hosts: host-gateway` entry in `docker-compose.yml` makes that same name resolve to the host gateway.

## Test plan

- [x] `docker compose up -d --build` boots; container reaches `(healthy)`.
- [x] `curl -s http://localhost:8080/` returns `<!doctype html>` from Vite's build (incl. hashed asset references).
- [x] `curl -s http://localhost:8080/api/health` → `{"status":"ok",...}` (proxied to backend on host :3000).
- [x] SPA fallback: `curl -s http://localhost:8080/any/route` returns `index.html`.
- [x] nginx config inside the container has `proxy_buffering off`, `proxy_read_timeout 24h`, `X-Forwarded-Proto $scheme` (verified by exec).
- [x] `npm run build` and `npm run dev` still work standalone on host.

## Related

The `setup` skill in the personal docs repo (`~/Documents/10_Projects/2026_Dev_ReceiptAssistant/.claude/skills/setup/`) is updated in a sibling commit to point operators at this stack under a new "Frontend (optional)" section.