### PR TITLE
fix(ui): drawer a11y polish on top of #16

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,20 @@ Fonts: **Manrope** (headlines), **Inter** (body text).
 
 Custom effects: `glass-panel` (backdrop blur), `neon-glow-primary` (teal glow on key metrics).
 
+## Supported breakpoints
+
+This project uses **canonical Tailwind v4 defaults** (no overrides in `src/index.css`):
+
+| Prefix | Min-width | Typical device |
+|--------|-----------|----------------|
+| `sm`   | 640 px    | Large phones (landscape) |
+| `md`   | 768 px    | Tablets (portrait), iPad Mini |
+| `lg`   | 1024 px   | Small laptops, iPad Pro (landscape) |
+| `xl`   | 1280 px   | Standard laptops |
+| `2xl`  | 1536 px   | Large desktops |
+
+`lg` is the **desktop threshold**. Below `lg`, the sidebar collapses into a hamburger-triggered drawer; at and above `lg`, the persistent 256 px sidebar returns. Page-level grid rules should default to mobile-first (single column / stacked) and add `lg:` variants for the desktop layout.
+
 ## Development
 
 ```bash

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Obsidian Wealth</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Manrope:wght@400;500;600;700;800&display=swap">
   </head>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Sidebar from './Sidebar';
 import TopBar from './TopBar';
 
@@ -10,16 +10,20 @@ interface LayoutProps {
 }
 
 export default function Layout({ children, activeTab, onTabChange, onAddTransaction }: LayoutProps) {
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+
   return (
     <div className="flex min-h-screen bg-background">
-      <Sidebar 
-        activeTab={activeTab} 
-        onTabChange={onTabChange} 
-        onAddTransaction={onAddTransaction} 
+      <Sidebar
+        activeTab={activeTab}
+        onTabChange={onTabChange}
+        onAddTransaction={onAddTransaction}
+        sidebarOpen={sidebarOpen}
+        setSidebarOpen={setSidebarOpen}
       />
-      <div className="flex-1 ml-64 flex flex-col">
-        <TopBar />
-        <main className="flex-1 pt-24 pb-12 px-10 overflow-x-hidden">
+      <div className="flex-1 lg:ml-64 flex flex-col">
+        <TopBar onOpenSidebar={() => setSidebarOpen(true)} sidebarOpen={sidebarOpen} />
+        <main className="flex-1 pt-24 pb-12 px-6 lg:px-10 overflow-x-hidden">
           {children}
         </main>
       </div>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -22,7 +22,7 @@ export default function Layout({ children, activeTab, onTabChange, onAddTransact
         setSidebarOpen={setSidebarOpen}
       />
       <div className="flex-1 lg:ml-64 flex flex-col">
-        <TopBar onOpenSidebar={() => setSidebarOpen(true)} sidebarOpen={sidebarOpen} />
+        <TopBar onToggleSidebar={() => setSidebarOpen(!sidebarOpen)} sidebarOpen={sidebarOpen} />
         <main className="flex-1 pt-24 pb-12 px-6 lg:px-10 overflow-x-hidden">
           {children}
         </main>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -52,9 +52,10 @@ export default function Sidebar({
   // sidebar is persistent and these effects must NOT run.
   useEffect(() => {
     if (!sidebarOpen) return;
-    const isDesktop = window.matchMedia('(min-width: 1024px)').matches;
-    if (isDesktop) return;
+    const mql = window.matchMedia('(min-width: 1024px)');
+    if (mql.matches) return;
 
+    const opener = document.activeElement as HTMLElement | null;
     const previousOverflow = document.body.style.overflow;
     document.body.style.overflow = 'hidden';
 
@@ -86,9 +87,18 @@ export default function Sidebar({
     };
     document.addEventListener('keydown', handleKey);
 
+    // Cross-breakpoint safety: if the viewport grows past `lg` while the drawer is open,
+    // close it so the cleanup below runs and the persistent sidebar takes over cleanly.
+    const handleViewportChange = (e: MediaQueryListEvent) => {
+      if (e.matches) setSidebarOpen(false);
+    };
+    mql.addEventListener('change', handleViewportChange);
+
     return () => {
       document.body.style.overflow = previousOverflow;
       document.removeEventListener('keydown', handleKey);
+      mql.removeEventListener('change', handleViewportChange);
+      opener?.focus();
     };
   }, [sidebarOpen, setSidebarOpen]);
 
@@ -114,6 +124,8 @@ export default function Sidebar({
         ref={drawerRef}
         id="sidebar-drawer"
         aria-label="Primary navigation"
+        role={sidebarOpen ? 'dialog' : undefined}
+        aria-modal={sidebarOpen ? true : undefined}
         className={cn(
           "h-screen w-64 fixed left-0 top-0 bg-background flex flex-col py-8 px-4 border-r border-outline-variant/15 z-50",
           "transition-transform duration-300 ease-out",

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
+import { motion, AnimatePresence } from 'motion/react';
 import {
   LayoutDashboard,
   ReceiptText,
@@ -14,9 +15,19 @@ interface SidebarProps {
   activeTab: string;
   onTabChange: (tab: string) => void;
   onAddTransaction: () => void;
+  sidebarOpen: boolean;
+  setSidebarOpen: (open: boolean) => void;
 }
 
-export default function Sidebar({ activeTab, onTabChange, onAddTransaction }: SidebarProps) {
+export default function Sidebar({
+  activeTab,
+  onTabChange,
+  onAddTransaction,
+  sidebarOpen,
+  setSidebarOpen,
+}: SidebarProps) {
+  const drawerRef = useRef<HTMLElement>(null);
+
   const navItems = [
     { id: 'dashboard', label: 'Dashboard', icon: LayoutDashboard },
     { id: 'transactions', label: 'Transactions', icon: ReceiptText },
@@ -26,55 +37,138 @@ export default function Sidebar({ activeTab, onTabChange, onAddTransaction }: Si
     { id: 'settings', label: 'Settings', icon: Settings },
   ];
 
+  const handleNavClick = (tabId: string) => {
+    onTabChange(tabId);
+    setSidebarOpen(false);
+  };
+
+  const handleAddClick = () => {
+    onAddTransaction();
+    setSidebarOpen(false);
+  };
+
+  // Body scroll lock + focus trap + Escape-to-close, only while drawer is open on small viewports.
+  // The `(min-width: 1024px)` query matches Tailwind's `lg` breakpoint — at and above it the
+  // sidebar is persistent and these effects must NOT run.
+  useEffect(() => {
+    if (!sidebarOpen) return;
+    const isDesktop = window.matchMedia('(min-width: 1024px)').matches;
+    if (isDesktop) return;
+
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+
+    const drawer = drawerRef.current;
+    const focusables = drawer
+      ? Array.from(
+          drawer.querySelectorAll<HTMLElement>(
+            'a, button, [tabindex]:not([tabindex="-1"]), input, select, textarea',
+          ),
+        ).filter((el) => !el.hasAttribute('disabled'))
+      : [];
+    const first = focusables[0];
+    const last = focusables[focusables.length - 1];
+    first?.focus();
+
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        setSidebarOpen(false);
+        return;
+      }
+      if (e.key !== 'Tab' || focusables.length === 0) return;
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+    document.addEventListener('keydown', handleKey);
+
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      document.removeEventListener('keydown', handleKey);
+    };
+  }, [sidebarOpen, setSidebarOpen]);
+
   return (
-    <aside className="h-screen w-64 fixed left-0 top-0 bg-background flex flex-col py-8 px-4 border-r border-outline-variant/15 z-50">
-      <div className="mb-10 px-2">
-        <h1 className="text-xl font-bold text-primary tracking-tight font-headline">Wealth Management</h1>
-        <p className="text-[10px] uppercase tracking-widest text-on-surface-variant mt-1 opacity-60">Private Banking</p>
-      </div>
+    <>
+      {/* Scrim — only renders < lg while drawer is open */}
+      <AnimatePresence>
+        {sidebarOpen && (
+          <motion.div
+            key="sidebar-scrim"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.2 }}
+            onClick={() => setSidebarOpen(false)}
+            className="fixed inset-0 z-40 bg-background/60 backdrop-blur-sm lg:hidden"
+            aria-hidden="true"
+          />
+        )}
+      </AnimatePresence>
 
-      <nav className="flex-1 space-y-2">
-        {navItems.map((item) => (
+      <aside
+        ref={drawerRef}
+        id="sidebar-drawer"
+        aria-label="Primary navigation"
+        className={cn(
+          "h-screen w-64 fixed left-0 top-0 bg-background flex flex-col py-8 px-4 border-r border-outline-variant/15 z-50",
+          "transition-transform duration-300 ease-out",
+          "lg:translate-x-0",
+          sidebarOpen ? "translate-x-0" : "-translate-x-full",
+        )}
+      >
+        <div className="mb-10 px-2">
+          <h1 className="text-xl font-bold text-primary tracking-tight font-headline">Wealth Management</h1>
+          <p className="text-[10px] uppercase tracking-widest text-on-surface-variant mt-1 opacity-60">Private Banking</p>
+        </div>
+
+        <nav className="flex-1 space-y-2">
+          {navItems.map((item) => (
+            <button
+              key={item.id}
+              onClick={() => handleNavClick(item.id)}
+              className={cn(
+                "w-full flex items-center gap-3 px-4 py-3 rounded-xl transition-all duration-300 scale-95 active:scale-90",
+                activeTab === item.id
+                  ? "text-primary font-bold border-r-2 border-primary bg-surface-container-high"
+                  : "text-on-surface-variant font-medium hover:bg-surface-container-high hover:text-primary"
+              )}
+            >
+              <item.icon size={20} />
+              <span className="text-sm">{item.label}</span>
+            </button>
+          ))}
+        </nav>
+
+        <div className="mt-auto px-2">
           <button
-            key={item.id}
-            onClick={() => onTabChange(item.id)}
-            className={cn(
-              "w-full flex items-center gap-3 px-4 py-3 rounded-xl transition-all duration-300 scale-95 active:scale-90",
-              activeTab === item.id 
-                ? "text-primary font-bold border-r-2 border-primary bg-surface-container-high" 
-                : "text-on-surface-variant font-medium hover:bg-surface-container-high hover:text-primary"
-            )}
+            onClick={handleAddClick}
+            className="w-full py-3 bg-gradient-to-br from-primary to-on-primary-container text-on-primary rounded-xl font-bold flex items-center justify-center gap-2 shadow-lg shadow-primary/10 hover:opacity-90 transition-opacity"
           >
-            <item.icon size={20} />
-            <span className="text-sm">{item.label}</span>
+            <Plus size={18} />
+            <span className="text-sm">Add Transaction</span>
           </button>
-        ))}
-      </nav>
 
-      <div className="mt-auto px-2">
-        <button 
-          onClick={onAddTransaction}
-          className="w-full py-3 bg-gradient-to-br from-primary to-on-primary-container text-on-primary rounded-xl font-bold flex items-center justify-center gap-2 shadow-lg shadow-primary/10 hover:opacity-90 transition-opacity"
-        >
-          <Plus size={18} />
-          <span className="text-sm">Add Transaction</span>
-        </button>
-
-        <div className="mt-6 flex items-center gap-3 pt-6 border-t border-outline-variant/15">
-          <div className="w-10 h-10 rounded-full overflow-hidden border border-primary/20">
-            <img 
-              src="https://picsum.photos/seed/executive/100/100" 
-              alt="User" 
-              className="w-full h-full object-cover"
-              referrerPolicy="no-referrer"
-            />
-          </div>
-          <div className="overflow-hidden">
-            <p className="text-sm font-bold text-white truncate">Julian Vance</p>
-            <p className="text-[10px] text-on-surface-variant truncate">Platinum Member</p>
+          <div className="mt-6 flex items-center gap-3 pt-6 border-t border-outline-variant/15">
+            <div className="w-10 h-10 rounded-full overflow-hidden border border-primary/20">
+              <img
+                src="https://picsum.photos/seed/executive/100/100"
+                alt="User"
+                className="w-full h-full object-cover"
+                referrerPolicy="no-referrer"
+              />
+            </div>
+            <div className="overflow-hidden">
+              <p className="text-sm font-bold text-white truncate">Julian Vance</p>
+              <p className="text-[10px] text-on-surface-variant truncate">Platinum Member</p>
+            </div>
           </div>
         </div>
-      </div>
-    </aside>
+      </aside>
+    </>
   );
 }

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -1,31 +1,49 @@
 import React from 'react';
-import { Search, Bell, UserCircle } from 'lucide-react';
+import { Search, Bell, UserCircle, Menu } from 'lucide-react';
 
-export default function TopBar() {
+interface TopBarProps {
+  onOpenSidebar: () => void;
+  sidebarOpen: boolean;
+}
+
+export default function TopBar({ onOpenSidebar, sidebarOpen }: TopBarProps) {
   return (
-    <header className="fixed top-0 right-0 left-64 h-16 z-40 bg-background/70 backdrop-blur-xl flex justify-between items-center px-8 border-b border-outline-variant/15">
-      <div className="flex items-center gap-6 flex-1 max-w-md">
+    <header
+      className="fixed top-0 right-0 left-0 lg:left-64 h-16 z-40 bg-background/70 backdrop-blur-xl flex justify-between items-center gap-4 px-4 lg:px-8 border-b border-outline-variant/15"
+      style={{ paddingTop: 'env(safe-area-inset-top)' }}
+    >
+      <div className="flex items-center gap-3 flex-1 md:max-w-md min-w-0">
+        <button
+          type="button"
+          onClick={onOpenSidebar}
+          aria-label="Open navigation"
+          aria-expanded={sidebarOpen}
+          aria-controls="sidebar-drawer"
+          className="lg:hidden flex items-center justify-center w-11 h-11 -ml-2 rounded-xl text-on-surface-variant hover:text-white hover:bg-surface-container-high transition-colors"
+        >
+          <Menu size={22} />
+        </button>
         <div className="relative w-full group">
           <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-on-surface-variant group-focus-within:text-primary transition-colors" size={18} />
-          <input 
-            className="w-full bg-surface-container-lowest border-none rounded-xl pl-10 pr-4 py-2 text-sm text-on-surface placeholder:text-on-surface-variant/40 focus:ring-1 focus:ring-primary/40 transition-all" 
-            placeholder="Search transactions, assets, or reports..." 
+          <input
+            className="w-full bg-surface-container-lowest border-none rounded-xl pl-10 pr-4 py-2 text-sm text-on-surface placeholder:text-on-surface-variant/40 focus:ring-1 focus:ring-primary/40 transition-all"
+            placeholder="Search transactions, assets, or reports..."
             type="text"
           />
         </div>
       </div>
 
-      <div className="flex items-center gap-6">
-        <div className="flex items-center gap-4">
-          <button className="text-on-surface-variant hover:text-white transition-colors relative">
+      <div className="flex items-center gap-3 sm:gap-6 shrink-0">
+        <div className="flex items-center gap-2 sm:gap-4">
+          <button className="text-on-surface-variant hover:text-white transition-colors relative w-11 h-11 flex items-center justify-center">
             <Bell size={20} />
-            <span className="absolute top-0 right-0 w-2 h-2 bg-primary rounded-full border-2 border-background"></span>
+            <span className="absolute top-2 right-2 w-2 h-2 bg-primary rounded-full border-2 border-background"></span>
           </button>
-          <button className="text-on-surface-variant hover:text-white transition-colors">
+          <button className="text-on-surface-variant hover:text-white transition-colors w-11 h-11 flex items-center justify-center">
             <UserCircle size={20} />
           </button>
         </div>
-        <span className="text-lg font-black text-white font-headline tracking-tight">Financial Gallery</span>
+        <span className="hidden sm:inline text-base lg:text-lg font-black text-white font-headline tracking-tight whitespace-nowrap">Financial Gallery</span>
       </div>
     </header>
   );

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -2,11 +2,11 @@ import React from 'react';
 import { Search, Bell, UserCircle, Menu } from 'lucide-react';
 
 interface TopBarProps {
-  onOpenSidebar: () => void;
+  onToggleSidebar: () => void;
   sidebarOpen: boolean;
 }
 
-export default function TopBar({ onOpenSidebar, sidebarOpen }: TopBarProps) {
+export default function TopBar({ onToggleSidebar, sidebarOpen }: TopBarProps) {
   return (
     <header
       className="fixed top-0 right-0 left-0 lg:left-64 h-16 z-40 bg-background/70 backdrop-blur-xl flex justify-between items-center gap-4 px-4 lg:px-8 border-b border-outline-variant/15"
@@ -15,8 +15,8 @@ export default function TopBar({ onOpenSidebar, sidebarOpen }: TopBarProps) {
       <div className="flex items-center gap-3 flex-1 md:max-w-md min-w-0">
         <button
           type="button"
-          onClick={onOpenSidebar}
-          aria-label="Open navigation"
+          onClick={onToggleSidebar}
+          aria-label={sidebarOpen ? 'Close navigation' : 'Open navigation'}
           aria-expanded={sidebarOpen}
           aria-controls="sidebar-drawer"
           className="lg:hidden flex items-center justify-center w-11 h-11 -ml-2 rounded-xl text-on-surface-variant hover:text-white hover:bg-surface-container-high transition-colors"


### PR DESCRIPTION
Follow-up to #16 — same Phase 1 mobile-responsive shell, plus the must-fix and recommended a11y polish from the review. If this looks good, merging this can supersede #16; otherwise the fix commit can be cherry-picked into #16's branch directly.

## Commits on this branch

1. **`feat(ui): mobile-responsive app shell with drawer sidebar`** — cherry-picked from #16, content-identical.
2. **`fix(ui): drawer a11y polish + viewport-resize leak`** — review feedback.

## Fixes layered on top

- **Viewport-resize side-effect leak.** When the drawer is open and the viewport crosses `lg` (1024 px), the original effect's `body { overflow: hidden }` and `keydown` trap stayed bound. Now subscribes to the media query and closes the drawer on cross-breakpoint change so the cleanup runs.
- **Restore focus to the trigger on close.** Captures `document.activeElement` when the drawer opens and re-focuses it on cleanup — standard WAI-ARIA disclosure/dialog pattern.
- **`role="dialog"` + `aria-modal="true"`** added to the `<aside>` while open, so screen readers treat it as modal in drawer mode. Persistent desktop landmark keeps default semantics.
- **Hamburger is now a toggle.** With the original "open-only" handler, tapping the hamburger while the drawer was open did nothing (TopBar paints over the scrim due to source-order at identical z-40, so the button is still hittable). `aria-label` now reflects open/close state too.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [ ] iPhone SE (375 × 667): hamburger toggle opens/closes, scrim/Esc/nav-click dismiss, focus returns to hamburger after close
- [ ] iPad Mini (768 × 1024): drawer behavior identical to phone
- [ ] Laptop (≥ 1024): persistent sidebar, no hamburger, no scroll lock when state was previously open at < lg
- [ ] **Regression check for the original leak**: open drawer at < lg → resize past 1024 px → confirm body scrolls and Escape no longer fires

Closes #14 (if merged in place of #16).

https://claude.ai/code/session_01HVYtAjDLHkq5MmEXhvzDPL

---
_Generated by [Claude Code](https://claude.ai/code/session_01HVYtAjDLHkq5MmEXhvzDPL)_