### PR TITLE
fix(reports): align bucket key + chart labels with backend 'YYYY-MM'

### DIFF
--- a/src/components/MonthlyReview.tsx
+++ b/src/components/MonthlyReview.tsx
@@ -40,6 +40,19 @@ function sixMonthsAgo(d: Date): Date {
   return new Date(d.getFullYear(), d.getMonth() - 5, 1);
 }
 
+// Backend `/v1/reports/cashflow` and `/v1/reports/trends` bucket keys are
+// 'YYYY-MM' (TO_CHAR), so frontend keys + parsing must match that shape —
+// not 'YYYY-MM-DD', and never `new Date('YYYY-MM')` which is UTC-midnight
+// and shifts back a day in negative timezones.
+function yearMonthKey(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
+}
+
+function parseYearMonth(ym: string): Date {
+  const [y, m] = ym.split('-').map(Number);
+  return new Date(y, m - 1, 1);
+}
+
 interface CategoryRow {
   name: string;
   currentMinor: number;
@@ -96,8 +109,8 @@ export default function MonthlyReview() {
     return <div className="text-center py-20 text-error">{error}</div>;
   }
 
-  const thisBucket = cashflow?.buckets.find((b) => b.month === startOfMonth(now));
-  const lastBucket = cashflow?.buckets.find((b) => b.month === startOfMonth(prevMonth));
+  const thisBucket = cashflow?.buckets.find((b) => b.month === yearMonthKey(now));
+  const lastBucket = cashflow?.buckets.find((b) => b.month === yearMonthKey(prevMonth));
   const thisExpenseMinor = thisBucket?.expense_minor ?? 0;
   const lastExpenseMinor = lastBucket?.expense_minor ?? 0;
   const delta = thisExpenseMinor - lastExpenseMinor;
@@ -126,7 +139,7 @@ export default function MonthlyReview() {
 
   const trendData = (trends?.buckets ?? []).map((b) => ({
     bucket: b.bucket,
-    label: new Date(b.bucket).toLocaleDateString(undefined, { month: 'short' }),
+    label: parseYearMonth(b.bucket).toLocaleDateString(undefined, { month: 'short' }),
     spendMinor: Math.abs(b.total_minor),
   }));
 

--- a/src/components/YearlyReview.tsx
+++ b/src/components/YearlyReview.tsx
@@ -109,7 +109,12 @@ export default function YearlyReview() {
 
   const trendData = (trends?.buckets ?? []).map((b) => ({
     bucket: b.bucket,
-    label: new Date(b.bucket).toLocaleDateString(undefined, { month: 'short' }),
+    // Parse 'YYYY-MM' as local — `new Date('YYYY-MM')` is UTC-midnight
+    // and silently shifts back a day in negative timezones.
+    label: (() => {
+      const [y, m] = b.bucket.split('-').map(Number);
+      return new Date(y, m - 1, 1).toLocaleDateString(undefined, { month: 'short' });
+    })(),
     spendMinor: Math.abs(b.total_minor),
   }));
 


### PR DESCRIPTION
## Summary

The Monthly Performance page rendered Total Outflow / Income / Net all as `$0` even when transactions existed, and the trend chart's month labels were off-by-one in negative timezones (e.g. `2026-05` → `Apr`). Both bugs stem from the frontend mis-interpreting the backend's bucket key format.

## Steps to reproduce

1. Have any transactions in the current month.
2. Open the app → tap **Review** in the bottom nav.
3. Observe hero card "TOTAL MONTHLY OUTFLOW: \$0", "vs \$0 last month", INCOME \$0, NET \$0.
4. Observe bar chart labels: Nov, Jan, Feb, Mar, Apr (instead of Dec, Feb, Mar, Apr, May).

## Expected

- Hero shows actual sum of this month's expenses (e.g. \$796 / \$306).
- Bar chart month labels match the months returned by ``/v1/reports/trends``.

## Actual

- Hero shows \$0 / \$0 / \$0 even though `/v1/reports/cashflow` returns real data.
- Lower category breakdown (Groceries \$389, Other \$309, Dining \$98) renders correctly — so only hero/stat cards + chart axis are affected.

Live evidence (broken state) captured against backend cashflow returning:

\`\`\`json
{"month":"2026-05","income_minor":0,"expense_minor":78697,"net_minor":-78697}
\`\`\`

Frontend computed find-key was `"2026-05-01"` → no match → `undefined`.

## Root cause

`code/receipt-assistant-frontend/src/components/MonthlyReview.tsx:99-100` (pre-fix):

\`\`\`ts
const thisBucket = cashflow?.buckets.find((b) => b.month === startOfMonth(now));
\`\`\`

- `startOfMonth(now)` returns `"YYYY-MM-DD"` but backend's `/v1/reports/cashflow` returns `b.month` as `"YYYY-MM"` (see ``src/routes/reports.ts:388`` — `TO_CHAR(date_trunc('month', t.occurred_on), 'YYYY-MM')``). The strict `===` comparison never matches.
- Same file line 129 (and `YearlyReview.tsx:112`): `new Date(b.bucket).toLocaleDateString(...)` parses `"YYYY-MM"` as UTC midnight, which becomes the *previous month* in any negative timezone (verified in `America/Los_Angeles` — `new Date('2026-05')` → `Apr 30 2026 17:00 PDT`).

## Proposed fix / scope

- New `yearMonthKey(d)` helper in `MonthlyReview.tsx` that returns `'YYYY-MM'`, used for both `find()` comparisons.
- New `parseYearMonth(ym)` helper that splits the string and constructs a local `Date(y, m-1, 1)`, used for the chart's month-short label.
- Same TZ-safe parse inlined in `YearlyReview.tsx`'s `trendData.label`.

## Acceptance criteria

- [x] `Monthly Financial Performance` hero shows current month's expense sum (not \$0).
- [x] "+/- X% spending" badge appears when there is data.
- [x] INCOME / NET cards reflect `cashflow.buckets` for the current month.
- [x] Bar chart X-axis labels match the months in `/v1/reports/trends` response.
- [x] No regression in the `Where your money went this month` category breakdown.
- [x] Same TZ-safe parsing in `YearlyReview`.

## Test plan

- [x] Desktop (1500×1000) — verified broken hero `$0` reproduces, then verified fix in browser via chrome-devtools MCP.
- [x] Mobile (440×956 DPR3, iPhone 16 Pro Max UA) — same.
- [x] Trend chart labels confirmed `Dec / Feb / Mar / Apr / May` post-fix.
- [x] Rebuilt `receipt-assistant-frontend:local` and confirmed deployed container on `:8080` renders fix.

## Impact / Relation

User-visible: Monthly Performance was effectively unusable since #29 (mobile-first redesign) — the page existed but hero numbers were always \$0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)