### PR TITLE
Add Uploads tab: batch list + live SSE detail

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,8 @@ import Dashboard from './components/Dashboard';
 import Transactions from './components/Transactions';
 import MonthlyReview from './components/MonthlyReview';
 import YearlyReview from './components/YearlyReview';
+import Batches from './components/Batches';
+import BatchDetail from './components/BatchDetail';
 import AddTransactionModal from './components/AddTransactionModal';
 import ProcessingToast from './components/ProcessingToast';
 import { useProcessingJobs } from './components/useProcessingJobs';
@@ -14,6 +16,7 @@ export default function App() {
   const [isModalOpen, setIsModalOpen] = React.useState(false);
   const [refreshKey, setRefreshKey] = React.useState(0);
   const [selectedReceiptId, setSelectedReceiptId] = React.useState<string | null>(null);
+  const [selectedBatchId, setSelectedBatchId] = React.useState<string | null>(null);
   const { jobs, addJob, removeJob } = useProcessingJobs();
 
   const handleUploadComplete = (job: { batchId: string; ingestId: string; filename: string }) => {
@@ -29,10 +32,29 @@ export default function App() {
     setSelectedReceiptId(null);
   };
 
+  const handleSelectBatch = (batchId: string) => {
+    setSelectedBatchId(batchId);
+  };
+
+  const handleBackFromBatch = () => {
+    setSelectedBatchId(null);
+  };
+
   const renderContent = () => {
-    // Receipt detail view takes priority
+    // Receipt detail view takes priority — can be opened from anywhere.
     if (selectedReceiptId) {
       return <ReceiptDetail receiptId={selectedReceiptId} onBack={handleBackFromDetail} />;
+    }
+
+    // Batch detail takes priority within the Uploads tab.
+    if (activeTab === 'batches' && selectedBatchId) {
+      return (
+        <BatchDetail
+          batchId={selectedBatchId}
+          onBack={handleBackFromBatch}
+          onSelectTransaction={handleSelectReceipt}
+        />
+      );
     }
 
     switch (activeTab) {
@@ -40,6 +62,8 @@ export default function App() {
         return <Dashboard key={refreshKey} onSelectReceipt={handleSelectReceipt} />;
       case 'transactions':
         return <Transactions key={refreshKey} onSelectReceipt={handleSelectReceipt} />;
+      case 'batches':
+        return <Batches key={refreshKey} onSelectBatch={handleSelectBatch} />;
       case 'monthly':
         return <MonthlyReview />;
       case 'yearly':
@@ -68,6 +92,7 @@ export default function App() {
         activeTab={activeTab}
         onTabChange={(tab) => {
           setSelectedReceiptId(null);
+          setSelectedBatchId(null);
           setActiveTab(tab);
         }}
         onAddTransaction={() => setIsModalOpen(true)}

--- a/src/components/BatchDetail.tsx
+++ b/src/components/BatchDetail.tsx
@@ -1,0 +1,305 @@
+import React, { useEffect, useRef, useState } from 'react';
+import {
+  ArrowLeft,
+  CheckCircle2,
+  AlertCircle,
+  Clock,
+  Cog,
+  FileText,
+  Zap,
+} from 'lucide-react';
+import {
+  getBatch,
+  subscribeToBatch,
+  extractProblemMessage,
+  type BackendBatch,
+  type BackendIngest,
+  type IngestStatus,
+} from '../lib/api';
+import { cn } from '../lib/utils';
+
+interface BatchDetailProps {
+  batchId: string;
+  onBack: () => void;
+  onSelectTransaction: (txnId: string) => void;
+}
+
+const INGEST_STATUS_META: Record<
+  IngestStatus,
+  { label: string; badge: string; icon: React.ComponentType<{ size?: number; className?: string }> }
+> = {
+  queued: { label: 'Queued', badge: 'bg-surface-container-highest text-on-surface-variant', icon: Clock },
+  processing: { label: 'Processing', badge: 'bg-tertiary/10 text-tertiary', icon: Cog },
+  done: { label: 'Done', badge: 'bg-primary/10 text-primary', icon: CheckCircle2 },
+  error: { label: 'Error', badge: 'bg-error/10 text-error', icon: AlertCircle },
+  unsupported: { label: 'Unsupported', badge: 'bg-error/10 text-error', icon: AlertCircle },
+};
+
+interface LiveEvent {
+  id: number;
+  at: Date;
+  name: string;
+  payload: unknown;
+}
+
+export default function BatchDetail({ batchId, onBack, onSelectTransaction }: BatchDetailProps) {
+  const [batch, setBatch] = useState<BackendBatch | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [events, setEvents] = useState<LiveEvent[]>([]);
+  const eventCounter = useRef(0);
+
+  const refetch = () => {
+    getBatch(batchId)
+      .then(setBatch)
+      .catch((e) => setError(extractProblemMessage(e)));
+  };
+
+  useEffect(() => {
+    setLoading(true);
+    getBatch(batchId)
+      .then(setBatch)
+      .catch((e) => setError(extractProblemMessage(e)))
+      .finally(() => setLoading(false));
+  }, [batchId]);
+
+  // Subscribe to the live stream. Each recognized event refetches the
+  // batch so status/counts stay in sync; we also accumulate a running log.
+  useEffect(() => {
+    const controller = subscribeToBatch(
+      batchId,
+      (name, payload) => {
+        eventCounter.current += 1;
+        const evt: LiveEvent = {
+          id: eventCounter.current,
+          at: new Date(),
+          name,
+          payload,
+        };
+        setEvents((prev) => [evt, ...prev].slice(0, 50));
+        // Any meaningful state change → refetch the batch snapshot.
+        if (name !== 'hello' && name !== 'message') refetch();
+      },
+      () => {
+        // EventSource errors are common when the server closes after a
+        // terminal frame. Leave the snapshot as-is.
+      },
+    );
+    return () => controller.abort();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [batchId]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-[60vh] gap-3">
+        <Cog className="animate-spin text-primary" size={32} />
+        <span className="text-on-surface-variant">Loading batch...</span>
+      </div>
+    );
+  }
+
+  if (error || !batch) {
+    return (
+      <div className="space-y-6 animate-in fade-in duration-500">
+        <button onClick={onBack} className="flex items-center gap-2 text-primary font-bold hover:opacity-80 transition-opacity">
+          <ArrowLeft size={20} />
+          Back
+        </button>
+        <div className="text-center py-20 text-error">{error || 'Batch not found'}</div>
+      </div>
+    );
+  }
+
+  const { counts } = batch;
+  const pct = counts.total > 0 ? Math.round(((counts.done + counts.error) / counts.total) * 100) : 0;
+
+  return (
+    <div className="space-y-8 animate-in fade-in slide-in-from-bottom-4 duration-700 max-w-5xl">
+      <button onClick={onBack} className="flex items-center gap-2 text-primary font-bold hover:opacity-80 transition-opacity">
+        <ArrowLeft size={20} />
+        Back to batches
+      </button>
+
+      <div className="glass-panel rounded-xl p-8 border border-outline-variant/10">
+        <div className="flex items-start justify-between flex-wrap gap-4">
+          <div>
+            <p className="text-xs text-on-surface-variant uppercase tracking-widest mb-2">Batch</p>
+            <p className="text-2xl font-bold text-white font-headline font-mono">
+              {batch.id.slice(0, 8)}…{batch.id.slice(-4)}
+            </p>
+            <p className="text-sm text-on-surface-variant mt-1">
+              Uploaded {new Date(batch.created_at).toLocaleString()} ·{' '}
+              {batch.auto_reconcile ? 'auto-reconcile on' : 'manual reconcile'}
+            </p>
+          </div>
+          <div className="text-right">
+            <p className="text-xs text-on-surface-variant uppercase tracking-widest mb-2">Status</p>
+            <p className="text-2xl font-bold text-white font-headline capitalize">
+              {batch.status.replace('_', ' ')}
+            </p>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-2 md:grid-cols-5 gap-4 mt-6 pt-6 border-t border-outline-variant/10">
+          <StatCard label="Total" value={counts.total} />
+          <StatCard label="Queued" value={counts.queued} tone="muted" />
+          <StatCard label="Processing" value={counts.processing} tone="tertiary" />
+          <StatCard label="Done" value={counts.done} tone="primary" />
+          <StatCard label="Error" value={counts.error + counts.unsupported} tone="error" />
+        </div>
+
+        <div className="mt-6 flex items-center gap-3">
+          <div className="flex-1 h-2 bg-surface-container-highest rounded-full overflow-hidden">
+            <div
+              className={cn('h-full transition-all duration-500', counts.error > 0 ? 'bg-error' : 'bg-primary')}
+              style={{ width: `${pct}%` }}
+            />
+          </div>
+          <span className="text-sm text-on-surface-variant font-mono">{pct}%</span>
+        </div>
+      </div>
+
+      <div className="glass-panel rounded-xl border border-outline-variant/10 overflow-hidden">
+        <div className="px-8 py-5 border-b border-outline-variant/10">
+          <h3 className="font-headline font-bold text-white flex items-center gap-2">
+            <FileText size={18} />
+            Files ({batch.items.length})
+          </h3>
+        </div>
+        <table className="w-full text-left">
+          <thead>
+            <tr className="bg-surface-container-low/50">
+              <th className="px-8 py-3 text-xs font-bold text-on-surface-variant uppercase tracking-widest">File</th>
+              <th className="px-8 py-3 text-xs font-bold text-on-surface-variant uppercase tracking-widest">Classification</th>
+              <th className="px-8 py-3 text-xs font-bold text-on-surface-variant uppercase tracking-widest">Status</th>
+              <th className="px-8 py-3 text-xs font-bold text-on-surface-variant uppercase tracking-widest">Produced</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-outline-variant/5">
+            {batch.items.map((ing) => (
+              <IngestRow key={ing.id} ingest={ing} onSelectTransaction={onSelectTransaction} />
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="glass-panel rounded-xl border border-outline-variant/10 overflow-hidden">
+        <div className="px-8 py-5 border-b border-outline-variant/10 flex items-center justify-between">
+          <h3 className="font-headline font-bold text-white flex items-center gap-2">
+            <Zap size={18} />
+            Live events
+          </h3>
+          <span className="text-xs text-on-surface-variant">
+            {events.length === 0 ? 'Waiting for server...' : `${events.length} event(s)`}
+          </span>
+        </div>
+        <div className="max-h-64 overflow-y-auto">
+          {events.length === 0 ? (
+            <p className="px-8 py-6 text-sm text-on-surface-variant/60">
+              Stream is open. Upload activity will appear here.
+            </p>
+          ) : (
+            <ul className="divide-y divide-outline-variant/5">
+              {events.map((e) => (
+                <li key={e.id} className="px-8 py-3 flex items-center gap-4 text-xs font-mono">
+                  <span className="text-on-surface-variant/60 w-20">
+                    {e.at.toLocaleTimeString([], { hour12: false })}
+                  </span>
+                  <span className="text-primary font-bold w-44 truncate">{e.name}</span>
+                  <span className="text-on-surface-variant truncate flex-1">
+                    {typeof e.payload === 'object' && e.payload !== null
+                      ? JSON.stringify(e.payload)
+                      : String(e.payload)}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function StatCard({
+  label,
+  value,
+  tone = 'default',
+}: {
+  label: string;
+  value: number;
+  tone?: 'default' | 'muted' | 'primary' | 'tertiary' | 'error';
+}) {
+  const valueClass =
+    tone === 'primary'
+      ? 'text-primary'
+      : tone === 'tertiary'
+        ? 'text-tertiary'
+        : tone === 'error'
+          ? 'text-error'
+          : tone === 'muted'
+            ? 'text-on-surface-variant'
+            : 'text-white';
+  return (
+    <div>
+      <p className="text-xs text-on-surface-variant uppercase tracking-widest">{label}</p>
+      <p className={cn('text-2xl font-bold font-headline mt-1', valueClass)}>{value}</p>
+    </div>
+  );
+}
+
+function IngestRow({
+  ingest,
+  onSelectTransaction,
+}: {
+  ingest: BackendIngest;
+  onSelectTransaction: (id: string) => void;
+}) {
+  const meta = INGEST_STATUS_META[ingest.status];
+  const Icon = meta.icon;
+  const txnIds = ingest.produced?.transaction_ids ?? [];
+  return (
+    <tr className="hover:bg-surface-container-high/30 transition-colors">
+      <td className="px-8 py-4">
+        <p className="text-sm font-medium text-white">{ingest.filename}</p>
+        {ingest.mime_type && (
+          <p className="text-[11px] text-on-surface-variant/70 mt-0.5 font-mono">{ingest.mime_type}</p>
+        )}
+        {ingest.error && (
+          <p className="text-[11px] text-error mt-1 truncate max-w-md">{ingest.error}</p>
+        )}
+      </td>
+      <td className="px-8 py-4 text-sm text-on-surface-variant">
+        {ingest.classification ? ingest.classification.replace('_', ' ') : '—'}
+      </td>
+      <td className="px-8 py-4">
+        <span
+          className={cn(
+            'inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-[11px] font-bold uppercase tracking-wider',
+            meta.badge,
+          )}
+        >
+          <Icon size={12} />
+          {meta.label}
+        </span>
+      </td>
+      <td className="px-8 py-4 text-sm">
+        {txnIds.length === 0 ? (
+          <span className="text-on-surface-variant/60">—</span>
+        ) : (
+          <div className="flex flex-wrap gap-2">
+            {txnIds.map((id) => (
+              <button
+                key={id}
+                onClick={() => onSelectTransaction(id)}
+                className="text-primary font-mono text-[11px] hover:underline"
+              >
+                {id.slice(0, 8)}…
+              </button>
+            ))}
+          </div>
+        )}
+      </td>
+    </tr>
+  );
+}

--- a/src/components/Batches.tsx
+++ b/src/components/Batches.tsx
@@ -1,0 +1,148 @@
+import React, { useEffect, useState } from 'react';
+import { Loader2, FileStack, CheckCircle2, AlertCircle, Clock, Cog } from 'lucide-react';
+import {
+  listBatches,
+  extractProblemMessage,
+  type BackendBatchSummary,
+  type BatchStatus,
+} from '../lib/api';
+import { cn } from '../lib/utils';
+
+interface BatchesProps {
+  onSelectBatch: (batchId: string) => void;
+}
+
+const STATUS_META: Record<
+  BatchStatus,
+  { label: string; badge: string; icon: React.ComponentType<{ size?: number; className?: string }> }
+> = {
+  pending: { label: 'Pending', badge: 'bg-surface-container-highest text-on-surface-variant', icon: Clock },
+  processing: { label: 'Processing', badge: 'bg-tertiary/10 text-tertiary', icon: Cog },
+  extracted: { label: 'Extracted', badge: 'bg-primary/10 text-primary', icon: CheckCircle2 },
+  reconciling: { label: 'Reconciling', badge: 'bg-tertiary/10 text-tertiary', icon: Cog },
+  reconciled: { label: 'Reconciled', badge: 'bg-primary/20 text-primary', icon: CheckCircle2 },
+  failed: { label: 'Failed', badge: 'bg-error/10 text-error', icon: AlertCircle },
+  reconcile_error: { label: 'Reconcile error', badge: 'bg-error/10 text-error', icon: AlertCircle },
+};
+
+function formatDate(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+export default function Batches({ onSelectBatch }: BatchesProps) {
+  const [items, setItems] = useState<BackendBatchSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    listBatches({ limit: 50 })
+      .then((r) => setItems(r.items))
+      .catch((e) => setError(extractProblemMessage(e)))
+      .finally(() => setLoading(false));
+  }, []);
+
+  return (
+    <div className="space-y-10 animate-in fade-in slide-in-from-bottom-4 duration-700">
+      <div>
+        <h2 className="text-4xl font-extrabold text-white font-headline tracking-tight">Upload Batches</h2>
+        <p className="text-on-surface-variant mt-2 font-inter">
+          Every receipt you upload is ingested as a batch. Open one to watch extraction + reconciliation progress in real time.
+        </p>
+      </div>
+
+      <div className="glass-panel border border-outline-variant/10 rounded-xl overflow-hidden shadow-2xl">
+        {loading ? (
+          <div className="flex items-center justify-center py-20">
+            <Loader2 className="animate-spin text-primary" size={32} />
+            <span className="ml-3 text-on-surface-variant">Loading batches...</span>
+          </div>
+        ) : error ? (
+          <div className="text-center py-20 text-error">{error}</div>
+        ) : items.length === 0 ? (
+          <div className="flex flex-col items-center py-20 gap-3 text-on-surface-variant">
+            <FileStack size={40} className="opacity-50" />
+            <p>No uploads yet. Drop a receipt from the Add Transaction button to get started.</p>
+          </div>
+        ) : (
+          <table className="w-full text-left border-collapse">
+            <thead>
+              <tr className="bg-surface-container-low/50">
+                <th className="px-8 py-5 text-xs font-bold text-on-surface-variant uppercase tracking-widest font-headline">Uploaded</th>
+                <th className="px-8 py-5 text-xs font-bold text-on-surface-variant uppercase tracking-widest font-headline">Files</th>
+                <th className="px-8 py-5 text-xs font-bold text-on-surface-variant uppercase tracking-widest font-headline">Progress</th>
+                <th className="px-8 py-5 text-xs font-bold text-on-surface-variant uppercase tracking-widest font-headline">Status</th>
+                <th className="px-8 py-5 text-xs font-bold text-on-surface-variant uppercase tracking-widest font-headline">Auto-reconcile</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-outline-variant/5">
+              {items.map((b) => {
+                const meta = STATUS_META[b.status];
+                const Icon = meta.icon;
+                const { done, error: errored, total } = b.counts;
+                const pct = total > 0 ? Math.round(((done + errored) / total) * 100) : 0;
+                return (
+                  <tr
+                    key={b.id}
+                    onClick={() => onSelectBatch(b.id)}
+                    className="hover:bg-surface-container-high/30 transition-colors cursor-pointer group"
+                  >
+                    <td className="px-8 py-6">
+                      <div className="flex flex-col">
+                        <span className="text-sm font-bold text-white group-hover:text-primary transition-colors">
+                          {formatDate(b.created_at)}
+                        </span>
+                        <span className="text-[11px] text-on-surface-variant/70 mt-0.5 font-mono">
+                          {b.id.slice(0, 8)}…
+                        </span>
+                      </div>
+                    </td>
+                    <td className="px-8 py-6 text-sm text-on-surface-variant">
+                      {b.file_count} {b.file_count === 1 ? 'file' : 'files'}
+                    </td>
+                    <td className="px-8 py-6">
+                      <div className="w-40 flex items-center gap-3">
+                        <div className="flex-1 h-1.5 bg-surface-container-highest rounded-full overflow-hidden">
+                          <div
+                            className={cn(
+                              'h-full transition-all',
+                              errored > 0 ? 'bg-error' : 'bg-primary',
+                            )}
+                            style={{ width: `${pct}%` }}
+                          />
+                        </div>
+                        <span className="text-[11px] text-on-surface-variant font-mono w-16 text-right">
+                          {done}/{total}
+                          {errored > 0 && <span className="text-error"> · {errored} err</span>}
+                        </span>
+                      </div>
+                    </td>
+                    <td className="px-8 py-6">
+                      <span
+                        className={cn(
+                          'inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-[11px] font-bold uppercase tracking-wider',
+                          meta.badge,
+                        )}
+                      >
+                        <Icon size={12} />
+                        {meta.label}
+                      </span>
+                    </td>
+                    <td className="px-8 py-6 text-sm text-on-surface-variant">
+                      {b.auto_reconcile ? 'On' : 'Off'}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
-import { 
-  LayoutDashboard, 
-  ReceiptText, 
-  CalendarDays, 
-  CalendarRange, 
-  Settings, 
-  Plus
+import {
+  LayoutDashboard,
+  ReceiptText,
+  CalendarDays,
+  CalendarRange,
+  FileStack,
+  Settings,
+  Plus,
 } from 'lucide-react';
 import { cn } from '../lib/utils';
 
@@ -19,6 +20,7 @@ export default function Sidebar({ activeTab, onTabChange, onAddTransaction }: Si
   const navItems = [
     { id: 'dashboard', label: 'Dashboard', icon: LayoutDashboard },
     { id: 'transactions', label: 'Transactions', icon: ReceiptText },
+    { id: 'batches', label: 'Uploads', icon: FileStack },
     { id: 'monthly', label: 'Monthly Review', icon: CalendarDays },
     { id: 'yearly', label: 'Yearly Review', icon: CalendarRange },
     { id: 'settings', label: 'Settings', icon: Settings },


### PR DESCRIPTION
## Summary
- New **Uploads** sidebar tab. Every receipt you upload is a batch in the v1 API; this surfaces them as first-class history + live progress, not just a transient toast.
- `Batches.tsx` is the list view (paginated via `GET /v1/batches`) with status pills and a `done/total` progress bar.
- `BatchDetail.tsx` renders a snapshot (`GET /v1/batches/:id`) **and** subscribes to `GET /v1/batches/:id/stream` via the existing `subscribeToBatch(EventSource)` helper. Every recognized server event (`job.started`, `job.done`, `batch.extracted`, `reconcile.*`, …) refetches the snapshot so status + counts stay in sync, and appends to a rolling log (last 50, most recent first).
- Clicking a produced `transaction_id` in the per-file table jumps straight into `ReceiptDetail`.

## Smoke-tested against real backend
Verified with a 30-file batch live on `localhost:3000` (\`status=processing\`, \`counts={queued:24, processing:3, done:3}\`) — list renders, progress bar updates, SSE log accumulates events as extractions finish.

## Acceptance criteria
- [x] TypeScript + ESLint green
- [x] No manual \`fetch\` / \`URLSource\` hand-writing — all API calls go through \`openapi-fetch\`
- [x] SSE subscription aborts on unmount (no leaked EventSource)
- [x] Cross-navigation to ReceiptDetail works via the existing \`selectedReceiptId\` state

🤖 Generated with [Claude Code](https://claude.com/claude-code)