### PR TITLE
Wire edit/void/delete UI in ReceiptDetail

### DIFF
--- a/src/components/ConfirmActionDialog.tsx
+++ b/src/components/ConfirmActionDialog.tsx
@@ -1,0 +1,153 @@
+import React from 'react';
+import { X, Loader2, AlertCircle, AlertTriangle } from 'lucide-react';
+import { motion, AnimatePresence } from 'motion/react';
+import { cn } from '../lib/utils';
+
+interface ConfirmActionDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  title: string;
+  message: React.ReactNode;
+  confirmLabel: string;
+  /** Red button styling for irreversible actions. */
+  destructive?: boolean;
+  /** If true, show a textarea for the user to enter a reason.
+   *  The reason is passed to onConfirm. */
+  requireReason?: boolean;
+  reasonPlaceholder?: string;
+  /** Return a promise; dialog manages loading/error states. */
+  onConfirm: (reason: string) => Promise<void>;
+}
+
+type DialogState = 'idle' | 'working' | 'error';
+
+export default function ConfirmActionDialog({
+  isOpen,
+  onClose,
+  title,
+  message,
+  confirmLabel,
+  destructive = false,
+  requireReason = false,
+  reasonPlaceholder = 'Reason (optional)',
+  onConfirm,
+}: ConfirmActionDialogProps) {
+  const [reason, setReason] = React.useState('');
+  const [state, setState] = React.useState<DialogState>('idle');
+  const [error, setError] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    if (isOpen) {
+      setReason('');
+      setState('idle');
+      setError(null);
+    }
+  }, [isOpen]);
+
+  const handleConfirm = async () => {
+    setState('working');
+    setError(null);
+    try {
+      await onConfirm(reason);
+      // Parent closes on success.
+    } catch (err: unknown) {
+      setState('error');
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  };
+
+  return (
+    <AnimatePresence>
+      {isOpen && (
+        <div className="fixed inset-0 z-[110] flex items-center justify-center p-4">
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            onClick={state === 'working' ? undefined : onClose}
+            className="absolute inset-0 bg-background/40 backdrop-blur-sm"
+          />
+
+          <motion.div
+            initial={{ opacity: 0, scale: 0.9, y: 20 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            exit={{ opacity: 0, scale: 0.9, y: 20 }}
+            className="glass-panel w-full max-w-md rounded-[2rem] overflow-hidden flex flex-col relative border border-outline-variant/20 shadow-2xl"
+          >
+            <div className="px-8 pt-8 pb-4 flex justify-between items-start gap-4">
+              <div className="flex items-start gap-3">
+                {destructive && (
+                  <AlertTriangle className="text-error flex-shrink-0 mt-1" size={24} />
+                )}
+                <h2 className="text-xl font-bold tracking-tight text-white font-headline">
+                  {title}
+                </h2>
+              </div>
+              <button
+                onClick={onClose}
+                disabled={state === 'working'}
+                className="w-10 h-10 rounded-full bg-white/5 flex items-center justify-center text-on-surface-variant hover:text-white transition-colors disabled:opacity-40"
+              >
+                <X size={20} />
+              </button>
+            </div>
+
+            <div className="px-8 pb-8 space-y-5">
+              <div className="text-sm text-on-surface-variant">{message}</div>
+
+              {requireReason && (
+                <textarea
+                  value={reason}
+                  onChange={(e) => setReason(e.target.value)}
+                  rows={3}
+                  placeholder={reasonPlaceholder}
+                  className="w-full px-4 py-3 rounded-xl bg-surface-container-lowest text-white placeholder:text-on-surface-variant/40 border border-outline-variant/10 focus:border-primary/40 focus:outline-none transition-colors resize-none"
+                />
+              )}
+
+              {state === 'error' && (
+                <div className="flex items-start gap-3 p-4 rounded-xl bg-surface-container-lowest">
+                  <AlertCircle className="text-error flex-shrink-0 mt-0.5" size={20} />
+                  <div className="flex-1">
+                    <p className="text-sm font-bold text-white">Couldn't complete</p>
+                    <p className="text-xs text-error mt-1">{error}</p>
+                  </div>
+                </div>
+              )}
+
+              <div className="flex gap-3 pt-2">
+                <button
+                  onClick={onClose}
+                  disabled={state === 'working'}
+                  className="flex-1 py-3 rounded-xl bg-surface-container-high text-on-surface-variant font-bold hover:text-white transition-colors disabled:opacity-40"
+                >
+                  Cancel
+                </button>
+                <button
+                  onClick={handleConfirm}
+                  disabled={state === 'working'}
+                  className={cn(
+                    'flex-1 py-3 rounded-xl font-bold transition-all flex items-center justify-center gap-2',
+                    destructive
+                      ? 'bg-error text-on-error hover:scale-[1.02] active:scale-95'
+                      : 'bg-primary text-on-primary hover:scale-[1.02] active:scale-95',
+                    state === 'working' && 'opacity-60 cursor-wait',
+                  )}
+                >
+                  {state === 'working' ? (
+                    <>
+                      <Loader2 className="animate-spin" size={18} />
+                      Working...
+                    </>
+                  ) : (
+                    confirmLabel
+                  )}
+                </button>
+              </div>
+            </div>
+          </motion.div>
+        </div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/src/components/EditReceiptModal.tsx
+++ b/src/components/EditReceiptModal.tsx
@@ -1,0 +1,214 @@
+import React from 'react';
+import { X, Save, Loader2, AlertCircle, RefreshCw } from 'lucide-react';
+import { motion, AnimatePresence } from 'motion/react';
+import {
+  patchTransaction,
+  extractProblemMessage,
+  type ReceiptView,
+  type BackendTransaction,
+  type UpdateTransactionRequest,
+} from '../lib/api';
+import { cn } from '../lib/utils';
+
+interface EditReceiptModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  receipt: ReceiptView;
+  /** Called after a successful PATCH. Parent should replace local state
+   *  (the new ETag is passed alongside the updated transaction). */
+  onUpdated: (txn: BackendTransaction, etag: string | null) => void;
+  /** Called if the server rejects with 412 version mismatch — parent
+   *  should refetch the receipt to capture the latest ETag. */
+  onStale: () => void;
+}
+
+type SaveState = 'idle' | 'saving' | 'error' | 'stale';
+
+export default function EditReceiptModal({
+  isOpen,
+  onClose,
+  receipt,
+  onUpdated,
+  onStale,
+}: EditReceiptModalProps) {
+  const [payee, setPayee] = React.useState(receipt.payee ?? '');
+  const [narration, setNarration] = React.useState(receipt.narration ?? '');
+  const [occurredOn, setOccurredOn] = React.useState(receipt.occurred_on);
+  const [state, setState] = React.useState<SaveState>('idle');
+  const [error, setError] = React.useState<string | null>(null);
+
+  // Reset form when the modal reopens for a different receipt.
+  React.useEffect(() => {
+    if (isOpen) {
+      setPayee(receipt.payee ?? '');
+      setNarration(receipt.narration ?? '');
+      setOccurredOn(receipt.occurred_on);
+      setState('idle');
+      setError(null);
+    }
+  }, [isOpen, receipt.id, receipt.payee, receipt.narration, receipt.occurred_on]);
+
+  const handleSave = async () => {
+    if (!receipt.etag) {
+      setState('error');
+      setError('No ETag available — reload the receipt and try again.');
+      return;
+    }
+    setState('saving');
+    setError(null);
+
+    // Only send fields that actually changed; PATCH is merge-patch.
+    const patch: UpdateTransactionRequest = { metadata: {} };
+    if (payee !== (receipt.payee ?? '')) patch.payee = payee || null;
+    if (narration !== (receipt.narration ?? '')) patch.narration = narration || null;
+    if (occurredOn !== receipt.occurred_on) patch.occurred_on = occurredOn;
+
+    // Nothing to send — bail out as a no-op.
+    if (!('payee' in patch) && !('narration' in patch) && !('occurred_on' in patch)) {
+      onClose();
+      return;
+    }
+
+    try {
+      const { data, etag } = await patchTransaction(receipt.id, patch, receipt.etag);
+      onUpdated(data, etag);
+      onClose();
+    } catch (err: unknown) {
+      const problem = (err as Error & { problem?: { status?: number } })?.problem;
+      const status = problem?.status ?? 0;
+      // 412 → ETag stale; 409 → some other conflict. Both mean "reload".
+      if (status === 412 || status === 409 || /412|409/.test(extractProblemMessage(err))) {
+        setState('stale');
+        setError(
+          'This receipt was modified elsewhere. Reload to see the latest version, then try again.',
+        );
+      } else {
+        setState('error');
+        setError(extractProblemMessage(err));
+      }
+    }
+  };
+
+  return (
+    <AnimatePresence>
+      {isOpen && (
+        <div className="fixed inset-0 z-[100] flex items-center justify-center p-4">
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            onClick={onClose}
+            className="absolute inset-0 bg-background/40 backdrop-blur-sm"
+          />
+
+          <motion.div
+            initial={{ opacity: 0, scale: 0.9, y: 20 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            exit={{ opacity: 0, scale: 0.9, y: 20 }}
+            className="glass-panel w-full max-w-lg rounded-[2rem] overflow-hidden flex flex-col relative border border-primary/20 shadow-2xl"
+          >
+            <div className="px-8 pt-8 pb-4 flex justify-between items-center">
+              <h2 className="text-xl font-bold tracking-tight text-white font-headline">Edit Receipt</h2>
+              <button
+                onClick={onClose}
+                className="w-10 h-10 rounded-full bg-white/5 flex items-center justify-center text-on-surface-variant hover:text-white transition-colors"
+              >
+                <X size={20} />
+              </button>
+            </div>
+
+            <div className="px-8 pb-8 space-y-5">
+              <div>
+                <label className="block text-xs font-bold text-on-surface-variant uppercase tracking-widest mb-2">
+                  Payee
+                </label>
+                <input
+                  type="text"
+                  value={payee}
+                  onChange={(e) => setPayee(e.target.value)}
+                  placeholder="e.g. Costco"
+                  className="w-full px-4 py-3 rounded-xl bg-surface-container-lowest text-white placeholder:text-on-surface-variant/40 border border-outline-variant/10 focus:border-primary/40 focus:outline-none transition-colors"
+                />
+              </div>
+
+              <div>
+                <label className="block text-xs font-bold text-on-surface-variant uppercase tracking-widest mb-2">
+                  Date
+                </label>
+                <input
+                  type="date"
+                  value={occurredOn}
+                  onChange={(e) => setOccurredOn(e.target.value)}
+                  className="w-full px-4 py-3 rounded-xl bg-surface-container-lowest text-white border border-outline-variant/10 focus:border-primary/40 focus:outline-none transition-colors"
+                />
+              </div>
+
+              <div>
+                <label className="block text-xs font-bold text-on-surface-variant uppercase tracking-widest mb-2">
+                  Notes
+                </label>
+                <textarea
+                  value={narration}
+                  onChange={(e) => setNarration(e.target.value)}
+                  rows={3}
+                  placeholder="Optional note"
+                  className="w-full px-4 py-3 rounded-xl bg-surface-container-lowest text-white placeholder:text-on-surface-variant/40 border border-outline-variant/10 focus:border-primary/40 focus:outline-none transition-colors resize-none"
+                />
+              </div>
+
+              {(state === 'error' || state === 'stale') && (
+                <div className="flex items-start gap-3 p-4 rounded-xl bg-surface-container-lowest">
+                  <AlertCircle className="text-error flex-shrink-0 mt-0.5" size={20} />
+                  <div className="flex-1">
+                    <p className="text-sm font-bold text-white">
+                      {state === 'stale' ? 'Out of date' : 'Error'}
+                    </p>
+                    <p className="text-xs text-error mt-1">{error}</p>
+                  </div>
+                </div>
+              )}
+
+              <div className="pt-2 flex gap-3">
+                {state === 'stale' ? (
+                  <button
+                    onClick={() => {
+                      onStale();
+                      onClose();
+                    }}
+                    className="w-full py-4 rounded-xl bg-primary text-on-primary font-bold text-lg hover:scale-[1.02] active:scale-95 transition-all flex items-center justify-center gap-2"
+                  >
+                    <RefreshCw size={20} />
+                    Reload receipt
+                  </button>
+                ) : (
+                  <button
+                    onClick={handleSave}
+                    disabled={state === 'saving'}
+                    className={cn(
+                      'w-full py-4 rounded-xl font-bold text-lg transition-all flex items-center justify-center gap-2',
+                      state === 'saving'
+                        ? 'bg-primary/50 text-on-primary cursor-wait'
+                        : 'bg-primary text-on-primary hover:scale-[1.02] active:scale-95 shadow-lg shadow-primary/20',
+                    )}
+                  >
+                    {state === 'saving' ? (
+                      <>
+                        <Loader2 className="animate-spin" size={20} />
+                        Saving...
+                      </>
+                    ) : (
+                      <>
+                        <Save size={20} />
+                        Save changes
+                      </>
+                    )}
+                  </button>
+                )}
+              </div>
+            </div>
+          </motion.div>
+        </div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/src/components/ReceiptDetail.tsx
+++ b/src/components/ReceiptDetail.tsx
@@ -1,13 +1,19 @@
 import React, { useEffect, useState } from 'react';
-import { ArrowLeft, Loader2, Receipt, CreditCard, Calendar, Tag, FileText, ChevronDown, ChevronUp, MapPin } from 'lucide-react';
+import { ArrowLeft, Loader2, Receipt, CreditCard, Calendar, Tag, FileText, ChevronDown, ChevronUp, MapPin, Pencil, Ban, Trash2 } from 'lucide-react';
 import { APIProvider, Map, Marker } from '@vis.gl/react-google-maps';
 import {
   fetchReceiptDetail,
   documentContentUrl,
   extractProblemMessage,
+  toReceiptView,
+  voidTransaction,
+  deleteTransaction,
   type ReceiptView,
+  type BackendTransaction,
 } from '../lib/api';
 import { cn } from '../lib/utils';
+import EditReceiptModal from './EditReceiptModal';
+import ConfirmActionDialog from './ConfirmActionDialog';
 
 const GOOGLE_MAPS_API_KEY = import.meta.env.VITE_GOOGLE_MAPS_API_KEY as string | undefined;
 
@@ -40,12 +46,35 @@ export default function ReceiptDetail({ receiptId, onBack }: ReceiptDetailProps)
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [showRawText, setShowRawText] = useState(false);
+  const [activeDialog, setActiveDialog] = useState<'edit' | 'void' | 'delete' | null>(null);
 
   const loadReceipt = () => {
     fetchReceiptDetail(receiptId)
       .then(setReceipt)
       .catch((e: unknown) => setError(extractProblemMessage(e)))
       .finally(() => setLoading(false));
+  };
+
+  const handleUpdated = (txn: BackendTransaction, etag: string | null) => {
+    setReceipt(toReceiptView(txn, etag));
+  };
+
+  const handleVoidConfirm = async (reason: string) => {
+    if (!receipt?.etag) throw new Error('No ETag — reload and retry.');
+    const updated = await voidTransaction(receipt.id, reason, receipt.etag);
+    // `voidTransaction` returns the mirror (reversing) txn, which has a
+    // different id. Refetch the current receipt so we see its new
+    // `voided` status and fresh ETag.
+    void updated;
+    setActiveDialog(null);
+    loadReceipt();
+  };
+
+  const handleDeleteConfirm = async () => {
+    if (!receipt?.etag) throw new Error('No ETag — reload and retry.');
+    await deleteTransaction(receipt.id, receipt.etag);
+    setActiveDialog(null);
+    onBack();
   };
 
   useEffect(() => {
@@ -113,12 +142,50 @@ export default function ReceiptDetail({ receiptId, onBack }: ReceiptDetailProps)
   );
   const merchantLabel = receipt.payee ?? receipt.narration ?? 'Unknown';
 
+  const canDelete = receipt.status === 'draft' || receipt.status === 'error';
+  const canVoid = receipt.status === 'posted' || receipt.status === 'reconciled';
+  const canEdit = receipt.status !== 'voided';
+
   return (
     <div className="space-y-8 animate-in fade-in slide-in-from-bottom-4 duration-700 max-w-4xl">
-      <button onClick={onBack} className="flex items-center gap-2 text-primary font-bold hover:opacity-80 transition-opacity">
-        <ArrowLeft size={20} />
-        Back to transactions
-      </button>
+      <div className="flex items-center justify-between gap-4 flex-wrap">
+        <button onClick={onBack} className="flex items-center gap-2 text-primary font-bold hover:opacity-80 transition-opacity">
+          <ArrowLeft size={20} />
+          Back to transactions
+        </button>
+
+        {!isProcessing && (
+          <div className="flex items-center gap-2">
+            <button
+              onClick={() => setActiveDialog('edit')}
+              disabled={!canEdit}
+              className="flex items-center gap-2 px-4 py-2 rounded-xl bg-surface-container-high text-white font-bold hover:bg-surface-container-highest transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+              title={canEdit ? 'Edit receipt' : 'Voided receipts cannot be edited'}
+            >
+              <Pencil size={16} />
+              Edit
+            </button>
+            <button
+              onClick={() => setActiveDialog('void')}
+              disabled={!canVoid}
+              className="flex items-center gap-2 px-4 py-2 rounded-xl bg-surface-container-high text-white font-bold hover:bg-surface-container-highest transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+              title={canVoid ? 'Void (reverse) this receipt' : 'Only posted receipts can be voided'}
+            >
+              <Ban size={16} />
+              Void
+            </button>
+            <button
+              onClick={() => setActiveDialog('delete')}
+              disabled={!canDelete}
+              className="flex items-center gap-2 px-4 py-2 rounded-xl bg-error/10 text-error font-bold hover:bg-error/20 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+              title={canDelete ? 'Delete this draft' : 'Only draft/error receipts can be deleted — use Void instead'}
+            >
+              <Trash2 size={16} />
+              Delete
+            </button>
+          </div>
+        )}
+      </div>
 
       {isProcessing && (
         <div className="flex items-center gap-4 p-5 rounded-xl bg-tertiary/10 border border-tertiary/20">
@@ -286,6 +353,51 @@ export default function ReceiptDetail({ receiptId, onBack }: ReceiptDetailProps)
           )}
         </div>
       )}
+
+      <EditReceiptModal
+        isOpen={activeDialog === 'edit'}
+        onClose={() => setActiveDialog(null)}
+        receipt={receipt}
+        onUpdated={handleUpdated}
+        onStale={loadReceipt}
+      />
+
+      <ConfirmActionDialog
+        isOpen={activeDialog === 'void'}
+        onClose={() => setActiveDialog(null)}
+        title="Void this receipt?"
+        message={
+          <>
+            <p>
+              Voiding creates a reversing entry in the ledger — the original transaction stays,
+              but its balance cancels out. Use this for posted receipts you can't simply delete.
+            </p>
+            <p className="mt-2 text-xs text-on-surface-variant/70">
+              This action can be reversed only by creating a new offsetting transaction.
+            </p>
+          </>
+        }
+        confirmLabel="Void receipt"
+        destructive
+        requireReason
+        reasonPlaceholder="Why are you voiding this? (optional)"
+        onConfirm={handleVoidConfirm}
+      />
+
+      <ConfirmActionDialog
+        isOpen={activeDialog === 'delete'}
+        onClose={() => setActiveDialog(null)}
+        title="Delete this draft?"
+        message={
+          <p>
+            This permanently removes the draft transaction and unlinks any attached documents.
+            Only drafts and errored extractions can be deleted — posted receipts must be voided.
+          </p>
+        }
+        confirmLabel="Delete forever"
+        destructive
+        onConfirm={handleDeleteConfirm}
+      />
 
       {!isProcessing && confidence != null && (
         <div className="glass-panel rounded-xl p-6 border border-outline-variant/10">


### PR DESCRIPTION
## Summary
- Adds edit/void/delete affordances to the receipt detail page. Backend v1 has always exposed these (PATCH, POST .../void, DELETE — all guarded by `If-Match: W/\"<version>\"`), but the frontend had no UI for them.
- `EditReceiptModal` patches payee / date / narration via `application/merge-patch+json`; handles 412 version mismatch by offering a reload.
- `ConfirmActionDialog` is a small reusable confirm with optional reason textarea; used for both void and delete.
- Buttons gate themselves by status: Delete only on `draft`/`error`, Void only on `posted`/`reconciled` (backend 409s otherwise).

## Smoke-tested against the real backend (localhost:3000)
- `POST /v1/transactions` with `Idempotency-Key` → 201
- `PATCH /v1/transactions/{id}` with `If-Match: W/\"1\"` → 200, ETag bumps to `W/\"2\"`, `version` 1→2
- `DELETE /v1/transactions/{id}` on `posted` status → **409** (as designed; UI disables the button)
- `POST /v1/transactions/{id}/void` with reason → **201**, mirror reversing txn created, original flipped to `status=voided` with `voided_by_id` set

## Acceptance criteria
- [x] TypeScript + ESLint green
- [x] `Idempotency-Key` not required on PATCH / void / delete (spec only mandates it on `POST /v1/transactions`)
- [x] All three paths use `If-Match` from the ETag captured at GET time
- [x] 412/409 paths surface a human-readable message via `extractProblemMessage`

## Note on labels
This repo still uses the legacy flat label set (`bug`, `enhancement`, …). Per the backend repo's `CLAUDE.md`, new repos should bootstrap the namespaced taxonomy (`kind/*`, `priority/*`, `area/*`, `status/*`, `severity/*`). Happy to send a small follow-up PR that bootstraps labels to match the other two repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)