### PR TITLE
fix: default Transactions sort to created_at desc so new uploads surface

### DIFF
--- a/src/generated/buildInfo.json
+++ b/src/generated/buildInfo.json
@@ -1,8 +1,8 @@
 {
   "service": "receipt-assistant-frontend",
   "version": "0.0.0",
-  "gitSha": "8c346c457fae159af013dac59ee81a4de6caedc3",
-  "gitShortSha": "8c346c4",
+  "gitSha": "2f0c53b69b1960849b45bbe385bd02b28080dfd2",
+  "gitShortSha": "2f0c53b",
   "gitBranch": "main",
-  "builtAt": "2026-05-11T01:45:04.945Z"
+  "builtAt": "2026-05-11T03:25:13.756Z"
 }

--- a/src/generated/buildInfo.ts
+++ b/src/generated/buildInfo.ts
@@ -1,8 +1,8 @@
 export const buildInfo = {
   "service": "receipt-assistant-frontend",
   "version": "0.0.0",
-  "gitSha": "8c346c457fae159af013dac59ee81a4de6caedc3",
-  "gitShortSha": "8c346c4",
+  "gitSha": "2f0c53b69b1960849b45bbe385bd02b28080dfd2",
+  "gitShortSha": "2f0c53b",
   "gitBranch": "main",
-  "builtAt": "2026-05-11T01:45:04.945Z"
+  "builtAt": "2026-05-11T03:25:13.756Z"
 } as const;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -376,7 +376,12 @@ export async function listTransactions(
 }
 
 /** High-level helper used by Transactions/Dashboard screens: returns
- *  the UI-row shape directly. */
+ *  the UI-row shape directly.
+ *
+ *  Default sort is `created_at desc` so freshly-uploaded receipts show
+ *  up at the top regardless of their `occurred_on` date — matches the
+ *  user's mental model after upload. Reports / monthly views should
+ *  call `listTransactions` directly with `sort: 'occurred_on'`. */
 export async function fetchTransactions(opts?: {
   from?: string;
   to?: string;
@@ -388,7 +393,7 @@ export async function fetchTransactions(opts?: {
     occurred_to: opts?.to,
     limit: opts?.limit,
     has_document: opts?.has_document,
-    sort: 'occurred_on',
+    sort: 'created_at',
     order: 'desc',
   });
   return items.map(mapTransaction);


### PR DESCRIPTION
## Summary

`fetchTransactions` (used by both the Transactions table and the Dashboard's Recent Activity) defaulted to `sort=occurred_on, order=desc`. That's the right shape for monthly / yearly reports — but it breaks the post-upload mental model: if you upload a receipt dated months ago, it lands at row 51+ in the latest-50 window and looks like nothing happened.

This PR switches the default to `created_at desc`. Newly-uploaded receipts now show up at the top regardless of their `occurred_on` date. Reports / monthly views that genuinely want `occurred_on` ordering can call the lower-level `listTransactions` directly with an explicit `sort` — the surface is unchanged.

Picks **Option A** from the issue. Option C (real pagination) is still the right long-term move and remains parked under #24.

Closes #25.

## Diff

One file, one default flipped:

```diff
- sort: 'occurred_on',
+ sort: 'created_at',
  order: 'desc',
```

(plus the `prebuild` hook bumping `src/generated/buildInfo.*` to the current main sha; no other code changes)

## Test plan

- [x] `npm run lint`
- [x] `npm run build`
- [ ] Reviewer: upload a receipt with a back-dated `occurred_on` (e.g. drop a 2025-09-30 fixture into the upload flow on a workspace whose 50 most-recent are all 2026 dated). Confirm the new row shows up at the top of the Transactions tab once processing completes.
- [ ] Reviewer: spot-check that Dashboard's Recent Activity still shows the 5 most-recent rows (now by `created_at`, which for steady-state usage looks identical to the old ordering on most fixtures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)