### PR TITLE
feat: surface deployed build metadata (#18)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,7 +5,6 @@
 
 node_modules
 dist
-.git
 .gitignore
 .env
 .env.*

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,8 @@ FROM node:22-bookworm AS builder
 
 WORKDIR /app
 
+RUN apt-get update && apt-get install -y --no-install-recommends git && rm -rf /var/lib/apt/lists/*
+
 # Vite inlines VITE_* env vars into the JS bundle at build time, so
 # they MUST be present in the builder stage env. Empty default is fine
 # — the frontend gates its map block on the key being truthy and
@@ -28,7 +30,9 @@ RUN npm ci
 
 # Copy everything the build needs. Keep this list explicit so that the
 # build context stays predictable (see .dockerignore for the blocklist).
+COPY .git ./.git
 COPY tsconfig.json vite.config.ts eslint.config.js index.html ./
+COPY scripts/ ./scripts/
 COPY src/ ./src/
 
 RUN npm run build
@@ -42,6 +46,8 @@ RUN apk add --no-cache gettext
 
 # Static bundle from the builder stage.
 COPY --from=builder /app/dist/ /usr/share/nginx/html/
+COPY --from=builder /app/src/generated/buildInfo.json /usr/share/nginx/html/version.json
+RUN chmod 644 /usr/share/nginx/html/version.json
 
 # nginx template — $BACKEND_URL is substituted at container start by the
 # default nginx entrypoint (/docker-entrypoint.d/20-envsubst-on-templates.sh).

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
+    "predev": "node scripts/generate-build-info.mjs",
     "dev": "vite",
+    "prebuild": "node scripts/generate-build-info.mjs",
     "build": "tsc && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",

--- a/scripts/generate-build-info.mjs
+++ b/scripts/generate-build-info.mjs
@@ -1,0 +1,36 @@
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const root = process.cwd();
+const pkg = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf8'));
+
+function run(cmd) {
+  try {
+    return execSync(cmd, { cwd: root, stdio: ['ignore', 'pipe', 'ignore'] }).toString().trim();
+  } catch {
+    return null;
+  }
+}
+
+const gitSha = process.env.GIT_SHA || run('git rev-parse HEAD') || 'unknown';
+const gitShortSha = process.env.GIT_SHORT_SHA || run('git rev-parse --short HEAD') || gitSha.slice(0, 7);
+const gitBranch = process.env.GIT_BRANCH || run('git rev-parse --abbrev-ref HEAD') || 'unknown';
+const builtAt = process.env.BUILD_TIME || new Date().toISOString();
+
+const payload = {
+  service: 'receipt-assistant-frontend',
+  version: pkg.version,
+  gitSha,
+  gitShortSha,
+  gitBranch,
+  builtAt,
+};
+
+const outDir = path.join(root, 'src', 'generated');
+fs.mkdirSync(outDir, { recursive: true });
+fs.writeFileSync(
+  path.join(outDir, 'buildInfo.ts'),
+  `export const buildInfo = ${JSON.stringify(payload, null, 2)} as const;\n`,
+);
+fs.writeFileSync(path.join(outDir, 'buildInfo.json'), `${JSON.stringify(payload, null, 2)}\n`);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,9 @@ import AddTransactionModal from './components/AddTransactionModal';
 import ProcessingToast from './components/ProcessingToast';
 import { useProcessingJobs } from './components/useProcessingJobs';
 import ReceiptDetail from './components/ReceiptDetail';
+import BuildInfoPanel from './components/BuildInfoPanel';
+import { buildInfo as frontendBuildInfo } from './generated/buildInfo';
+import { fetchBackendBuildInfo, type BuildInfo } from './lib/api';
 
 export default function App() {
   const [activeTab, setActiveTab] = React.useState('dashboard');
@@ -17,7 +20,12 @@ export default function App() {
   const [refreshKey, setRefreshKey] = React.useState(0);
   const [selectedReceiptId, setSelectedReceiptId] = React.useState<string | null>(null);
   const [selectedBatchId, setSelectedBatchId] = React.useState<string | null>(null);
+  const [backendBuildInfo, setBackendBuildInfo] = React.useState<BuildInfo | null>(null);
   const { jobs, addJob, removeJob } = useProcessingJobs();
+
+  React.useEffect(() => {
+    fetchBackendBuildInfo().then(setBackendBuildInfo).catch(() => setBackendBuildInfo(null));
+  }, []);
 
   const handleUploadComplete = (job: { batchId: string; ingestId: string; filename: string }) => {
     addJob(job);
@@ -70,15 +78,12 @@ export default function App() {
         return <YearlyReview />;
       case 'settings':
         return (
-          <div className="flex flex-col items-center justify-center h-[60vh] text-center space-y-4 animate-in fade-in duration-700">
-            <div className="w-20 h-20 rounded-full bg-surface-container-high flex items-center justify-center text-on-surface-variant">
-              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"/><circle cx="12" cy="12" r="3"/></svg>
+          <div className="space-y-6 animate-in fade-in duration-700">
+            <div className="space-y-2">
+              <h2 className="text-2xl font-bold text-white font-headline">Build & Deploy Info</h2>
+              <p className="text-on-surface-variant max-w-2xl">Use this to verify exactly which frontend and backend build is currently deployed.</p>
             </div>
-            <h2 className="text-2xl font-bold text-white font-headline">Account Settings</h2>
-            <p className="text-on-surface-variant max-w-md">Customize your private banking experience, manage security protocols, and configure AI-driven insights.</p>
-            <button className="px-6 py-2 bg-surface-container-high text-primary font-bold rounded-xl border border-primary/20 hover:bg-surface-container-highest transition-all">
-              Configure Profile
-            </button>
+            <BuildInfoPanel backendBuildInfo={backendBuildInfo} />
           </div>
         );
       default:
@@ -96,6 +101,11 @@ export default function App() {
           setActiveTab(tab);
         }}
         onAddTransaction={() => setIsModalOpen(true)}
+        rightSlot={
+          <span className="hidden xl:inline rounded-full border border-primary/20 bg-surface-container-high px-3 py-1 text-xs font-medium text-on-surface-variant">
+            {frontendBuildInfo.gitShortSha}
+          </span>
+        }
       >
         {renderContent()}
       </Layout>

--- a/src/components/BuildInfoPanel.tsx
+++ b/src/components/BuildInfoPanel.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { buildInfo as frontendBuildInfo } from '@/generated/buildInfo';
+
+export interface BuildInfoShape {
+  service: string;
+  version: string;
+  gitSha: string;
+  gitShortSha: string;
+  gitBranch: string;
+  builtAt: string;
+}
+
+function InfoRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-start justify-between gap-4 py-2 border-b border-outline-variant/10 last:border-b-0">
+      <span className="text-sm text-on-surface-variant">{label}</span>
+      <code className="text-sm text-white text-right break-all">{value}</code>
+    </div>
+  );
+}
+
+export default function BuildInfoPanel({ backendBuildInfo }: { backendBuildInfo: BuildInfoShape | null }) {
+  const cards = [
+    { title: 'Frontend', info: frontendBuildInfo },
+    { title: 'Backend', info: backendBuildInfo },
+  ];
+
+  return (
+    <div className="grid gap-4 lg:grid-cols-2 w-full max-w-5xl">
+      {cards.map((card) => (
+        <section key={card.title} className="rounded-2xl border border-outline-variant/20 bg-surface-container-low p-5 text-left">
+          <div className="flex items-center justify-between gap-3 mb-4">
+            <h3 className="text-lg font-bold text-white">{card.title}</h3>
+            <span className="px-2.5 py-1 rounded-full text-xs font-semibold bg-surface-container-high text-primary border border-primary/20">
+              {card.info ? `${card.info.version} (${card.info.gitShortSha})` : 'Unavailable'}
+            </span>
+          </div>
+          {card.info ? (
+            <div>
+              <InfoRow label="Service" value={card.info.service} />
+              <InfoRow label="Branch" value={card.info.gitBranch} />
+              <InfoRow label="Commit" value={card.info.gitSha} />
+              <InfoRow label="Built at" value={new Date(card.info.builtAt).toLocaleString()} />
+            </div>
+          ) : (
+            <p className="text-sm text-on-surface-variant">Backend build info unavailable.</p>
+          )}
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -7,9 +7,10 @@ interface LayoutProps {
   activeTab: string;
   onTabChange: (tab: string) => void;
   onAddTransaction: () => void;
+  rightSlot?: React.ReactNode;
 }
 
-export default function Layout({ children, activeTab, onTabChange, onAddTransaction }: LayoutProps) {
+export default function Layout({ children, activeTab, onTabChange, onAddTransaction, rightSlot }: LayoutProps) {
   const [sidebarOpen, setSidebarOpen] = useState(false);
 
   return (
@@ -22,7 +23,7 @@ export default function Layout({ children, activeTab, onTabChange, onAddTransact
         setSidebarOpen={setSidebarOpen}
       />
       <div className="flex-1 lg:ml-64 flex flex-col">
-        <TopBar onToggleSidebar={() => setSidebarOpen(!sidebarOpen)} sidebarOpen={sidebarOpen} />
+        <TopBar onToggleSidebar={() => setSidebarOpen(!sidebarOpen)} sidebarOpen={sidebarOpen} rightSlot={rightSlot} />
         <main className="flex-1 pt-24 pb-12 px-6 lg:px-10 overflow-x-hidden">
           {children}
         </main>

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -4,9 +4,10 @@ import { Search, Bell, UserCircle, Menu } from 'lucide-react';
 interface TopBarProps {
   onToggleSidebar: () => void;
   sidebarOpen: boolean;
+  rightSlot?: React.ReactNode;
 }
 
-export default function TopBar({ onToggleSidebar, sidebarOpen }: TopBarProps) {
+export default function TopBar({ onToggleSidebar, sidebarOpen, rightSlot }: TopBarProps) {
   return (
     <header
       className="fixed top-0 right-0 left-0 lg:left-64 h-16 z-40 bg-background/70 backdrop-blur-xl flex justify-between items-center gap-4 px-4 lg:px-8 border-b border-outline-variant/15"
@@ -43,7 +44,10 @@ export default function TopBar({ onToggleSidebar, sidebarOpen }: TopBarProps) {
             <UserCircle size={20} />
           </button>
         </div>
-        <span className="hidden sm:inline text-base lg:text-lg font-black text-white font-headline tracking-tight whitespace-nowrap">Financial Gallery</span>
+        <div className="flex items-center gap-3">
+          {rightSlot}
+          <span className="hidden sm:inline text-base lg:text-lg font-black text-white font-headline tracking-tight whitespace-nowrap">Financial Gallery</span>
+        </div>
       </div>
     </header>
   );

--- a/src/generated/buildInfo.json
+++ b/src/generated/buildInfo.json
@@ -1,0 +1,8 @@
+{
+  "service": "receipt-assistant-frontend",
+  "version": "0.0.0",
+  "gitSha": "a02db0161e2bfeb1e36f8cae5896ce5f90d162b0",
+  "gitShortSha": "a02db01",
+  "gitBranch": "main",
+  "builtAt": "2026-04-27T22:07:53.685Z"
+}

--- a/src/generated/buildInfo.ts
+++ b/src/generated/buildInfo.ts
@@ -1,0 +1,8 @@
+export const buildInfo = {
+  "service": "receipt-assistant-frontend",
+  "version": "0.0.0",
+  "gitSha": "a02db0161e2bfeb1e36f8cae5896ce5f90d162b0",
+  "gitShortSha": "a02db01",
+  "gitBranch": "main",
+  "builtAt": "2026-04-27T22:07:53.685Z"
+} as const;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -26,6 +26,15 @@ import type { Transaction } from '@/types';
 
 const client = createClient<paths>({ baseUrl: '/api' });
 
+export interface BuildInfo {
+  service: string;
+  version: string;
+  gitSha: string;
+  gitShortSha: string;
+  gitBranch: string;
+  builtAt: string;
+}
+
 // ── Backend type aliases (derived from the OpenAPI spec) ────────
 
 export type BackendTransaction = components['schemas']['Transaction'];
@@ -50,6 +59,14 @@ export type CreateTransactionRequest = components['schemas']['CreateTransactionR
 export type DocumentKind = components['schemas']['DocumentKind'];
 export type BatchStatus = components['schemas']['BatchStatus'];
 export type IngestStatus = components['schemas']['IngestStatus'];
+
+export async function fetchBackendBuildInfo(): Promise<BuildInfo> {
+  const response = await fetch('/api/version');
+  if (!response.ok) {
+    throw new Error(`fetchBackendBuildInfo failed (${response.status})`);
+  }
+  return response.json() as Promise<BuildInfo>;
+}
 
 /** An ETag-aware wrapper. Keep the ETag alongside the resource so PATCH
  *  / POST-void / DELETE calls can fill in `If-Match`. */


### PR DESCRIPTION
## Summary
- generate frontend build metadata automatically at build time
- publish deployed frontend metadata at /version.json
- show frontend/backend build info in the UI for verification

Closes #18

## Test plan
- [x] npm run build
- [x] docker compose up -d --build
- [x] curl http://localhost:8080/version.json
- [x] verify Build & Deploy Info renders in Settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)