### PR TITLE
feat: render merchant location map from backend transaction.place

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,10 @@ GEMINI_API_KEY="MY_GEMINI_API_KEY"
 # AI Studio automatically injects this at runtime with the Cloud Run service URL.
 # Used for self-referential links, OAuth callbacks, and API endpoints.
 APP_URL="MY_APP_URL"
+
+# GOOGLE_MAPS_API_KEY: used by docker compose at build time to pass
+# VITE_GOOGLE_MAPS_API_KEY into the Vite build. Baked into the JS
+# bundle — anyone with DevTools can read it once deployed. Restrict
+# the key by HTTP referrer in Google Cloud Console for any public
+# deployment. Leave unset to hide the map block entirely.
+# GOOGLE_MAPS_API_KEY=

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,13 @@ FROM node:22-bookworm AS builder
 
 WORKDIR /app
 
+# Vite inlines VITE_* env vars into the JS bundle at build time, so
+# they MUST be present in the builder stage env. Empty default is fine
+# — the frontend gates its map block on the key being truthy and
+# simply hides the block otherwise (see ReceiptDetail.tsx).
+ARG VITE_GOOGLE_MAPS_API_KEY=
+ENV VITE_GOOGLE_MAPS_API_KEY=$VITE_GOOGLE_MAPS_API_KEY
+
 # Install deps first (cached layer as long as package*.json is unchanged)
 COPY package.json package-lock.json ./
 RUN npm ci

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The Vite dev server proxies `/api/*` to `localhost:3000` automatically.
 
 | Variable | When needed | Purpose |
 |----------|-------------|---------|
-| `VITE_GOOGLE_MAPS_API_KEY` | Receipt detail page | Enables the map + marker when an extraction produces `latitude` / `longitude`. Feature is gated on the key's presence — without it the map block is simply not rendered. |
+| `VITE_GOOGLE_MAPS_API_KEY` | Receipt detail page | Enables the map + marker when the backend returns a non-null `transaction.place` (Google Places entry joined in from the `places` table with `lat` / `lng` / `formatted_address`). Baked into the JS bundle at build time via Docker build arg `VITE_GOOGLE_MAPS_API_KEY` (substituted from `GOOGLE_MAPS_API_KEY` in this repo's `.env`). Gated on the key's presence — without it the map block is simply not rendered. Can reuse the same Google Maps API key the backend uses for server-side Geocoding/Places calls. |
 
 Set either in `.env.local` (for dev) or as build-time variables for Docker builds.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,14 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      args:
+        # Baked into the JS bundle at build time by Vite. Set
+        # GOOGLE_MAPS_API_KEY in this repo's .env (gitignored). Empty
+        # is fine — the frontend simply hides the map block when
+        # unset. Anyone with browser DevTools can read this key once
+        # it's in the bundle; for a public deploy, restrict the key
+        # in Google Cloud Console to the deploy origin.
+        VITE_GOOGLE_MAPS_API_KEY: ${GOOGLE_MAPS_API_KEY:-}
     image: receipt-assistant-frontend:local
     container_name: receipt-assistant-frontend
     ports:

--- a/src/components/ReceiptDetail.tsx
+++ b/src/components/ReceiptDetail.tsx
@@ -127,9 +127,12 @@ export default function ReceiptDetail({ receiptId, onBack }: ReceiptDetailProps)
   const isProcessing = receipt.status === 'draft';
   const tax = md<number>(legacy, 'tax');
   const tip = md<number>(legacy, 'tip');
-  const latitude = md<number>(legacy, 'latitude');
-  const longitude = md<number>(legacy, 'longitude');
-  const address = md<string>(legacy, 'address');
+  // Geo comes from the v1 `transactions.place` JOIN (see backend
+  // `places` table). Older transactions written before the places
+  // migration have `place: null` and render without a map block.
+  const latitude = receipt.place?.lat ?? null;
+  const longitude = receipt.place?.lng ?? null;
+  const address = receipt.place?.formatted_address ?? md<string>(legacy, 'address');
   const rawText = md<string>(legacy, 'raw_text');
   const items = md<Array<{ name: string; quantity?: number; unit_price?: number; total_price?: number }>>(legacy, 'items');
   const confidence = md<number>(

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -2249,6 +2249,19 @@ export interface components {
             id: string;
             kind: string;
         };
+        Place: {
+            /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            id: string;
+            google_place_id: string;
+            formatted_address: string;
+            lat: number;
+            lng: number;
+            /** @enum {string} */
+            source: "google_geocode" | "google_places";
+        } | null;
         Transaction: {
             /**
              * Format: uuid
@@ -2300,6 +2313,7 @@ export interface components {
             updated_at: string;
             postings: components["schemas"]["Posting"][];
             documents: components["schemas"]["TransactionDocumentRef"][];
+            place: components["schemas"]["Place"];
         };
         BulkResultItem: {
             index: number;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -30,6 +30,7 @@ const client = createClient<paths>({ baseUrl: '/api' });
 
 export type BackendTransaction = components['schemas']['Transaction'];
 export type BackendPosting = components['schemas']['Posting'];
+export type BackendPlace = components['schemas']['Place'];
 export type BackendDocument = components['schemas']['Document'];
 export type BackendBatch = components['schemas']['Batch'];
 export type BackendBatchSummary = components['schemas']['BatchSummary'];
@@ -80,6 +81,8 @@ export interface ReceiptView {
   documentKind: string | null;
   documents: BackendTransaction['documents'];
   postings: BackendPosting[];
+  /** Google Places entry for the merchant location, if geocoded. */
+  place: BackendPlace | null;
   etag: string | null;
 }
 
@@ -179,6 +182,7 @@ export function toReceiptView(t: BackendTransaction, etag: string | null = null)
     documentKind: doc?.kind ?? null,
     documents: t.documents,
     postings: t.postings,
+    place: t.place ?? null,
     etag,
   };
 }


### PR DESCRIPTION
## Summary

- Switch Receipt Detail page's Google Maps block from unpopulated flat metadata keys to the new typed \`transaction.place\` subobject from the backend
- Wire \`GOOGLE_MAPS_API_KEY\` through the Docker build so Vite bakes it into the bundle (reuse the same key the backend uses at runtime)
- Regenerate \`api-types.ts\` from the backend OpenAPI

Closes #12
Depends on: TINKPA/receipt-assistant#47

## Test plan

- [x] Backend returns \`transaction.place\` with lat/lng/formatted_address → frontend Receipt Detail page renders a Google Map + marker at the correct location (verified against Urth Caffe Santa Monica — pin lands at Ocean Park)
- [x] Pre-places transactions (\`place: null\`) render the detail page without the map block, no console errors
- [x] Operator sets one env var (\`GOOGLE_MAPS_API_KEY\`) in the frontend repo's \`.env\`, \`docker compose up -d --build\` bakes it in
- [x] Address on the map block matches Google's \`formatted_address\` (not the OCR'd text)

Note: \`src/lib/api-types.ts\` was regenerated from the local backend build. Once TINKPA/receipt-assistant#47 merges, re-running \`npm run api:types\` against GitHub main should produce an identical diff — nothing to reconcile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)