### PR TITLE
feat: wire Transactions filter chips to backend filter surface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ coverage/
 *.log
 .env*
 !.env.example
+test-reports/

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -87,6 +87,7 @@ export default function App() {
             key={refreshKey}
             onSelectReceipt={handleSelectReceipt}
             searchQuery={transactionsSearch}
+            onClearSearch={() => setTransactionsSearch('')}
           />
         );
       case 'batches':

--- a/src/components/Transactions.tsx
+++ b/src/components/Transactions.tsx
@@ -29,6 +29,11 @@ import {
 interface TransactionsProps {
   onSelectReceipt?: (receiptId: string) => void;
   searchQuery?: string;
+  /** Reset the top-bar search input. The search lives in App.tsx so
+   *  the table's `Clear filters` button needs a hook to reach it —
+   *  without this, the q parameter would survive a "clear all" click
+   *  even though the user clearly meant to wipe the slate. */
+  onClearSearch?: () => void;
 }
 
 interface TombstoneRow {
@@ -37,7 +42,7 @@ interface TombstoneRow {
   doc?: BackendDocument;
 }
 
-export default function Transactions({ onSelectReceipt, searchQuery = '' }: TransactionsProps) {
+export default function Transactions({ onSelectReceipt, searchQuery = '', onClearSearch }: TransactionsProps) {
   const [transactions, setTransactions] = useState<Transaction[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -259,7 +264,10 @@ export default function Transactions({ onSelectReceipt, searchQuery = '' }: Tran
           filters={filters}
           onChange={setFilters}
           hasActiveFilter={hasActiveFilter}
-          onClear={() => setFilters(DEFAULT_FILTERS)}
+          onClear={() => {
+            setFilters(DEFAULT_FILTERS);
+            onClearSearch?.();
+          }}
           showDeleted={showDeleted}
           onToggleShowDeleted={() => setShowDeleted((s) => !s)}
         />

--- a/src/components/Transactions.tsx
+++ b/src/components/Transactions.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { TrendingDown, Filter, Utensils, Plane, Zap, Film, Landmark, ShoppingBag, Car, Loader2, Eye, EyeOff, RotateCcw, FileX } from 'lucide-react';
+import { TrendingDown, Utensils, Plane, Zap, Film, Landmark, ShoppingBag, Car, Loader2, RotateCcw, FileX } from 'lucide-react';
 import {
   fetchTransactions,
   extractProblemMessage,
@@ -11,12 +11,20 @@ import {
   type BackendDocument,
 } from '../lib/api';
 import { listTombstones, removeTombstone } from '../lib/tombstones';
+import { useDebouncedValue } from '../lib/useDebouncedValue';
 import { cn } from '../lib/utils';
 import type { Transaction } from '../types';
 import TransactionRowMenu from './TransactionRowMenu';
 import ConfirmActionDialog from './ConfirmActionDialog';
 import UnreconcileDialog from './UnreconcileDialog';
 import DeletedBadge from './DeletedBadge';
+import TransactionsFilters from './TransactionsFilters';
+import {
+  DEFAULT_FILTERS,
+  effectiveDateRange,
+  isFilterActive,
+  type FilterState,
+} from '../lib/transactionsFilterState';
 
 interface TransactionsProps {
   onSelectReceipt?: (receiptId: string) => void;
@@ -45,13 +53,57 @@ export default function Transactions({ onSelectReceipt, searchQuery = '' }: Tran
   const [tombstones, setTombstones] = useState<TombstoneRow[]>([]);
   const [tombstoneLoading, setTombstoneLoading] = useState(false);
 
+  // Filter state. Server-side filters (date, status, payee, amount, q)
+  // trigger a re-fetch via the effect below; category filtering is
+  // applied client-side over the loaded page because the backend has
+  // no first-class category column.
+  const [filters, setFilters] = useState<FilterState>(DEFAULT_FILTERS);
+  const debouncedSearch = useDebouncedValue(searchQuery, 300);
+  const debouncedPayee = useDebouncedValue(filters.payeeContains, 300);
+  const debouncedAmountMin = useDebouncedValue(filters.amountMinDollars, 300);
+  const debouncedAmountMax = useDebouncedValue(filters.amountMaxDollars, 300);
+
+  // Stable per-filter-state derived range used in deps.
+  const dateRange = useMemo(() => effectiveDateRange(filters), [filters]);
+
+  const hasActiveFilter = isFilterActive(filters, searchQuery);
+
   useEffect(() => {
     setLoading(true);
-    fetchTransactions({ limit: 50, has_document: true })
-      .then(setTransactions)
+    const dollarsToMinor = (s: string): number | undefined => {
+      const trimmed = s.trim();
+      if (!trimmed) return undefined;
+      const n = Number(trimmed);
+      if (!Number.isFinite(n)) return undefined;
+      return Math.round(n * 100);
+    };
+    fetchTransactions({
+      limit: 50,
+      has_document: true,
+      q: debouncedSearch.trim() || undefined,
+      status: filters.status,
+      payee_contains: debouncedPayee.trim() || undefined,
+      amount_min_minor: dollarsToMinor(debouncedAmountMin),
+      amount_max_minor: dollarsToMinor(debouncedAmountMax),
+      from: dateRange.occurred_from,
+      to: dateRange.occurred_to,
+    })
+      .then((rows) => {
+        setTransactions(rows);
+        setError(null);
+      })
       .catch((e: unknown) => setError(extractProblemMessage(e)))
       .finally(() => setLoading(false));
-  }, [refreshKey]);
+  }, [
+    refreshKey,
+    debouncedSearch,
+    debouncedPayee,
+    debouncedAmountMin,
+    debouncedAmountMax,
+    filters.status,
+    dateRange.occurred_from,
+    dateRange.occurred_to,
+  ]);
 
   useEffect(() => {
     if (!showDeleted) {
@@ -91,23 +143,14 @@ export default function Transactions({ onSelectReceipt, searchQuery = '' }: Tran
       .finally(() => setTombstoneLoading(false));
   }, [showDeleted, refreshKey]);
 
+  // Server-side filters (q, date, status, payee, amount) already
+  // narrowed the result set; this memo only applies the client-side
+  // category filter on top.
   const filteredTransactions = useMemo(() => {
-    const q = searchQuery.trim().toLowerCase();
-    if (!q) return transactions;
-    return transactions.filter((tx) => {
-      const haystack = [
-        tx.description,
-        tx.category,
-        tx.date,
-        tx.paymentMethod,
-        tx.status,
-      ]
-        .filter(Boolean)
-        .join(' ')
-        .toLowerCase();
-      return haystack.includes(q);
-    });
-  }, [transactions, searchQuery]);
+    if (filters.categories.length === 0) return transactions;
+    const set = new Set<string>(filters.categories);
+    return transactions.filter((tx) => set.has(tx.category));
+  }, [transactions, filters.categories]);
 
   const totalExpenses = filteredTransactions
     .filter((tx) => tx.amount < 0)
@@ -211,30 +254,15 @@ export default function Transactions({ onSelectReceipt, searchQuery = '' }: Tran
         </div>
       </div>
 
-      <div className="flex flex-wrap gap-4">
-        <div className="bg-surface-container-high px-4 py-2 rounded-xl flex items-center gap-3 border border-outline-variant/15 text-sm font-medium text-white">
-          <span className="text-on-surface-variant">Date:</span> All Time
-        </div>
-        <div className="bg-surface-container-high px-4 py-2 rounded-xl flex items-center gap-3 border border-outline-variant/15 text-sm font-medium text-white">
-          <span className="text-on-surface-variant">Category:</span> All
-        </div>
-        <button
-          data-testid="toggle-show-deleted"
-          onClick={() => setShowDeleted((s) => !s)}
-          className={cn(
-            'px-4 py-2 rounded-xl flex items-center gap-2 border text-sm font-medium transition-colors',
-            showDeleted
-              ? 'bg-error/10 border-error/30 text-error'
-              : 'bg-surface-container-high border-outline-variant/15 text-white hover:border-outline-variant/30',
-          )}
-        >
-          {showDeleted ? <EyeOff size={16} /> : <Eye size={16} />}
-          {showDeleted ? 'Hide deleted' : 'Show deleted'}
-        </button>
-        <button className="ml-auto flex items-center gap-2 text-primary font-bold text-sm hover:opacity-80 transition-opacity">
-          <Filter size={16} />
-          More Filters
-        </button>
+      <div className="space-y-4">
+        <TransactionsFilters
+          filters={filters}
+          onChange={setFilters}
+          hasActiveFilter={hasActiveFilter}
+          onClear={() => setFilters(DEFAULT_FILTERS)}
+          showDeleted={showDeleted}
+          onToggleShowDeleted={() => setShowDeleted((s) => !s)}
+        />
       </div>
 
       {rowError && (
@@ -317,10 +345,16 @@ export default function Transactions({ onSelectReceipt, searchQuery = '' }: Tran
           </div>
         ) : error ? (
           <div className="text-center py-20 text-error">{error}</div>
-        ) : transactions.length === 0 ? (
-          <div className="text-center py-20 text-on-surface-variant">No transactions yet. Upload a receipt to get started.</div>
         ) : filteredTransactions.length === 0 ? (
-          <div className="text-center py-20 text-on-surface-variant">No transactions match “{searchQuery}”.</div>
+          hasActiveFilter ? (
+            <div className="text-center py-20 text-on-surface-variant">
+              No transactions match the current filters.
+            </div>
+          ) : (
+            <div className="text-center py-20 text-on-surface-variant">
+              No transactions yet. Upload a receipt to get started.
+            </div>
+          )
         ) : (
           <table className="w-full text-left border-collapse">
             <thead>

--- a/src/components/TransactionsFilters.tsx
+++ b/src/components/TransactionsFilters.tsx
@@ -1,0 +1,313 @@
+import { useEffect, useRef, useState } from 'react';
+import { Calendar, ChevronDown, Eye, EyeOff, Filter, Tag, X } from 'lucide-react';
+import { cn } from '../lib/utils';
+import {
+  DATE_PRESET_LABEL,
+  STATUS_OPTIONS,
+  type DatePreset,
+  type FilterState,
+} from '../lib/transactionsFilterState';
+import { CATEGORIES, type Category, type RawTransactionStatus } from '../types';
+
+/** Closes the popover when a click lands outside the wrapped element. */
+function useClickAway(onAway: () => void) {
+  const ref = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    const onDocClick = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        onAway();
+      }
+    };
+    document.addEventListener('mousedown', onDocClick);
+    return () => document.removeEventListener('mousedown', onDocClick);
+  }, [onAway]);
+  return ref;
+}
+
+interface TransactionsFiltersProps {
+  filters: FilterState;
+  onChange: (next: FilterState) => void;
+  hasActiveFilter: boolean;
+  onClear: () => void;
+  showDeleted: boolean;
+  onToggleShowDeleted: () => void;
+}
+
+export default function TransactionsFilters({
+  filters,
+  onChange,
+  hasActiveFilter,
+  onClear,
+  showDeleted,
+  onToggleShowDeleted,
+}: TransactionsFiltersProps) {
+  const [openPopover, setOpenPopover] = useState<'date' | 'category' | null>(null);
+  const [moreOpen, setMoreOpen] = useState(false);
+
+  const dateRef = useClickAway(() => setOpenPopover((p) => (p === 'date' ? null : p)));
+  const categoryRef = useClickAway(() => setOpenPopover((p) => (p === 'category' ? null : p)));
+
+  const dateLabel =
+    filters.datePreset === 'custom'
+      ? filters.customFrom || filters.customTo
+        ? `${filters.customFrom || '…'} → ${filters.customTo || '…'}`
+        : 'Custom range'
+      : DATE_PRESET_LABEL[filters.datePreset];
+
+  const categoryLabel =
+    filters.categories.length === 0
+      ? 'All'
+      : filters.categories.length === 1
+        ? filters.categories[0]
+        : `${filters.categories.length} selected`;
+
+  const toggleCategory = (c: Category) => {
+    onChange({
+      ...filters,
+      categories: filters.categories.includes(c)
+        ? filters.categories.filter((x) => x !== c)
+        : [...filters.categories, c],
+    });
+  };
+
+  return (
+    <>
+      <div className="flex flex-wrap gap-3 items-center">
+        {/* Date chip */}
+        <div ref={dateRef} className="relative">
+          <button
+            type="button"
+            data-testid="filter-date"
+            onClick={() => setOpenPopover((p) => (p === 'date' ? null : 'date'))}
+            className={cn(
+              'px-4 py-2 rounded-xl flex items-center gap-2 border text-sm font-medium transition-colors',
+              filters.datePreset !== 'all'
+                ? 'bg-primary/10 border-primary/30 text-primary'
+                : 'bg-surface-container-high border-outline-variant/15 text-white hover:border-outline-variant/30',
+            )}
+          >
+            <Calendar size={16} />
+            <span className="text-on-surface-variant">Date:</span> {dateLabel}
+            <ChevronDown size={14} />
+          </button>
+          {openPopover === 'date' && (
+            <div
+              data-testid="filter-date-popover"
+              className="absolute z-30 mt-2 left-0 min-w-[240px] bg-surface-container-highest border border-outline-variant/20 rounded-xl shadow-2xl p-2"
+            >
+              {(Object.keys(DATE_PRESET_LABEL) as DatePreset[]).map((preset) => (
+                <button
+                  type="button"
+                  key={preset}
+                  data-testid={`filter-date-${preset}`}
+                  onClick={() => {
+                    onChange({ ...filters, datePreset: preset });
+                    if (preset !== 'custom') setOpenPopover(null);
+                  }}
+                  className={cn(
+                    'w-full text-left px-3 py-2 rounded-lg text-sm transition-colors',
+                    filters.datePreset === preset
+                      ? 'bg-primary/15 text-primary font-bold'
+                      : 'text-white hover:bg-surface-container-high',
+                  )}
+                >
+                  {DATE_PRESET_LABEL[preset]}
+                </button>
+              ))}
+              {filters.datePreset === 'custom' && (
+                <div className="mt-2 pt-3 border-t border-outline-variant/15 px-1 space-y-2">
+                  <label className="block text-xs text-on-surface-variant">
+                    From
+                    <input
+                      type="date"
+                      data-testid="filter-date-custom-from"
+                      value={filters.customFrom}
+                      onChange={(e) => onChange({ ...filters, customFrom: e.target.value })}
+                      className="mt-1 w-full bg-surface-container-low border border-outline-variant/15 rounded-lg px-2 py-1.5 text-sm text-white"
+                    />
+                  </label>
+                  <label className="block text-xs text-on-surface-variant">
+                    To
+                    <input
+                      type="date"
+                      data-testid="filter-date-custom-to"
+                      value={filters.customTo}
+                      onChange={(e) => onChange({ ...filters, customTo: e.target.value })}
+                      className="mt-1 w-full bg-surface-container-low border border-outline-variant/15 rounded-lg px-2 py-1.5 text-sm text-white"
+                    />
+                  </label>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* Category chip */}
+        <div ref={categoryRef} className="relative">
+          <button
+            type="button"
+            data-testid="filter-category"
+            onClick={() => setOpenPopover((p) => (p === 'category' ? null : 'category'))}
+            className={cn(
+              'px-4 py-2 rounded-xl flex items-center gap-2 border text-sm font-medium transition-colors',
+              filters.categories.length > 0
+                ? 'bg-primary/10 border-primary/30 text-primary'
+                : 'bg-surface-container-high border-outline-variant/15 text-white hover:border-outline-variant/30',
+            )}
+          >
+            <Tag size={16} />
+            <span className="text-on-surface-variant">Category:</span> {categoryLabel}
+            <ChevronDown size={14} />
+          </button>
+          {openPopover === 'category' && (
+            <div
+              data-testid="filter-category-popover"
+              className="absolute z-30 mt-2 left-0 min-w-[220px] max-h-72 overflow-y-auto bg-surface-container-highest border border-outline-variant/20 rounded-xl shadow-2xl p-2"
+            >
+              {CATEGORIES.map((c) => {
+                const checked = filters.categories.includes(c);
+                return (
+                  <label
+                    key={c}
+                    data-testid={`filter-category-${c}`}
+                    className={cn(
+                      'flex items-center gap-2 px-3 py-2 rounded-lg text-sm cursor-pointer transition-colors',
+                      checked ? 'bg-primary/10 text-primary' : 'text-white hover:bg-surface-container-high',
+                    )}
+                  >
+                    <input
+                      type="checkbox"
+                      checked={checked}
+                      onChange={() => toggleCategory(c)}
+                      className="accent-primary"
+                    />
+                    {c}
+                  </label>
+                );
+              })}
+              {filters.categories.length > 0 && (
+                <button
+                  type="button"
+                  data-testid="filter-category-clear"
+                  onClick={() => onChange({ ...filters, categories: [] })}
+                  className="w-full mt-1 px-3 py-2 rounded-lg text-xs text-on-surface-variant hover:text-white hover:bg-surface-container-high transition-colors"
+                >
+                  Clear category selection
+                </button>
+              )}
+            </div>
+          )}
+        </div>
+
+        <button
+          type="button"
+          data-testid="toggle-show-deleted"
+          onClick={onToggleShowDeleted}
+          className={cn(
+            'px-4 py-2 rounded-xl flex items-center gap-2 border text-sm font-medium transition-colors',
+            showDeleted
+              ? 'bg-error/10 border-error/30 text-error'
+              : 'bg-surface-container-high border-outline-variant/15 text-white hover:border-outline-variant/30',
+          )}
+        >
+          {showDeleted ? <EyeOff size={16} /> : <Eye size={16} />}
+          {showDeleted ? 'Hide deleted' : 'Show deleted'}
+        </button>
+
+        {hasActiveFilter && (
+          <button
+            type="button"
+            data-testid="filter-clear-all"
+            onClick={onClear}
+            className="px-3 py-2 rounded-xl flex items-center gap-1 text-sm text-on-surface-variant hover:text-white transition-colors"
+          >
+            <X size={14} />
+            Clear filters
+          </button>
+        )}
+
+        <button
+          type="button"
+          data-testid="filter-more-toggle"
+          onClick={() => setMoreOpen((s) => !s)}
+          className={cn(
+            'ml-auto flex items-center gap-2 font-bold text-sm transition-opacity',
+            moreOpen ? 'text-white' : 'text-primary hover:opacity-80',
+          )}
+        >
+          <Filter size={16} />
+          {moreOpen ? 'Hide filters' : 'More Filters'}
+        </button>
+      </div>
+
+      {moreOpen && (
+        <div
+          data-testid="filter-more-panel"
+          className="grid grid-cols-1 md:grid-cols-4 gap-4 p-4 rounded-xl bg-surface-container-low border border-outline-variant/10"
+        >
+          <label className="block text-xs text-on-surface-variant">
+            Status
+            <select
+              data-testid="filter-status"
+              value={filters.status ?? ''}
+              onChange={(e) =>
+                onChange({
+                  ...filters,
+                  status: e.target.value === '' ? undefined : (e.target.value as RawTransactionStatus),
+                })
+              }
+              className="mt-1 w-full bg-surface-container-low border border-outline-variant/15 rounded-lg px-2 py-1.5 text-sm text-white"
+            >
+              <option value="">Any status</option>
+              {STATUS_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="block text-xs text-on-surface-variant">
+            Payee contains
+            <input
+              type="text"
+              data-testid="filter-payee"
+              value={filters.payeeContains}
+              onChange={(e) => onChange({ ...filters, payeeContains: e.target.value })}
+              placeholder="e.g. Costco"
+              className="mt-1 w-full bg-surface-container-low border border-outline-variant/15 rounded-lg px-2 py-1.5 text-sm text-white"
+            />
+          </label>
+
+          <label className="block text-xs text-on-surface-variant">
+            Min amount ($)
+            <input
+              type="number"
+              inputMode="decimal"
+              step="0.01"
+              data-testid="filter-amount-min"
+              value={filters.amountMinDollars}
+              onChange={(e) => onChange({ ...filters, amountMinDollars: e.target.value })}
+              placeholder="0.00"
+              className="mt-1 w-full bg-surface-container-low border border-outline-variant/15 rounded-lg px-2 py-1.5 text-sm text-white"
+            />
+          </label>
+
+          <label className="block text-xs text-on-surface-variant">
+            Max amount ($)
+            <input
+              type="number"
+              inputMode="decimal"
+              step="0.01"
+              data-testid="filter-amount-max"
+              value={filters.amountMaxDollars}
+              onChange={(e) => onChange({ ...filters, amountMaxDollars: e.target.value })}
+              placeholder="0.00"
+              className="mt-1 w-full bg-surface-container-low border border-outline-variant/15 rounded-lg px-2 py-1.5 text-sm text-white"
+            />
+          </label>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/generated/buildInfo.json
+++ b/src/generated/buildInfo.json
@@ -1,8 +1,8 @@
 {
   "service": "receipt-assistant-frontend",
   "version": "0.0.0",
-  "gitSha": "e2b71db93fff585a1934018535e3da0b5d62672b",
-  "gitShortSha": "e2b71db",
-  "gitBranch": "main",
-  "builtAt": "2026-05-11T03:36:45.535Z"
+  "gitSha": "1091a76389a3e01b9ad6fae0a4e0086dcf84aa34",
+  "gitShortSha": "1091a76",
+  "gitBranch": "feat/transactions-filters",
+  "builtAt": "2026-05-11T04:10:20.930Z"
 }

--- a/src/generated/buildInfo.json
+++ b/src/generated/buildInfo.json
@@ -1,8 +1,8 @@
 {
   "service": "receipt-assistant-frontend",
   "version": "0.0.0",
-  "gitSha": "2f0c53b69b1960849b45bbe385bd02b28080dfd2",
-  "gitShortSha": "2f0c53b",
+  "gitSha": "e2b71db93fff585a1934018535e3da0b5d62672b",
+  "gitShortSha": "e2b71db",
   "gitBranch": "main",
-  "builtAt": "2026-05-11T03:25:13.756Z"
+  "builtAt": "2026-05-11T03:36:45.535Z"
 }

--- a/src/generated/buildInfo.ts
+++ b/src/generated/buildInfo.ts
@@ -1,8 +1,8 @@
 export const buildInfo = {
   "service": "receipt-assistant-frontend",
   "version": "0.0.0",
-  "gitSha": "e2b71db93fff585a1934018535e3da0b5d62672b",
-  "gitShortSha": "e2b71db",
-  "gitBranch": "main",
-  "builtAt": "2026-05-11T03:36:45.535Z"
+  "gitSha": "1091a76389a3e01b9ad6fae0a4e0086dcf84aa34",
+  "gitShortSha": "1091a76",
+  "gitBranch": "feat/transactions-filters",
+  "builtAt": "2026-05-11T04:10:20.930Z"
 } as const;

--- a/src/generated/buildInfo.ts
+++ b/src/generated/buildInfo.ts
@@ -1,8 +1,8 @@
 export const buildInfo = {
   "service": "receipt-assistant-frontend",
   "version": "0.0.0",
-  "gitSha": "2f0c53b69b1960849b45bbe385bd02b28080dfd2",
-  "gitShortSha": "2f0c53b",
+  "gitSha": "e2b71db93fff585a1934018535e3da0b5d62672b",
+  "gitShortSha": "e2b71db",
   "gitBranch": "main",
-  "builtAt": "2026-05-11T03:25:13.756Z"
+  "builtAt": "2026-05-11T03:36:45.535Z"
 } as const;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -382,19 +382,34 @@ export async function listTransactions(
  *  up at the top regardless of their `occurred_on` date — matches the
  *  user's mental model after upload. Reports / monthly views should
  *  call `listTransactions` directly with `sort: 'occurred_on'`. */
-export async function fetchTransactions(opts?: {
+export interface FetchTransactionsOpts {
   from?: string;
   to?: string;
   limit?: number;
   has_document?: boolean;
-}): Promise<Transaction[]> {
+  // Extended filter surface used by the Transactions tab UI.
+  q?: string;
+  status?: BackendTransaction['status'];
+  payee_contains?: string;
+  amount_min_minor?: number;
+  amount_max_minor?: number;
+  sort?: 'occurred_on' | 'amount' | 'created_at';
+  order?: 'asc' | 'desc';
+}
+
+export async function fetchTransactions(opts?: FetchTransactionsOpts): Promise<Transaction[]> {
   const { items } = await listTransactions({
     occurred_from: opts?.from,
     occurred_to: opts?.to,
     limit: opts?.limit,
     has_document: opts?.has_document,
-    sort: 'created_at',
-    order: 'desc',
+    q: opts?.q,
+    status: opts?.status,
+    payee_contains: opts?.payee_contains,
+    amount_min_minor: opts?.amount_min_minor,
+    amount_max_minor: opts?.amount_max_minor,
+    sort: opts?.sort ?? 'created_at',
+    order: opts?.order ?? 'desc',
   });
   return items.map(mapTransaction);
 }

--- a/src/lib/transactionsFilterState.ts
+++ b/src/lib/transactionsFilterState.ts
@@ -1,0 +1,87 @@
+import type { Category, RawTransactionStatus } from '../types';
+
+export type DatePreset = 'all' | 'last_30d' | 'last_90d' | 'this_year' | 'custom';
+
+export interface FilterState {
+  datePreset: DatePreset;
+  // Only consulted when datePreset === 'custom'.
+  customFrom: string;
+  customTo: string;
+  // Empty array = all categories.
+  categories: Category[];
+  status?: RawTransactionStatus;
+  payeeContains: string;
+  // Dollars as user-entered strings; converted to minor units when querying.
+  amountMinDollars: string;
+  amountMaxDollars: string;
+}
+
+export const DEFAULT_FILTERS: FilterState = {
+  datePreset: 'all',
+  customFrom: '',
+  customTo: '',
+  categories: [],
+  status: undefined,
+  payeeContains: '',
+  amountMinDollars: '',
+  amountMaxDollars: '',
+};
+
+export const DATE_PRESET_LABEL: Record<DatePreset, string> = {
+  all: 'All time',
+  last_30d: 'Last 30 days',
+  last_90d: 'Last 90 days',
+  this_year: 'This year',
+  custom: 'Custom range',
+};
+
+export const STATUS_OPTIONS: { value: RawTransactionStatus; label: string }[] = [
+  { value: 'draft', label: 'Draft' },
+  { value: 'posted', label: 'Posted' },
+  { value: 'voided', label: 'Voided' },
+  { value: 'reconciled', label: 'Reconciled' },
+  { value: 'error', label: 'Error' },
+];
+
+/** Compute the ISO date range that should be sent to the backend
+ *  for a given filter state. Returns undefined values for "no bound". */
+export function effectiveDateRange(
+  filters: FilterState,
+  now: Date = new Date(),
+): { occurred_from?: string; occurred_to?: string } {
+  const ymd = (d: Date) => d.toISOString().slice(0, 10);
+  switch (filters.datePreset) {
+    case 'all':
+      return {};
+    case 'last_30d': {
+      const from = new Date(now);
+      from.setDate(from.getDate() - 30);
+      return { occurred_from: ymd(from), occurred_to: ymd(now) };
+    }
+    case 'last_90d': {
+      const from = new Date(now);
+      from.setDate(from.getDate() - 90);
+      return { occurred_from: ymd(from), occurred_to: ymd(now) };
+    }
+    case 'this_year': {
+      return { occurred_from: `${now.getFullYear()}-01-01`, occurred_to: ymd(now) };
+    }
+    case 'custom':
+      return {
+        occurred_from: filters.customFrom || undefined,
+        occurred_to: filters.customTo || undefined,
+      };
+  }
+}
+
+export function isFilterActive(filters: FilterState, q: string): boolean {
+  return (
+    filters.datePreset !== 'all' ||
+    filters.categories.length > 0 ||
+    filters.status !== undefined ||
+    filters.payeeContains.trim() !== '' ||
+    filters.amountMinDollars.trim() !== '' ||
+    filters.amountMaxDollars.trim() !== '' ||
+    q.trim() !== ''
+  );
+}

--- a/src/lib/useDebouncedValue.ts
+++ b/src/lib/useDebouncedValue.ts
@@ -1,0 +1,13 @@
+import { useEffect, useState } from 'react';
+
+/** Returns a copy of `value` that only updates after it has been
+ *  stable for `delayMs` milliseconds. Useful for debouncing text
+ *  inputs that drive network requests (search box, free-text filters). */
+export function useDebouncedValue<T>(value: T, delayMs = 300): T {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    const handle = setTimeout(() => setDebounced(value), delayMs);
+    return () => clearTimeout(handle);
+  }, [value, delayMs]);
+  return debounced;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,18 @@
-export type Category = 'Dining' | 'Transport' | 'Utilities' | 'Fun' | 'Income' | 'Shopping' | 'Housing' | 'Investments' | 'Travel' | 'Entertainment' | 'Real Estate';
+export const CATEGORIES = [
+  'Dining',
+  'Transport',
+  'Utilities',
+  'Fun',
+  'Income',
+  'Shopping',
+  'Housing',
+  'Investments',
+  'Travel',
+  'Entertainment',
+  'Real Estate',
+] as const;
+
+export type Category = typeof CATEGORIES[number];
 
 export type RawTransactionStatus =
   | 'draft'


### PR DESCRIPTION
## Summary

Replaces the three decorative filter affordances on the Transactions tab — the `Date: All Time` chip, the `Category: All` chip, and the `More Filters` button — with real, working filters backed by the existing `/v1/transactions` filter surface.

Also folds the top-bar `Search` input (shipped client-side as a stop-gap in [#26](https://github.com/TINKPA/receipt-assistant-frontend/pull/26)) into the same fetch pipeline as the backend's `q` parameter — so search now spans the whole workspace, not just the latest 50.

Closes #24.

## What changed

### Server-side filters (re-fetch on change; text inputs debounced 300ms)

| Filter | Backend param | UI |
|---|---|---|
| Date | `occurred_from` / `occurred_to` | Dropdown: All time / Last 30 days / Last 90 days / This year / Custom range |
| Status | `status` | Select inside More Filters |
| Payee | `payee_contains` | Text input inside More Filters |
| Amount range | `amount_min_minor` / `amount_max_minor` | Two numeric inputs inside More Filters (entered in dollars, converted on submit) |
| Top-bar Search | `q` | Existing controlled input from #26; just routed through `fetchTransactions` instead of `useMemo` |

### Client-side filter

- **Category** — multi-select over the loaded page. The backend has no first-class category column (the value lives in `transaction.metadata`), so this is local on purpose; a server-side filter would need its own backend change.

### UX

- Active chips render in the primary tint with a chevron affordance
- `Clear filters` button appears once any filter is active
- Empty-state copy distinguishes "No transactions yet" vs "No transactions match the current filters"
- All filters reset when the user switches tabs (uses the existing `searchQuery` reset path in `App.tsx`)

## Files

| File | Purpose |
|---|---|
| `src/components/TransactionsFilters.tsx` (new) | Chip / popover / panel UI |
| `src/lib/transactionsFilterState.ts` (new) | `FilterState`, `DEFAULT_FILTERS`, `effectiveDateRange`, `isFilterActive`. Split from the component file to satisfy `react-refresh/only-export-components` |
| `src/lib/useDebouncedValue.ts` (new) | 10-line debounce hook |
| `src/components/Transactions.tsx` | Wire in the new filters; rewrite the `useEffect` to refetch on filter / debounced-input changes; replace the substring `useMemo` with a category-only client filter |
| `src/lib/api.ts` | Extend `fetchTransactions` opts with `q` / `status` / `payee_contains` / `amount_min_minor` / `amount_max_minor` (existing callers untouched) |
| `src/types.ts` | Promote `Category` to a `CATEGORIES` const tuple so the multi-select has a runtime enumeration |
| `.gitignore` | Add `test-reports/` so local QA artifacts can't be accidentally committed |

## Out of scope (parked)

- A real backend category filter — would need a new column / metadata index. Not blocking the v1 UX.
- Paginated cursor / load-more — the table still fetches `limit=50` per refetch; filters narrow within that window. If your workspace has thousands of rows, filtered results may still be incomplete. Worth its own issue once the data set grows.
- Saved-filter presets and URL state — neither in the original #24 scope.

## Test plan

- [x] `npm run lint`
- [x] `npm run build`
- [ ] Reviewer manual QA — see the suggested checklist below.

### Suggested manual QA

> Backend on :3000 with ≥ 20 transactions spanning multiple dates, categories, and statuses.

**Date chip**
- [ ] Default chip reads `Date: All time`
- [ ] Open dropdown → preset list shows; clicking `Last 30 days` re-fetches; chip turns primary-tinted and reads `Last 30 days`
- [ ] Click `Custom range`; pickers appear; entering valid `From` / `To` re-fetches and rows narrow accordingly
- [ ] Clicking `All time` clears the date filter; chip returns to neutral

**Category chip**
- [ ] Default chip reads `Category: All`
- [ ] Multi-select two categories → only those rows remain; chip reads `2 selected`
- [ ] `Clear category selection` empties the multi-select; chip returns to `All`

**More Filters panel**
- [ ] Click `More Filters` → button label flips to `Hide filters`; inline panel appears with four fields
- [ ] Pick `Posted` status → list narrows on next debounce
- [ ] Type `costco` in `Payee contains` → list narrows after ~300 ms
- [ ] Enter `10` in min / `50` in max → list narrows to that range
- [ ] Clear all four → panel still open, list back to broader set (or the date/cat filter, if any)

**Top-bar search**
- [ ] Search input still only visible on Transactions tab
- [ ] Typing triggers a network call after ~300 ms (check DevTools Network tab — request includes `q=...`)
- [ ] Result set is no longer just-substring-over-50 — it can include rows that weren't in the unfiltered view

**Clear filters + empty state**
- [ ] Any single filter active → `Clear filters` button appears
- [ ] Click it → all filters reset; chip labels return to defaults; full list returns
- [ ] Apply filters that match zero rows → table shows `No transactions match the current filters.`
- [ ] On an empty workspace (or after `Hide deleted` so nothing's listed) → table shows `No transactions yet. Upload a receipt to get started.`

**Regression**
- [ ] `Show deleted` / `Hide deleted` toggle still works and is positioned correctly in the filter row
- [ ] Clicking a row still opens Receipt Detail
- [ ] Switching tabs resets the filter chips (datePreset = all, no categories, no status, etc.)
- [ ] `npm run dev` console clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)