### PR TITLE
chore: remove dead placeholder buttons + wire View All and TopBar search

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ export default function App() {
   const [selectedReceiptId, setSelectedReceiptId] = React.useState<string | null>(null);
   const [selectedBatchId, setSelectedBatchId] = React.useState<string | null>(null);
   const [backendBuildInfo, setBackendBuildInfo] = React.useState<BuildInfo | null>(null);
+  const [transactionsSearch, setTransactionsSearch] = React.useState('');
   const { jobs, addJob, removeJob } = useProcessingJobs();
 
   React.useEffect(() => {
@@ -73,9 +74,21 @@ export default function App() {
 
     switch (activeTab) {
       case 'dashboard':
-        return <Dashboard key={refreshKey} onSelectReceipt={handleSelectReceipt} />;
+        return (
+          <Dashboard
+            key={refreshKey}
+            onSelectReceipt={handleSelectReceipt}
+            onViewAllTransactions={() => setActiveTab('transactions')}
+          />
+        );
       case 'transactions':
-        return <Transactions key={refreshKey} onSelectReceipt={handleSelectReceipt} />;
+        return (
+          <Transactions
+            key={refreshKey}
+            onSelectReceipt={handleSelectReceipt}
+            searchQuery={transactionsSearch}
+          />
+        );
       case 'batches':
         return <Batches key={refreshKey} onSelectBatch={handleSelectBatch} />;
       case 'monthly':
@@ -93,7 +106,13 @@ export default function App() {
           </div>
         );
       default:
-        return <Dashboard key={refreshKey} onSelectReceipt={handleSelectReceipt} />;
+        return (
+          <Dashboard
+            key={refreshKey}
+            onSelectReceipt={handleSelectReceipt}
+            onViewAllTransactions={() => setActiveTab('transactions')}
+          />
+        );
     }
   };
 
@@ -104,9 +123,13 @@ export default function App() {
         onTabChange={(tab) => {
           setSelectedReceiptId(null);
           setSelectedBatchId(null);
+          setTransactionsSearch('');
           setActiveTab(tab);
         }}
         onAddTransaction={() => setIsModalOpen(true)}
+        showSearch={activeTab === 'transactions' && !selectedReceiptId}
+        searchQuery={transactionsSearch}
+        onSearchChange={setTransactionsSearch}
         rightSlot={
           <span className="hidden xl:inline rounded-full border border-primary/20 bg-surface-container-high px-3 py-1 text-xs font-medium text-on-surface-variant">
             {frontendBuildInfo.gitShortSha}

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -9,7 +9,6 @@ import {
   Car,
   ShoppingBag,
   Zap,
-  MoreHorizontal,
   Loader2
 } from 'lucide-react';
 import {
@@ -30,9 +29,10 @@ const CHART_COLORS = ['#4edea3', '#d0bcff', '#7bd0ff', '#ffb4ab', '#a8c7fa'];
 
 interface DashboardProps {
   onSelectReceipt?: (receiptId: string) => void;
+  onViewAllTransactions?: () => void;
 }
 
-export default function Dashboard({ onSelectReceipt }: DashboardProps) {
+export default function Dashboard({ onSelectReceipt, onViewAllTransactions }: DashboardProps) {
   const [transactions, setTransactions] = useState<Transaction[]>([]);
   const [summary, setSummary] = useState<SpendingSummary[]>([]);
   const [loading, setLoading] = useState(true);
@@ -111,9 +111,6 @@ export default function Dashboard({ onSelectReceipt }: DashboardProps) {
           <div className="bg-surface-container-high rounded-xl p-6 flex flex-col justify-between border border-outline-variant/5">
             <div className="flex justify-between items-start mb-4">
               <h4 className="text-sm font-bold text-white">Spending by Category</h4>
-              <button className="text-on-surface-variant hover:text-white transition-colors">
-                <MoreHorizontal size={18} />
-              </button>
             </div>
             {spendingData.length > 0 ? (
               <div className="h-32 w-full">
@@ -190,7 +187,13 @@ export default function Dashboard({ onSelectReceipt }: DashboardProps) {
         <div className="lg:col-span-7 bg-surface-container-low rounded-xl p-6 border border-outline-variant/5">
           <div className="flex justify-between items-center mb-6">
             <h4 className="font-headline font-bold text-white">Recent Activity</h4>
-            <button className="text-xs font-bold text-primary hover:underline">View All</button>
+            <button
+              type="button"
+              onClick={onViewAllTransactions}
+              className="text-xs font-bold text-primary hover:underline"
+            >
+              View All
+            </button>
           </div>
           {loading ? (
             <div className="flex items-center justify-center py-10">

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -8,9 +8,21 @@ interface LayoutProps {
   onTabChange: (tab: string) => void;
   onAddTransaction: () => void;
   rightSlot?: React.ReactNode;
+  showSearch?: boolean;
+  searchQuery?: string;
+  onSearchChange?: (q: string) => void;
 }
 
-export default function Layout({ children, activeTab, onTabChange, onAddTransaction, rightSlot }: LayoutProps) {
+export default function Layout({
+  children,
+  activeTab,
+  onTabChange,
+  onAddTransaction,
+  rightSlot,
+  showSearch,
+  searchQuery,
+  onSearchChange,
+}: LayoutProps) {
   const [sidebarOpen, setSidebarOpen] = useState(false);
 
   return (
@@ -23,7 +35,14 @@ export default function Layout({ children, activeTab, onTabChange, onAddTransact
         setSidebarOpen={setSidebarOpen}
       />
       <div className="flex-1 lg:ml-64 flex flex-col">
-        <TopBar onToggleSidebar={() => setSidebarOpen(!sidebarOpen)} sidebarOpen={sidebarOpen} rightSlot={rightSlot} />
+        <TopBar
+          onToggleSidebar={() => setSidebarOpen(!sidebarOpen)}
+          sidebarOpen={sidebarOpen}
+          rightSlot={rightSlot}
+          showSearch={showSearch}
+          searchQuery={searchQuery}
+          onSearchChange={onSearchChange}
+        />
         <main className="flex-1 pt-24 pb-12 px-6 lg:px-10 overflow-x-hidden">
           {children}
         </main>

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -1,13 +1,23 @@
 import React from 'react';
-import { Search, Bell, UserCircle, Menu } from 'lucide-react';
+import { Search, Menu } from 'lucide-react';
 
 interface TopBarProps {
   onToggleSidebar: () => void;
   sidebarOpen: boolean;
   rightSlot?: React.ReactNode;
+  showSearch?: boolean;
+  searchQuery?: string;
+  onSearchChange?: (q: string) => void;
 }
 
-export default function TopBar({ onToggleSidebar, sidebarOpen, rightSlot }: TopBarProps) {
+export default function TopBar({
+  onToggleSidebar,
+  sidebarOpen,
+  rightSlot,
+  showSearch = false,
+  searchQuery = '',
+  onSearchChange,
+}: TopBarProps) {
   return (
     <header
       className="fixed top-0 right-0 left-0 lg:left-64 h-16 z-40 bg-background/70 backdrop-blur-xl flex justify-between items-center gap-4 px-4 lg:px-8 border-b border-outline-variant/15"
@@ -24,30 +34,24 @@ export default function TopBar({ onToggleSidebar, sidebarOpen, rightSlot }: TopB
         >
           <Menu size={22} />
         </button>
-        <div className="relative w-full group">
-          <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-on-surface-variant group-focus-within:text-primary transition-colors" size={18} />
-          <input
-            className="w-full bg-surface-container-lowest border-none rounded-xl pl-10 pr-4 py-2 text-sm text-on-surface placeholder:text-on-surface-variant/40 focus:ring-1 focus:ring-primary/40 transition-all"
-            placeholder="Search transactions, assets, or reports..."
-            type="text"
-          />
-        </div>
+        {showSearch && (
+          <div className="relative w-full group">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-on-surface-variant group-focus-within:text-primary transition-colors" size={18} />
+            <input
+              data-testid="topbar-search"
+              className="w-full bg-surface-container-lowest border-none rounded-xl pl-10 pr-4 py-2 text-sm text-on-surface placeholder:text-on-surface-variant/40 focus:ring-1 focus:ring-primary/40 transition-all"
+              placeholder="Search transactions…"
+              type="text"
+              value={searchQuery}
+              onChange={(e) => onSearchChange?.(e.target.value)}
+            />
+          </div>
+        )}
       </div>
 
-      <div className="flex items-center gap-3 sm:gap-6 shrink-0">
-        <div className="flex items-center gap-2 sm:gap-4">
-          <button className="text-on-surface-variant hover:text-white transition-colors relative w-11 h-11 flex items-center justify-center">
-            <Bell size={20} />
-            <span className="absolute top-2 right-2 w-2 h-2 bg-primary rounded-full border-2 border-background"></span>
-          </button>
-          <button className="text-on-surface-variant hover:text-white transition-colors w-11 h-11 flex items-center justify-center">
-            <UserCircle size={20} />
-          </button>
-        </div>
-        <div className="flex items-center gap-3">
-          {rightSlot}
-          <span className="hidden sm:inline text-base lg:text-lg font-black text-white font-headline tracking-tight whitespace-nowrap">Financial Gallery</span>
-        </div>
+      <div className="flex items-center gap-3 shrink-0">
+        {rightSlot}
+        <span className="hidden sm:inline text-base lg:text-lg font-black text-white font-headline tracking-tight whitespace-nowrap">Financial Gallery</span>
       </div>
     </header>
   );

--- a/src/components/Transactions.tsx
+++ b/src/components/Transactions.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { TrendingDown, Filter, Utensils, Plane, Zap, Film, Landmark, ShoppingBag, Car, Loader2, Eye, EyeOff, RotateCcw, FileX } from 'lucide-react';
 import {
   fetchTransactions,
@@ -20,6 +20,7 @@ import DeletedBadge from './DeletedBadge';
 
 interface TransactionsProps {
   onSelectReceipt?: (receiptId: string) => void;
+  searchQuery?: string;
 }
 
 interface TombstoneRow {
@@ -28,7 +29,7 @@ interface TombstoneRow {
   doc?: BackendDocument;
 }
 
-export default function Transactions({ onSelectReceipt }: TransactionsProps) {
+export default function Transactions({ onSelectReceipt, searchQuery = '' }: TransactionsProps) {
   const [transactions, setTransactions] = useState<Transaction[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -90,7 +91,25 @@ export default function Transactions({ onSelectReceipt }: TransactionsProps) {
       .finally(() => setTombstoneLoading(false));
   }, [showDeleted, refreshKey]);
 
-  const totalExpenses = transactions
+  const filteredTransactions = useMemo(() => {
+    const q = searchQuery.trim().toLowerCase();
+    if (!q) return transactions;
+    return transactions.filter((tx) => {
+      const haystack = [
+        tx.description,
+        tx.category,
+        tx.date,
+        tx.paymentMethod,
+        tx.status,
+      ]
+        .filter(Boolean)
+        .join(' ')
+        .toLowerCase();
+      return haystack.includes(q);
+    });
+  }, [transactions, searchQuery]);
+
+  const totalExpenses = filteredTransactions
     .filter((tx) => tx.amount < 0)
     .reduce((sum, tx) => sum + tx.amount, 0);
 
@@ -186,7 +205,7 @@ export default function Transactions({ onSelectReceipt }: TransactionsProps) {
               <span className="text-2xl font-bold text-white font-headline">
                 {totalExpenses.toLocaleString('en-US', { style: 'currency', currency: 'USD' })}
               </span>
-              <span className="text-on-surface-variant text-xs">{transactions.length} transactions</span>
+              <span className="text-on-surface-variant text-xs">{filteredTransactions.length} transactions</span>
             </div>
           </div>
         </div>
@@ -300,6 +319,8 @@ export default function Transactions({ onSelectReceipt }: TransactionsProps) {
           <div className="text-center py-20 text-error">{error}</div>
         ) : transactions.length === 0 ? (
           <div className="text-center py-20 text-on-surface-variant">No transactions yet. Upload a receipt to get started.</div>
+        ) : filteredTransactions.length === 0 ? (
+          <div className="text-center py-20 text-on-surface-variant">No transactions match “{searchQuery}”.</div>
         ) : (
           <table className="w-full text-left border-collapse">
             <thead>
@@ -314,7 +335,7 @@ export default function Transactions({ onSelectReceipt }: TransactionsProps) {
               </tr>
             </thead>
             <tbody className="divide-y divide-outline-variant/5">
-              {transactions.map((tx) => (
+              {filteredTransactions.map((tx) => (
                 <tr
                   key={tx.id}
                   data-testid={`txn-row-${tx.id}`}

--- a/src/generated/buildInfo.json
+++ b/src/generated/buildInfo.json
@@ -1,8 +1,8 @@
 {
   "service": "receipt-assistant-frontend",
   "version": "0.0.0",
-  "gitSha": "012dc13768ba9ca3c5404fbdece98cabf6f807c5",
-  "gitShortSha": "012dc13",
+  "gitSha": "8c346c457fae159af013dac59ee81a4de6caedc3",
+  "gitShortSha": "8c346c4",
   "gitBranch": "main",
-  "builtAt": "2026-04-30T17:56:30.997Z"
+  "builtAt": "2026-05-11T01:45:04.945Z"
 }

--- a/src/generated/buildInfo.ts
+++ b/src/generated/buildInfo.ts
@@ -1,8 +1,8 @@
 export const buildInfo = {
   "service": "receipt-assistant-frontend",
   "version": "0.0.0",
-  "gitSha": "012dc13768ba9ca3c5404fbdece98cabf6f807c5",
-  "gitShortSha": "012dc13",
+  "gitSha": "8c346c457fae159af013dac59ee81a4de6caedc3",
+  "gitShortSha": "8c346c4",
   "gitBranch": "main",
-  "builtAt": "2026-04-30T17:56:30.997Z"
+  "builtAt": "2026-05-11T01:45:04.945Z"
 } as const;


### PR DESCRIPTION
## Summary

Cleanup pass over the frontend's "dead" UI — buttons that looked interactive but had no `onClick`. Three were removed because nothing on the roadmap backs them; two were wired up because the intent was clear and the wiring was just missing.

### Removed (no behavior, no follow-up)

- `Dashboard.tsx` — "Spending by Category" ⋯ menu (no semantics implied)
- `TopBar.tsx` — 🔔 bell button (was even rendering a fake red unread dot)
- `TopBar.tsx` — 👤 profile icon

### Wired up (real behavior, not removal)

- **`Dashboard.tsx` — "View All" button** in Recent Activity now switches the active tab to `transactions`. Reuses the existing tab state in `App.tsx`; no router needed.
- **`TopBar.tsx` — Search input** is now a controlled input that:
  - only renders on the Transactions tab (hidden on Dashboard / Uploads / Monthly / Yearly / Settings, and hidden inside Receipt Detail);
  - filters the loaded transactions client-side via `useMemo`, matching on `description / category / date / paymentMethod / status` (case-insensitive substring);
  - drives the `Total Expenses` total + transaction counter on the page (both recompute against the filtered set);
  - resets to empty on any tab change.

The decision to keep the search a Transactions-scoped local filter (rather than a global cross-screen search) was explicit. The original placeholder said "Search transactions, assets, or reports…" which implies a much bigger feature; this PR ships the realistic version.

## QA verdict — all green

Manual test plan run against `npm run dev` (50 fixtures across Dining/Fun/Shopping/Transport, statuses New Charge / Pending):

| Section | Coverage | Result |
|---|---|---|
| A — Dashboard "View All" navigation | A1–A4 | ✅ |
| B — Removed ⋯ menu | B1 | ✅ |
| C — Removed bell + profile | C1–C3 | ✅ |
| D — Search show/hide + filter + reset | D1–D13 | ✅ |
| E — Regression (row click, Show deleted, row ⋯, mobile drawer, console) | E1–E5, E7 | ✅ |

`npm run lint` clean. `npm run build` clean (tsc + vite build).

## Out of scope (intentional, with tracking)

- **Transactions filter chips** (`Date: All Time` / `Category: All` / `More Filters`) — kept as-is. The backend already exposes `occurred_from/to`, `amount_min/max_minor`, `payee_contains`, `q`, `status`, `has_document` etc., so wiring these is a real feature, not cleanup. Tracked in **#24**.
- **Newly uploaded older-than-50-most-recent receipt is invisible** — found during QA step E6. Pre-existing behavior caused by the table's `limit:50, sort:occurred_on desc` request; unrelated to this PR. Tracked in **#25** with two proposed fixes.
- Monthly / Yearly Review placeholder content (#23) and Dashboard category totals mismatch (#22) — already on file.

## Files

- `src/App.tsx` — lift `transactionsSearch` state; gate `showSearch` on `activeTab === 'transactions' && !selectedReceiptId`; pass `onViewAllTransactions` to Dashboard; reset search on tab change.
- `src/components/Dashboard.tsx` — wire View All; drop ⋯ button + `MoreHorizontal` import.
- `src/components/TopBar.tsx` — drop Bell + UserCircle; make search controlled and conditional.
- `src/components/Layout.tsx` — forward `showSearch` / `searchQuery` / `onSearchChange` to TopBar.
- `src/components/Transactions.tsx` — accept `searchQuery` prop; `useMemo` filter; "no match" empty state; counter + Total Expenses driven by filtered set.
- `src/generated/buildInfo.{ts,json}` — regenerated by `prebuild` hook (already in the tracked path).

## Test plan

- [x] `npm run lint`
- [x] `npm run build`
- [x] Manual QA — full A/B/C/D/E checklist (see above)
- [ ] Reviewer smoke test on a fresh `npm run dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)