### PR TITLE
feat(categories): 11→7 categories + transactionType dimension (#32)

### DIFF
--- a/src/categoryMeta.ts
+++ b/src/categoryMeta.ts
@@ -1,0 +1,44 @@
+import {
+  Utensils,
+  Bus,
+  ShoppingBag,
+  Plane,
+  Clapperboard,
+  HeartPulse,
+  Briefcase,
+  type LucideIcon,
+} from 'lucide-react';
+import type { Category } from './types';
+
+export interface CategoryMetaEntry {
+  color: string;
+  glyph: LucideIcon;
+}
+
+export const CATEGORY_META: Record<Category, CategoryMetaEntry> = {
+  'Food & Drinks': { color: '#FF8A3D', glyph: Utensils },
+  'Transportation': { color: '#3D8BFD', glyph: Bus },
+  'Shopping': { color: '#6E6E73', glyph: ShoppingBag },
+  'Travel': { color: '#34C759', glyph: Plane },
+  'Entertainment': { color: '#FF4D8F', glyph: Clapperboard },
+  'Health': { color: '#FF453A', glyph: HeartPulse },
+  'Services': { color: '#AF52DE', glyph: Briefcase },
+};
+
+const LEGACY_CATEGORY_MAP: Record<string, Category | null> = {
+  Dining: 'Food & Drinks',
+  Transport: 'Transportation',
+  Shopping: 'Shopping',
+  Travel: 'Travel',
+  Fun: 'Entertainment',
+  Entertainment: 'Entertainment',
+  Utilities: 'Services',
+  Housing: 'Services',
+  'Real Estate': 'Services',
+  Income: null,
+  Investments: null,
+};
+
+export function migrateLegacyCategory(legacy: string): Category | null {
+  return LEGACY_CATEGORY_MAP[legacy] ?? null;
+}

--- a/src/components/CategoryIcon.tsx
+++ b/src/components/CategoryIcon.tsx
@@ -1,16 +1,42 @@
+import { ArrowDownLeft, ArrowLeftRight, TrendingUp, Circle } from 'lucide-react';
 import { CATEGORY_META } from '../categoryMeta';
-import type { Category } from '../types';
+import type { Category, TransactionType } from '../types';
 
 interface CategoryIconProps {
-  category: Category;
+  category: Category | null;
+  transactionType?: TransactionType;
   size?: number;
 }
 
-export function CategoryIcon({ category, size = 44 }: CategoryIconProps) {
-  const meta = CATEGORY_META[category];
-  const Glyph = meta.glyph;
+const NON_SPENDING_META: Record<Exclude<TransactionType, 'spending'>, { color: string; glyph: typeof Circle }> = {
+  income: { color: '#34C759', glyph: ArrowDownLeft },
+  transfer: { color: '#8E8E93', glyph: ArrowLeftRight },
+  investment: { color: '#5856D6', glyph: TrendingUp },
+};
+
+export function CategoryIcon({ category, transactionType, size = 44 }: CategoryIconProps) {
   const radius = Math.round(size * 0.32);
   const glyphSize = Math.round(size * 0.55);
+
+  let color: string;
+  let Glyph: typeof Circle;
+  let label: string;
+
+  if (category) {
+    const meta = CATEGORY_META[category];
+    color = meta.color;
+    Glyph = meta.glyph;
+    label = category;
+  } else if (transactionType && transactionType !== 'spending') {
+    const meta = NON_SPENDING_META[transactionType];
+    color = meta.color;
+    Glyph = meta.glyph;
+    label = transactionType;
+  } else {
+    color = '#C7C7CC';
+    Glyph = Circle;
+    label = 'Uncategorized';
+  }
 
   return (
     <div
@@ -18,13 +44,13 @@ export function CategoryIcon({ category, size = 44 }: CategoryIconProps) {
         width: size,
         height: size,
         borderRadius: radius,
-        background: meta.color,
+        background: color,
         display: 'inline-flex',
         alignItems: 'center',
         justifyContent: 'center',
         flexShrink: 0,
       }}
-      aria-label={category}
+      aria-label={label}
     >
       <Glyph size={glyphSize} strokeWidth={2} color="#fff" />
     </div>

--- a/src/components/CategoryIcon.tsx
+++ b/src/components/CategoryIcon.tsx
@@ -1,0 +1,32 @@
+import { CATEGORY_META } from '../categoryMeta';
+import type { Category } from '../types';
+
+interface CategoryIconProps {
+  category: Category;
+  size?: number;
+}
+
+export function CategoryIcon({ category, size = 44 }: CategoryIconProps) {
+  const meta = CATEGORY_META[category];
+  const Glyph = meta.glyph;
+  const radius = Math.round(size * 0.32);
+  const glyphSize = Math.round(size * 0.55);
+
+  return (
+    <div
+      style={{
+        width: size,
+        height: size,
+        borderRadius: radius,
+        background: meta.color,
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        flexShrink: 0,
+      }}
+      aria-label={category}
+    >
+      <Glyph size={glyphSize} strokeWidth={2} color="#fff" />
+    </div>
+  );
+}

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,11 +1,23 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { fetchTransactions, fetchSummary, type SpendingSummary } from '../lib/api';
-import type { Transaction } from '../types';
+import {
+  fetchTransactions,
+  fetchSummary,
+  classifyBackendCategory,
+  type SpendingSummary,
+} from '../lib/api';
+import type { Transaction, Category } from '../types';
 import { cn } from '../lib/utils';
+import { CategoryIcon } from './CategoryIcon';
 
 interface DashboardProps {
   onSelectReceipt?: (receiptId: string) => void;
   onViewAllTransactions?: () => void;
+}
+
+interface SpendingCategorySlice {
+  category: Category;
+  total: number;
+  count: number;
 }
 
 /**
@@ -39,21 +51,31 @@ export default function Dashboard({ onSelectReceipt, onViewAllTransactions }: Da
       .finally(() => setLoading(false));
   }, [monthRange.from, monthRange.to]);
 
+  const spendingByCategory = useMemo<SpendingCategorySlice[]>(() => {
+    const buckets = new Map<Category, { total: number; count: number }>();
+    for (const item of summary) {
+      const { category, transactionType } = classifyBackendCategory(item.category);
+      if (transactionType !== 'spending' || !category) continue;
+      const amount = Math.abs(Number(item.total_spent));
+      const existing = buckets.get(category);
+      if (existing) {
+        existing.total += amount;
+        existing.count += item.count;
+      } else {
+        buckets.set(category, { total: amount, count: item.count });
+      }
+    }
+    return Array.from(buckets, ([category, v]) => ({ category, total: v.total, count: v.count }))
+      .sort((a, b) => b.total - a.total);
+  }, [summary]);
+
   const totalSpent = useMemo(
-    () => summary.reduce((s, c) => s + Math.abs(Number(c.total_spent)), 0),
-    [summary],
+    () => spendingByCategory.reduce((s, c) => s + c.total, 0),
+    [spendingByCategory],
   );
   const totalCount = useMemo(
-    () => summary.reduce((s, c) => s + c.count, 0),
-    [summary],
-  );
-
-  const topCats = useMemo(
-    () =>
-      [...summary]
-        .sort((a, b) => Math.abs(Number(b.total_spent)) - Math.abs(Number(a.total_spent)))
-        .slice(0, 4),
-    [summary],
+    () => spendingByCategory.reduce((s, c) => s + c.count, 0),
+    [spendingByCategory],
   );
 
   return (
@@ -63,8 +85,8 @@ export default function Dashboard({ onSelectReceipt, onViewAllTransactions }: Da
 
       <SpentCard amount={totalSpent} count={totalCount} loading={loading} />
 
-      <SectionTitle title="where it went" more={topCats.length > 4 ? 'see all →' : undefined} />
-      <CategoryGrid items={topCats} loading={loading} />
+      <SectionTitle title="where it went" />
+      <CategoryGrid items={spendingByCategory} loading={loading} />
 
       <SectionTitle
         title="recent"
@@ -205,16 +227,9 @@ function SectionTitle({
   );
 }
 
-/* ── Category grid (2×2) ─────────────────────────────────────── */
+/* ── Category grid (up to 7 spending categories) ─────────────── */
 
-const BLOB_COLORS = [
-  'var(--color-terracotta)',
-  'var(--color-sage)',
-  '#d4a574', /* sand */
-  '#b89d8a', /* earth */
-];
-
-function CategoryGrid({ items, loading }: { items: SpendingSummary[]; loading: boolean }) {
+function CategoryGrid({ items, loading }: { items: SpendingCategorySlice[]; loading: boolean }) {
   if (loading) {
     return (
       <div className="grid grid-cols-2 gap-3">
@@ -237,26 +252,22 @@ function CategoryGrid({ items, loading }: { items: SpendingSummary[]; loading: b
   }
   return (
     <div className="grid grid-cols-2 gap-3">
-      {items.map((c, i) => (
+      {items.map((c) => (
         <div
-          key={c.category + i}
+          key={c.category}
           className={cn(
             'rounded-[18px] p-4 min-h-[100px]',
             'border border-[var(--color-rule)] bg-[var(--color-surface)]',
             'flex flex-col justify-between',
           )}
         >
-          <span
-            aria-hidden="true"
-            className="block h-6 w-6 rounded-lg"
-            style={{ backgroundColor: BLOB_COLORS[i % BLOB_COLORS.length] }}
-          />
+          <CategoryIcon category={c.category} size={28} />
           <div>
             <p className="text-[13px] font-medium text-[var(--color-ink-muted)] mb-0.5">
-              {prettyCategory(c.category)}
+              {c.category}
             </p>
             <p className="font-display italic font-medium text-[1.375rem] leading-none tracking-tight tnum">
-              ${Math.round(Math.abs(Number(c.total_spent))).toLocaleString()}
+              ${Math.round(c.total).toLocaleString()}
             </p>
           </div>
         </div>
@@ -329,7 +340,7 @@ function RecentList({
             >
               <p className="text-[15px] font-medium truncate">{tx.description}</p>
               <p className="mt-0.5 text-xs text-[var(--color-ink-muted)] truncate">
-                {prettyCategory(tx.category)}
+                {prettyCategory(tx.category ?? tx.transactionType)}
               </p>
             </button>
             <span className="font-display italic font-medium text-[17px] tnum">

--- a/src/components/MonthlyReview.tsx
+++ b/src/components/MonthlyReview.tsx
@@ -9,6 +9,7 @@ import {
   YAxis,
 } from 'recharts';
 import {
+  classifyBackendCategory,
   extractProblemMessage,
   getCashflowReport,
   getSummaryReport,
@@ -17,7 +18,9 @@ import {
   type BackendSummaryReport,
   type BackendTrendsReport,
 } from '../lib/api';
+import type { Category } from '../types';
 import { cn } from '../lib/utils';
+import { CategoryIcon } from './CategoryIcon';
 
 function formatMoney(minor: number, currency = 'USD'): string {
   return (minor / 100).toLocaleString(undefined, {
@@ -54,7 +57,7 @@ function parseYearMonth(ym: string): Date {
 }
 
 interface CategoryRow {
-  name: string;
+  category: Category;
   currentMinor: number;
   previousMinor: number;
 }
@@ -118,22 +121,20 @@ export default function MonthlyReview() {
     lastExpenseMinor > 0 ? Math.round((delta / lastExpenseMinor) * 100) : null;
   const spendingDown = delta < 0;
 
-  // Merge this-month + last-month category summaries into rows.
+  // Merge this-month + last-month category summaries into rows, aggregated
+  // by the new 7-category model. Non-spending buckets (income/investment)
+  // are dropped — they belong on a separate flow view, not this one.
   const categoryRows: CategoryRow[] = (() => {
-    const map = new Map<string, CategoryRow>();
-    for (const it of thisMonth?.items ?? []) {
-      map.set(it.key || 'other', {
-        name: it.key || 'other',
-        currentMinor: it.total_minor,
-        previousMinor: 0,
-      });
-    }
-    for (const it of lastMonth?.items ?? []) {
-      const key = it.key || 'other';
-      const row = map.get(key) ?? { name: key, currentMinor: 0, previousMinor: 0 };
-      row.previousMinor = it.total_minor;
-      map.set(key, row);
-    }
+    const map = new Map<Category, CategoryRow>();
+    const addBucket = (key: string | undefined, minor: number, field: 'currentMinor' | 'previousMinor') => {
+      const { category, transactionType } = classifyBackendCategory(key);
+      if (transactionType !== 'spending' || !category) return;
+      const row = map.get(category) ?? { category, currentMinor: 0, previousMinor: 0 };
+      row[field] += minor;
+      map.set(category, row);
+    };
+    for (const it of thisMonth?.items ?? []) addBucket(it.key, it.total_minor, 'currentMinor');
+    for (const it of lastMonth?.items ?? []) addBucket(it.key, it.total_minor, 'previousMinor');
     return [...map.values()].sort((a, b) => b.currentMinor - a.currentMinor);
   })();
 
@@ -273,9 +274,12 @@ export default function MonthlyReview() {
                     : null;
                 const isOver = deltaPct != null && deltaPct > 0;
                 return (
-                  <div key={cat.name} className="space-y-3">
+                  <div key={cat.category} className="space-y-3">
                     <div className="flex justify-between items-center mb-1">
-                      <span className="text-sm font-bold text-white capitalize">{cat.name}</span>
+                      <span className="text-sm font-bold text-white flex items-center gap-2">
+                        <CategoryIcon category={cat.category} size={20} />
+                        {cat.category}
+                      </span>
                       <div className="text-right">
                         <span className="text-sm font-bold text-white">
                           {formatMoney(cat.currentMinor, currency)}

--- a/src/components/ReceiptDetail.tsx
+++ b/src/components/ReceiptDetail.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { APIProvider, Map, Marker } from '@vis.gl/react-google-maps';
 import {
+  classifyBackendCategory,
   fetchReceiptDetail,
   documentContentUrl,
   extractProblemMessage,
@@ -12,6 +13,7 @@ import {
   type BackendTransaction,
 } from '../lib/api';
 import { cn } from '../lib/utils';
+import { CategoryIcon } from './CategoryIcon';
 import EditReceiptModal from './EditReceiptModal';
 import ConfirmActionDialog from './ConfirmActionDialog';
 import DeleteReceiptDialog from './DeleteReceiptDialog';
@@ -441,9 +443,23 @@ function FieldsGrid({
           value={payment.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())}
         />
       )}
-      {category && (
-        <SmallFieldCard label="Category" value={category} />
-      )}
+      {category && <CategoryFieldCard rawCategory={category} />}
+    </div>
+  );
+}
+
+function CategoryFieldCard({ rawCategory }: { rawCategory: string }) {
+  const { category, transactionType } = classifyBackendCategory(rawCategory);
+  const label = category ?? (transactionType === 'spending' ? 'Uncategorized' : transactionType);
+  return (
+    <div className="rounded-[14px] border border-[var(--color-rule)] bg-[var(--color-surface)] px-4 py-3">
+      <p className="text-[11px] font-medium tracking-[0.14em] uppercase text-[var(--color-ink-muted)]">
+        Category
+      </p>
+      <div className="mt-1 flex items-center gap-2">
+        <CategoryIcon category={category} transactionType={transactionType} size={22} />
+        <span className="text-[15px] font-medium capitalize">{label}</span>
+      </div>
     </div>
   );
 }

--- a/src/components/Transactions.tsx
+++ b/src/components/Transactions.tsx
@@ -13,6 +13,7 @@ import { listTombstones, removeTombstone } from '../lib/tombstones';
 import { useDebouncedValue } from '../lib/useDebouncedValue';
 import { cn } from '../lib/utils';
 import type { Transaction } from '../types';
+import { CategoryIcon } from './CategoryIcon';
 import TransactionRowMenu from './TransactionRowMenu';
 import ConfirmActionDialog from './ConfirmActionDialog';
 import UnreconcileDialog from './UnreconcileDialog';
@@ -151,10 +152,17 @@ export default function Transactions({
   }, [showDeleted, refreshKey]);
 
   const filteredTransactions = useMemo(() => {
-    if (filters.categories.length === 0) return transactions;
-    const set = new Set<string>(filters.categories);
-    return transactions.filter((tx) => set.has(tx.category));
-  }, [transactions, filters.categories]);
+    let out = transactions;
+    if (filters.transactionTypes.length > 0) {
+      const typeSet = new Set(filters.transactionTypes);
+      out = out.filter((tx) => typeSet.has(tx.transactionType));
+    }
+    if (filters.categories.length > 0) {
+      const catSet = new Set<string>(filters.categories);
+      out = out.filter((tx) => tx.category !== null && catSet.has(tx.category));
+    }
+    return out;
+  }, [transactions, filters.categories, filters.transactionTypes]);
 
   const totalExpenses = filteredTransactions
     .filter((tx) => tx.amount < 0)
@@ -459,16 +467,13 @@ function LedgerRow({
         'rounded-[16px] border border-[var(--color-rule)] bg-[var(--color-surface)] p-3 pr-2',
       )}
     >
-      {/* Thumb */}
-      <div
-        className="relative h-12 w-12 rounded-[14px] flex-shrink-0"
-        style={{
-          background: hasDoc
-            ? 'linear-gradient(135deg, var(--color-butter), var(--color-paper-deep))'
-            : 'var(--color-paper-deep)',
-        }}
-        aria-hidden="true"
-      >
+      {/* Category icon (with optional has-receipt ✦ badge) */}
+      <div className="relative h-12 w-12 flex-shrink-0">
+        <CategoryIcon
+          category={tx.category}
+          transactionType={tx.transactionType}
+          size={48}
+        />
         {hasDoc && (
           <span
             className={cn(
@@ -496,7 +501,7 @@ function LedgerRow({
           {tx.description}
         </p>
         <p className="mt-0.5 text-[11px] tracking-[0.04em] uppercase text-[var(--color-ink-muted)] truncate">
-          {tx.category} · {formatDay(tx.date)}
+          {tx.category ?? tx.transactionType} · {formatDay(tx.date)}
           {tx.status !== 'New Charge' && ` · ${tx.status}`}
         </p>
       </button>

--- a/src/components/TransactionsFilters.tsx
+++ b/src/components/TransactionsFilters.tsx
@@ -6,7 +6,14 @@ import {
   type DatePreset,
   type FilterState,
 } from '../lib/transactionsFilterState';
-import { CATEGORIES, type Category, type RawTransactionStatus } from '../types';
+import {
+  CATEGORIES,
+  TRANSACTION_TYPES,
+  type Category,
+  type RawTransactionStatus,
+  type TransactionType,
+} from '../types';
+import { CategoryIcon } from './CategoryIcon';
 
 /** Closes the popover when a click lands outside the wrapped element. */
 function useClickAway(onAway: () => void) {
@@ -47,10 +54,11 @@ export default function TransactionsFilters({
   showDeleted,
   onToggleShowDeleted,
 }: TransactionsFiltersProps) {
-  const [openPopover, setOpenPopover] = useState<'date' | 'category' | null>(null);
+  const [openPopover, setOpenPopover] = useState<'date' | 'type' | 'category' | null>(null);
   const [moreOpen, setMoreOpen] = useState(false);
 
   const dateRef = useClickAway(() => setOpenPopover((p) => (p === 'date' ? null : p)));
+  const typeRef = useClickAway(() => setOpenPopover((p) => (p === 'type' ? null : p)));
   const categoryRef = useClickAway(() => setOpenPopover((p) => (p === 'category' ? null : p)));
 
   const dateLabel =
@@ -67,6 +75,13 @@ export default function TransactionsFilters({
         ? filters.categories[0]
         : `${filters.categories.length} selected`;
 
+  const typeLabel =
+    filters.transactionTypes.length === 0
+      ? 'All'
+      : filters.transactionTypes.length === 1
+        ? filters.transactionTypes[0]
+        : `${filters.transactionTypes.length} selected`;
+
   const toggleCategory = (c: Category) => {
     onChange({
       ...filters,
@@ -75,6 +90,20 @@ export default function TransactionsFilters({
         : [...filters.categories, c],
     });
   };
+
+  const toggleTransactionType = (t: TransactionType) => {
+    onChange({
+      ...filters,
+      transactionTypes: filters.transactionTypes.includes(t)
+        ? filters.transactionTypes.filter((x) => x !== t)
+        : [...filters.transactionTypes, t],
+    });
+  };
+
+  // Hide the category chip when transactionTypes filter is set but excludes
+  // 'spending' — categories only apply to spending rows.
+  const showCategoryChip =
+    filters.transactionTypes.length === 0 || filters.transactionTypes.includes('spending');
 
   return (
     <>
@@ -138,60 +167,116 @@ export default function TransactionsFilters({
           )}
         </div>
 
-        {/* Category chip */}
-        <div ref={categoryRef} className="relative">
+        {/* Transaction type chip */}
+        <div ref={typeRef} className="relative">
           <Chip
-            data-testid="filter-category"
-            active={filters.categories.length > 0}
-            onClick={() => setOpenPopover((p) => (p === 'category' ? null : 'category'))}
+            data-testid="filter-type"
+            active={filters.transactionTypes.length > 0}
+            onClick={() => setOpenPopover((p) => (p === 'type' ? null : 'type'))}
           >
-            <span className="text-[var(--color-ink-muted)] mr-1">Category:</span>
-            {categoryLabel}
+            <span className="text-[var(--color-ink-muted)] mr-1">Type:</span>
+            {typeLabel}
           </Chip>
-          {openPopover === 'category' && (
-            <Popover testid="filter-category-popover">
-              <div className="max-h-72 overflow-y-auto">
-                {CATEGORIES.map((c) => {
-                  const checked = filters.categories.includes(c);
-                  return (
-                    <label
-                      key={c}
-                      data-testid={`filter-category-${c}`}
-                      className={cn(
-                        'flex items-center gap-2 px-3 py-2 rounded-[10px] text-sm cursor-pointer transition-colors',
-                        checked
-                          ? 'bg-[var(--color-terracotta-soft)] text-[var(--color-terracotta-deep)]'
-                          : 'text-[var(--color-ink)] hover:bg-[var(--color-paper-deep)]',
-                      )}
-                    >
-                      <input
-                        type="checkbox"
-                        checked={checked}
-                        onChange={() => toggleCategory(c)}
-                        className="accent-[var(--color-terracotta)]"
-                      />
-                      {c}
-                    </label>
-                  );
-                })}
-              </div>
-              {filters.categories.length > 0 && (
+          {openPopover === 'type' && (
+            <Popover testid="filter-type-popover">
+              {TRANSACTION_TYPES.map((t) => {
+                const checked = filters.transactionTypes.includes(t);
+                return (
+                  <label
+                    key={t}
+                    data-testid={`filter-type-${t}`}
+                    className={cn(
+                      'flex items-center gap-2 px-3 py-2 rounded-[10px] text-sm cursor-pointer transition-colors capitalize',
+                      checked
+                        ? 'bg-[var(--color-terracotta-soft)] text-[var(--color-terracotta-deep)]'
+                        : 'text-[var(--color-ink)] hover:bg-[var(--color-paper-deep)]',
+                    )}
+                  >
+                    <input
+                      type="checkbox"
+                      checked={checked}
+                      onChange={() => toggleTransactionType(t)}
+                      className="accent-[var(--color-terracotta)]"
+                    />
+                    {t}
+                  </label>
+                );
+              })}
+              {filters.transactionTypes.length > 0 && (
                 <button
                   type="button"
-                  data-testid="filter-category-clear"
-                  onClick={() => onChange({ ...filters, categories: [] })}
+                  data-testid="filter-type-clear"
+                  onClick={() => onChange({ ...filters, transactionTypes: [] })}
                   className={cn(
                     'w-full mt-1 px-3 py-2 rounded-[10px] text-xs',
                     'text-[var(--color-ink-muted)] hover:text-[var(--color-ink)] hover:bg-[var(--color-paper-deep)]',
                     'transition-colors',
                   )}
                 >
-                  Clear category selection
+                  Clear type selection
                 </button>
               )}
             </Popover>
           )}
         </div>
+
+        {/* Category chip — hidden when transactionTypes excludes 'spending' */}
+        {showCategoryChip && (
+          <div ref={categoryRef} className="relative">
+            <Chip
+              data-testid="filter-category"
+              active={filters.categories.length > 0}
+              onClick={() => setOpenPopover((p) => (p === 'category' ? null : 'category'))}
+            >
+              <span className="text-[var(--color-ink-muted)] mr-1">Category:</span>
+              {categoryLabel}
+            </Chip>
+            {openPopover === 'category' && (
+              <Popover testid="filter-category-popover">
+                <div className="max-h-72 overflow-y-auto">
+                  {CATEGORIES.map((c) => {
+                    const checked = filters.categories.includes(c);
+                    return (
+                      <label
+                        key={c}
+                        data-testid={`filter-category-${c}`}
+                        className={cn(
+                          'flex items-center gap-2 px-3 py-2 rounded-[10px] text-sm cursor-pointer transition-colors',
+                          checked
+                            ? 'bg-[var(--color-terracotta-soft)] text-[var(--color-terracotta-deep)]'
+                            : 'text-[var(--color-ink)] hover:bg-[var(--color-paper-deep)]',
+                        )}
+                      >
+                        <input
+                          type="checkbox"
+                          checked={checked}
+                          onChange={() => toggleCategory(c)}
+                          className="accent-[var(--color-terracotta)]"
+                        />
+                        <CategoryIcon category={c} size={20} />
+                        {c}
+                      </label>
+                    );
+                  })}
+                </div>
+                {filters.categories.length > 0 && (
+                  <button
+                    type="button"
+                    data-testid="filter-category-clear"
+                    onClick={() => onChange({ ...filters, categories: [] })}
+                    className={cn(
+                      'w-full mt-1 px-3 py-2 rounded-[10px] text-xs',
+                      'text-[var(--color-ink-muted)] hover:text-[var(--color-ink)] hover:bg-[var(--color-paper-deep)]',
+                      'transition-colors',
+                    )}
+                  >
+                    Clear category selection
+                  </button>
+                )}
+              </Popover>
+            )}
+          </div>
+        )}
 
         <Chip
           data-testid="toggle-show-deleted"

--- a/src/components/YearlyReview.tsx
+++ b/src/components/YearlyReview.tsx
@@ -10,6 +10,7 @@ import {
   YAxis,
 } from 'recharts';
 import {
+  classifyBackendCategory,
   extractProblemMessage,
   getCashflowReport,
   getNetWorthReport,
@@ -20,7 +21,9 @@ import {
   type BackendSummaryReport,
   type BackendTrendsReport,
 } from '../lib/api';
+import type { Category } from '../types';
 import { cn } from '../lib/utils';
+import { CategoryIcon } from './CategoryIcon';
 
 function formatMoney(minor: number, currency = 'USD'): string {
   return (minor / 100).toLocaleString(undefined, {
@@ -118,7 +121,20 @@ export default function YearlyReview() {
     spendMinor: Math.abs(b.total_minor),
   }));
 
-  const maxCategoryMinor = summary?.items.reduce((m, it) => Math.max(m, it.total_minor), 0) ?? 1;
+  // Aggregate the year's category summary into the new 7-category model,
+  // dropping non-spending buckets (income/investment) so the "Category
+  // Breakdown" panel only shows actual outflows.
+  const spendingCategoryRows = (() => {
+    const buckets = new Map<Category, number>();
+    for (const it of summary?.items ?? []) {
+      const { category, transactionType } = classifyBackendCategory(it.key);
+      if (transactionType !== 'spending' || !category) continue;
+      buckets.set(category, (buckets.get(category) ?? 0) + it.total_minor);
+    }
+    return Array.from(buckets, ([category, total_minor]) => ({ category, total_minor }))
+      .sort((a, b) => b.total_minor - a.total_minor);
+  })();
+  const maxCategoryMinor = spendingCategoryRows.reduce((m, it) => Math.max(m, it.total_minor), 0) || 1;
 
   // Aggregate monthly cashflow into quarters.
   const quarterAgg = (cashflow?.buckets ?? []).reduce<Record<string, { inflow: number; outflow: number; net: number }>>(
@@ -240,15 +256,16 @@ export default function YearlyReview() {
           <p className="text-on-surface-variant text-xs mb-8">
             Top spending categories YTD
           </p>
-          {summary?.items.length === 0 ? (
+          {spendingCategoryRows.length === 0 ? (
             <p className="text-sm text-on-surface-variant">No spending data for this year yet.</p>
           ) : (
             <div className="space-y-5 flex-1">
-              {summary?.items.slice(0, 6).map((it) => (
-                <div key={it.key || 'other'} className="space-y-2">
+              {spendingCategoryRows.slice(0, 7).map((it) => (
+                <div key={it.category} className="space-y-2">
                   <div className="flex justify-between text-sm">
-                    <span className="text-on-surface font-medium capitalize">
-                      {it.key || 'Uncategorized'}
+                    <span className="text-on-surface font-medium flex items-center gap-2">
+                      <CategoryIcon category={it.category} size={20} />
+                      {it.category}
                     </span>
                     <span className="text-white font-bold">{formatMoney(it.total_minor, currency)}</span>
                   </div>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,7 +4,8 @@ export const TRANSACTIONS: Transaction[] = [
   {
     id: '1',
     description: 'The Gilded Fork',
-    category: 'Dining',
+    category: 'Food & Drinks',
+    transactionType: 'spending',
     date: 'Oct 24, 2023',
     paymentMethod: 'Amex Platinum',
     amount: -1240.00,
@@ -15,7 +16,8 @@ export const TRANSACTIONS: Transaction[] = [
   {
     id: '2',
     description: 'Delta Airlines',
-    category: 'Transport',
+    category: 'Travel',
+    transactionType: 'spending',
     date: 'Oct 22, 2023',
     paymentMethod: 'Bank Transfer',
     amount: -4850.30,
@@ -26,7 +28,8 @@ export const TRANSACTIONS: Transaction[] = [
   {
     id: '3',
     description: 'Grid Solutions LLC',
-    category: 'Utilities',
+    category: 'Services',
+    transactionType: 'spending',
     date: 'Oct 20, 2023',
     paymentMethod: 'Visa Signature',
     amount: -315.45,
@@ -37,7 +40,8 @@ export const TRANSACTIONS: Transaction[] = [
   {
     id: '4',
     description: 'Grand Cinema Premiere',
-    category: 'Fun',
+    category: 'Entertainment',
+    transactionType: 'spending',
     date: 'Oct 18, 2023',
     paymentMethod: 'Amex Platinum',
     amount: -85.00,
@@ -48,7 +52,8 @@ export const TRANSACTIONS: Transaction[] = [
   {
     id: '5',
     description: 'Dividends Payout',
-    category: 'Income',
+    category: null,
+    transactionType: 'income',
     date: 'Oct 15, 2023',
     paymentMethod: 'Investment Portfolio',
     amount: 12400.00,

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -105,33 +105,28 @@ export interface ReceiptView {
 
 // ── Frontend display mapping ────────────────────────────────────
 
-const CATEGORY_MAP: Record<string, Transaction['category']> = {
-  food: 'Dining',
-  dining: 'Dining',
-  restaurants: 'Dining',
-  groceries: 'Shopping',
-  transport: 'Transport',
-  shopping: 'Shopping',
-  utilities: 'Utilities',
-  entertainment: 'Entertainment',
-  health: 'Shopping',
-  education: 'Shopping',
-  travel: 'Travel',
-  other: 'Fun',
-};
+interface CategoryClassification {
+  category: Transaction['category'];
+  transactionType: Transaction['transactionType'];
+}
 
-const ICON_MAP: Record<string, string> = {
-  Dining: 'restaurant',
-  Transport: 'directions_car',
-  Shopping: 'shopping_bag',
-  Utilities: 'bolt',
-  Entertainment: 'theaters',
-  Travel: 'flight',
-  Fun: 'celebration',
-  Income: 'account_balance',
-  Housing: 'home',
-  Investments: 'trending_up',
-  'Real Estate': 'real_estate_agent',
+const CATEGORY_MAP: Record<string, CategoryClassification> = {
+  food: { category: 'Food & Drinks', transactionType: 'spending' },
+  dining: { category: 'Food & Drinks', transactionType: 'spending' },
+  restaurants: { category: 'Food & Drinks', transactionType: 'spending' },
+  groceries: { category: 'Food & Drinks', transactionType: 'spending' },
+  transport: { category: 'Transportation', transactionType: 'spending' },
+  shopping: { category: 'Shopping', transactionType: 'spending' },
+  utilities: { category: 'Services', transactionType: 'spending' },
+  entertainment: { category: 'Entertainment', transactionType: 'spending' },
+  fun: { category: 'Entertainment', transactionType: 'spending' },
+  health: { category: 'Health', transactionType: 'spending' },
+  education: { category: 'Services', transactionType: 'spending' },
+  travel: { category: 'Travel', transactionType: 'spending' },
+  housing: { category: 'Services', transactionType: 'spending' },
+  income: { category: null, transactionType: 'income' },
+  investments: { category: null, transactionType: 'investment' },
+  real_estate: { category: null, transactionType: 'investment' },
 };
 
 function normalizeCategoryKey(raw: string | null | undefined): string | null {
@@ -208,8 +203,8 @@ export function toReceiptView(t: BackendTransaction, etag: string | null = null)
 export function mapTransaction(t: BackendTransaction): Transaction {
   const rv = toReceiptView(t);
   const rawCat = normalizeCategoryKey(rv.category);
-  const category: Transaction['category'] =
-    (rawCat ? CATEGORY_MAP[rawCat] : undefined) ?? 'Fun';
+  const classification: CategoryClassification =
+    (rawCat ? CATEGORY_MAP[rawCat] : undefined) ?? { category: null, transactionType: 'spending' };
   const status: Transaction['status'] =
     t.status === 'draft' || t.status === 'error' ? 'Pending'
     : t.status === 'voided' ? 'Pending'
@@ -218,14 +213,15 @@ export function mapTransaction(t: BackendTransaction): Transaction {
   return {
     id: t.id,
     description: rv.payee ?? rv.narration ?? 'Unknown',
-    category,
+    category: classification.category,
+    transactionType: classification.transactionType,
     date: rv.occurred_on,
     paymentMethod: rv.paymentMethod ?? 'Unknown',
-    // UI convention: expenses render as negative.
-    amount: -rv.total,
+    // UI convention: expenses render as negative; income stays positive.
+    amount: classification.transactionType === 'income' ? rv.total : -rv.total,
     status,
-    icon: ICON_MAP[category] ?? 'receipt',
-    color: 'primary',
+    icon: '',
+    color: '',
     rawStatus: t.status,
     documentId: rv.documentId,
   };

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -105,9 +105,17 @@ export interface ReceiptView {
 
 // ── Frontend display mapping ────────────────────────────────────
 
-interface CategoryClassification {
+export interface CategoryClassification {
   category: Transaction['category'];
   transactionType: Transaction['transactionType'];
+}
+
+/** Classify a raw backend category string into our 7-category + transactionType
+ *  model. Used by mapTransaction (per-row) and by aggregate consumers
+ *  (e.g. Dashboard summary) that get raw category strings from the backend. */
+export function classifyBackendCategory(raw: string | null | undefined): CategoryClassification {
+  const key = normalizeCategoryKey(raw);
+  return (key ? CATEGORY_MAP[key] : undefined) ?? { category: null, transactionType: 'spending' };
 }
 
 const CATEGORY_MAP: Record<string, CategoryClassification> = {

--- a/src/lib/transactionsFilterState.ts
+++ b/src/lib/transactionsFilterState.ts
@@ -1,4 +1,4 @@
-import type { Category, RawTransactionStatus } from '../types';
+import type { Category, RawTransactionStatus, TransactionType } from '../types';
 
 export type DatePreset = 'all' | 'last_30d' | 'last_90d' | 'this_year' | 'custom';
 
@@ -9,6 +9,9 @@ export interface FilterState {
   customTo: string;
   // Empty array = all categories.
   categories: Category[];
+  // Empty array = all transaction types. When set without 'spending',
+  // category filter has no effect and the category chip is hidden in UI.
+  transactionTypes: TransactionType[];
   status?: RawTransactionStatus;
   payeeContains: string;
   // Dollars as user-entered strings; converted to minor units when querying.
@@ -21,6 +24,7 @@ export const DEFAULT_FILTERS: FilterState = {
   customFrom: '',
   customTo: '',
   categories: [],
+  transactionTypes: [],
   status: undefined,
   payeeContains: '',
   amountMinDollars: '',
@@ -78,6 +82,7 @@ export function isFilterActive(filters: FilterState, q: string): boolean {
   return (
     filters.datePreset !== 'all' ||
     filters.categories.length > 0 ||
+    filters.transactionTypes.length > 0 ||
     filters.status !== undefined ||
     filters.payeeContains.trim() !== '' ||
     filters.amountMinDollars.trim() !== '' ||

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,18 +1,23 @@
 export const CATEGORIES = [
-  'Dining',
-  'Transport',
-  'Utilities',
-  'Fun',
-  'Income',
+  'Food & Drinks',
+  'Transportation',
   'Shopping',
-  'Housing',
-  'Investments',
   'Travel',
   'Entertainment',
-  'Real Estate',
+  'Health',
+  'Services',
 ] as const;
 
 export type Category = typeof CATEGORIES[number];
+
+export const TRANSACTION_TYPES = [
+  'spending',
+  'income',
+  'transfer',
+  'investment',
+] as const;
+
+export type TransactionType = typeof TRANSACTION_TYPES[number];
 
 export type RawTransactionStatus =
   | 'draft'
@@ -24,12 +29,16 @@ export type RawTransactionStatus =
 export interface Transaction {
   id: string;
   description: string;
-  category: Category;
+  /** Null when transactionType !== 'spending'. */
+  category: Category | null;
+  transactionType: TransactionType;
   date: string;
   paymentMethod: string;
   amount: number;
   status: 'Verified' | 'Pending' | 'New Charge' | 'Surplus' | 'Peak' | 'Processing';
+  /** @deprecated icon/color now derived from category via CATEGORY_META. Retained for unmigrated callers. */
   icon: string;
+  /** @deprecated see icon. */
   color: string;
   /** The raw backend status (before UI normalization). Needed for delete /
    *  unreconcile menus that branch on `posted` vs `reconciled` etc. */


### PR DESCRIPTION
Closes #32.

## Summary
- Replace 11-entry `CATEGORIES` (`Dining`, `Transport`, `Utilities`, `Fun`, `Income`, `Shopping`, `Housing`, `Investments`, `Travel`, `Entertainment`, `Real Estate`) with the 7-entry Apple-Wallet-aligned set: `Food & Drinks`, `Transportation`, `Shopping`, `Travel`, `Entertainment`, `Health`, `Services`.
- Add `transactionType` dimension (`spending` / `income` / `transfer` / `investment`) on `Transaction`. `category` is now nullable; only meaningful for spending rows.
- New `CategoryIcon` component: rounded-square colored container + white Lucide glyph. Drives the visual identity of every category surface — list rows, filters, dashboard cells, reviews, ReceiptDetail.
- New exported `classifyBackendCategory(raw)` in `lib/api.ts` maps raw backend category strings to `{ category, transactionType }`. Used by every aggregate consumer.

## What changes for the user
- **Ledger row**: left-side butter-gradient receipt thumbnail → colored CategoryIcon. ✦ has-receipt badge preserved as corner overlay.
- **Ledger filters**: new "Type" chip (4 checkboxes for transaction types) added before "Category" chip. Category chip hides automatically when type filter excludes Spending. Category popover rows now show inline icons.
- **Dashboard "where it went"**: aggregates by classified Category, drops Income/Investment from the spending total (fixes long-standing Income contamination), shows colored icon per cell.
- **MonthlyReview**: category comparison rows render the new icon next to each name; non-spending buckets dropped from the comparison.
- **YearlyReview**: Category Breakdown ranks the 7 spending categories with icons (expanded from top-6 since we now have exactly 7).
- **ReceiptDetail**: Category field card replaced with one that shows CategoryIcon + classified label, gracefully handles non-spending rows.

## What didn't change in this PR
- Backend schema still has the legacy category strings. This PR only changes the frontend's reading + display layer; backend migration is `TINKPA/receipt-assistant#64`.
- Inline category quick-edit popover (referenced in #35 ReceiptDetail redesign) is a separate follow-up.
- Dashboard 7-cell layout: kept the 2-column grid, which now wraps to ~4 rows for 7 categories. Per #32 the final 4+3 vs scroller decision is a deferred design pass.
- Status union (`Verified | Pending | New Charge | ...`) and the `Surplus`/`Peak` leak are addressed separately in #35.
- `icon` / `color` fields on `Transaction` are marked `@deprecated` but kept so unmigrated callers don't break. Can be removed after #35 + #33 land.

## Commits
1. `feat(categories): foundation for 7-category + transactionType system (#32)` — types, categoryMeta, CategoryIcon, constants, lib/api mapping
2. `feat(categories): wire CategoryIcon + transactionType filter into Ledger (#32)` — Transactions list rows + filters
3. `feat(categories): Dashboard 'where it went' aggregates by new 7-category (#32)` — exported classifier, aggregation, icon-driven grid
4. `feat(categories): wire 7-category aggregation into Reviews + ReceiptDetail (#32)` — MonthlyReview, YearlyReview, ReceiptDetail FieldsGrid

## Test plan
- [ ] `npm run lint` — passes clean (verified locally, 0 warnings)
- [ ] `npm run build` — passes clean (verified locally)
- [ ] Open Ledger; verify each row's left icon is colored per its category; income mock row shows the green income variant
- [ ] Open filters; click "Type"; toggle Income only → Category chip disappears
- [ ] Toggle Type back to all; click Category; pick Food & Drinks → only Dining-equivalent rows remain
- [ ] Dashboard "where it went" shows 1-7 cells, each with its colored icon; total no longer includes Income
- [ ] MonthlyReview & YearlyReview category sections show icons; rows are spending-only
- [ ] Open any receipt; Category cell shows icon + label

🤖 Generated with [Claude Code](https://claude.com/claude-code)