### PR TITLE
feat(merchant): MerchantDetail page + ledger tap navigation reversal (#33)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import Capture from './components/Capture';
 import ProcessingToast from './components/ProcessingToast';
 import { useProcessingJobs } from './components/useProcessingJobs';
 import ReceiptDetail from './components/ReceiptDetail';
+import MerchantDetail from './components/MerchantDetail';
 import BuildInfoPanel from './components/BuildInfoPanel';
 import { fetchBackendBuildInfo, type BuildInfo } from './lib/api';
 
@@ -36,6 +37,7 @@ export default function App() {
   const [refreshKey, setRefreshKey] = React.useState(0);
   const [selectedReceiptId, setSelectedReceiptId] = React.useState<string | null>(null);
   const [selectedBatchId, setSelectedBatchId] = React.useState<string | null>(null);
+  const [selectedMerchantBrandId, setSelectedMerchantBrandId] = React.useState<string | null>(null);
   const [backendBuildInfo, setBackendBuildInfo] = React.useState<BuildInfo | null>(null);
   const [transactionsSearch, setTransactionsSearch] = React.useState('');
   const { jobs, addJob, removeJob } = useProcessingJobs();
@@ -54,6 +56,7 @@ export default function App() {
   const goToTab = (tab: ActiveTab) => {
     setSelectedReceiptId(null);
     setSelectedBatchId(null);
+    setSelectedMerchantBrandId(null);
     setTransactionsSearch('');
     setActiveTab(tab);
   };
@@ -70,6 +73,11 @@ export default function App() {
   const handleBackFromDetail = () => setSelectedReceiptId(null);
   const handleSelectBatch = (batchId: string) => setSelectedBatchId(batchId);
   const handleBackFromBatch = () => setSelectedBatchId(null);
+  const handleSelectMerchant = (brandId: string) => {
+    setSelectedReceiptId(null);
+    setSelectedMerchantBrandId(brandId);
+  };
+  const handleBackFromMerchant = () => setSelectedMerchantBrandId(null);
 
   const renderContent = () => {
     if (activeTab === 'add') {
@@ -86,7 +94,19 @@ export default function App() {
         <ReceiptDetail
           receiptId={selectedReceiptId}
           onBack={handleBackFromDetail}
+          onSelectMerchant={handleSelectMerchant}
           onAfterMutation={() => setRefreshKey((k) => k + 1)}
+        />
+      );
+    }
+
+    if (selectedMerchantBrandId) {
+      return (
+        <MerchantDetail
+          key={selectedMerchantBrandId}
+          brandId={selectedMerchantBrandId}
+          onBack={handleBackFromMerchant}
+          onSelectReceipt={handleSelectReceipt}
         />
       );
     }
@@ -107,6 +127,7 @@ export default function App() {
           <Dashboard
             key={refreshKey}
             onSelectReceipt={handleSelectReceipt}
+            onSelectMerchant={handleSelectMerchant}
             onViewAllTransactions={() => setActiveTab('transactions')}
           />
         );
@@ -115,6 +136,7 @@ export default function App() {
           <Transactions
             key={refreshKey}
             onSelectReceipt={handleSelectReceipt}
+            onSelectMerchant={handleSelectMerchant}
             searchQuery={transactionsSearch}
             onSearchChange={setTransactionsSearch}
             onClearSearch={() => setTransactionsSearch('')}

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -12,6 +12,7 @@ import { CategoryIcon } from './CategoryIcon';
 
 interface DashboardProps {
   onSelectReceipt?: (receiptId: string) => void;
+  onSelectMerchant?: (brandId: string) => void;
   onViewAllTransactions?: () => void;
 }
 
@@ -32,7 +33,7 @@ interface SpendingCategorySlice {
  * there is no /budget endpoint on the backend yet. The big spend card stands
  * on its own without an invented number.
  */
-export default function Dashboard({ onSelectReceipt, onViewAllTransactions }: DashboardProps) {
+export default function Dashboard({ onSelectReceipt, onSelectMerchant, onViewAllTransactions }: DashboardProps) {
   const [transactions, setTransactions] = useState<Transaction[]>([]);
   const [summary, setSummary] = useState<SpendingSummary[]>([]);
   const [loading, setLoading] = useState(true);
@@ -97,7 +98,13 @@ export default function Dashboard({ onSelectReceipt, onViewAllTransactions }: Da
       <RecentList
         items={transactions}
         loading={loading}
-        onSelect={onSelectReceipt}
+        onSelect={(tx) => {
+          if (tx.merchantBrandId && onSelectMerchant) {
+            onSelectMerchant(tx.merchantBrandId);
+          } else {
+            onSelectReceipt?.(tx.id);
+          }
+        }}
       />
     </div>
   );
@@ -286,7 +293,7 @@ function RecentList({
 }: {
   items: Transaction[];
   loading: boolean;
-  onSelect?: (id: string) => void;
+  onSelect?: (tx: Transaction) => void;
 }) {
   if (loading) {
     return (
@@ -332,7 +339,7 @@ function RecentList({
             </span>
             <button
               type="button"
-              onClick={() => !isProcessing && onSelect?.(tx.id)}
+              onClick={() => !isProcessing && onSelect?.(tx)}
               disabled={isProcessing}
               className={cn(
                 'text-left min-w-0',

--- a/src/components/MerchantDetail.tsx
+++ b/src/components/MerchantDetail.tsx
@@ -1,0 +1,262 @@
+import { useEffect, useState } from 'react';
+import {
+  extractProblemMessage,
+  fetchMerchant,
+  fetchMerchantTransactions,
+  type MerchantDetailResponse,
+  type MerchantTransactionRow,
+} from '../lib/api';
+import { CATEGORY_META } from '../categoryMeta';
+import type { Category } from '../types';
+import { cn } from '../lib/utils';
+import { CategoryIcon } from './CategoryIcon';
+import { statusBadge } from '../lib/transactionStatus';
+
+interface MerchantDetailProps {
+  brandId: string;
+  onBack: () => void;
+  onSelectReceipt?: (receiptId: string) => void;
+}
+
+export default function MerchantDetail({ brandId, onBack, onSelectReceipt }: MerchantDetailProps) {
+  const [detail, setDetail] = useState<MerchantDetailResponse | null>(null);
+  const [txns, setTxns] = useState<MerchantTransactionRow[] | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    Promise.all([
+      fetchMerchant(brandId),
+      fetchMerchantTransactions(brandId, { limit: 100 }),
+    ])
+      .then(([d, t]) => {
+        if (cancelled) return;
+        setDetail(d);
+        setTxns(t.items);
+        setLoading(false);
+      })
+      .catch((e: unknown) => {
+        if (cancelled) return;
+        setError(extractProblemMessage(e));
+        setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [brandId]);
+
+  if (loading) {
+    return (
+      <div className="space-y-4">
+        <BackBar onBack={onBack} />
+        <p className="py-16 text-center font-hand text-xl text-[var(--color-ink-muted)]">loading…</p>
+      </div>
+    );
+  }
+
+  if (error || !detail) {
+    return (
+      <div className="space-y-4">
+        <BackBar onBack={onBack} />
+        <div className="rounded-[18px] border border-[var(--color-rule)] bg-[var(--color-surface)] py-12 text-center text-[var(--color-stamp)]">
+          {error || 'Merchant not found'}
+        </div>
+      </div>
+    );
+  }
+
+  const m = detail.merchant;
+  const category = (m.category as Category | null) ?? null;
+  const meta = category ? CATEGORY_META[category] : null;
+  const heroBg = meta?.color ?? '#C7C7CC';
+
+  return (
+    <div className="space-y-6 pb-24">
+      <BackBar onBack={onBack} />
+
+      {/* Hero */}
+      <div
+        className="relative rounded-[20px] overflow-hidden h-[180px] sm:h-[220px] flex items-end p-5"
+        style={
+          m.photo_url
+            ? {
+                backgroundImage: `linear-gradient(180deg, transparent 0%, rgba(0,0,0,0.55) 100%), url(${m.photo_url})`,
+                backgroundSize: 'cover',
+                backgroundPosition: 'center',
+              }
+            : { background: heroBg }
+        }
+      >
+        {!m.photo_url && category && (
+          <div className="absolute inset-0 flex items-center justify-center pointer-events-none opacity-25">
+            <CategoryIcon category={category} size={120} />
+          </div>
+        )}
+        <div className="relative z-10">
+          {category && (
+            <p className="text-[11px] tracking-[0.18em] uppercase font-medium text-white/85">
+              {category}
+            </p>
+          )}
+          <h1 className={cn(
+            'font-display italic font-medium text-3xl sm:text-4xl leading-tight tracking-tight',
+            m.photo_url ? 'text-white' : 'text-white',
+          )}>
+            {m.canonical_name}
+          </h1>
+        </div>
+        {m.photo_url && m.photo_attribution && (
+          <p className="absolute right-3 bottom-2 z-10 text-[10px] text-white/70">
+            {m.photo_attribution}
+          </p>
+        )}
+      </div>
+
+      {/* Stats strip */}
+      <StatsStrip
+        currentMonthMinor={detail.stats.current_month_spend_minor}
+        lifetimeMinor={detail.stats.lifetime_spend_minor}
+        count={detail.stats.transaction_count}
+        currency={detail.stats.currency}
+      />
+
+      {/* Address (when enriched) */}
+      {m.address && (
+        <a
+          href={`https://maps.google.com/?q=${encodeURIComponent(m.address)}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="block rounded-[16px] border border-[var(--color-rule)] bg-[var(--color-surface)] px-5 py-4 text-sm hover:bg-[var(--color-paper-deep)]/30 transition-colors"
+        >
+          {m.address}
+        </a>
+      )}
+
+      {/* Transaction history */}
+      <div className="space-y-3">
+        <h2 className="font-display italic font-medium text-xl leading-none">
+          Transaction history
+        </h2>
+        {(!txns || txns.length === 0) ? (
+          <p className="font-hand text-lg text-[var(--color-ink-muted)] py-4">
+            no entries yet —
+          </p>
+        ) : (
+          <ul className="rounded-[18px] border border-[var(--color-rule)] bg-[var(--color-surface)] divide-y divide-[var(--color-rule-soft)]">
+            {txns.map((tx) => (
+              <li key={tx.id}>
+                <MerchantTxnRow tx={tx} onSelect={onSelectReceipt} />
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function BackBar({ onBack }: { onBack: () => void }) {
+  return (
+    <div className="flex items-center text-[11px] tracking-[0.16em] uppercase text-[var(--color-ink-muted)]">
+      <button
+        type="button"
+        onClick={onBack}
+        className="flex items-center gap-2 hover:text-[var(--color-ink)] transition-colors"
+      >
+        <span className="font-display italic text-lg leading-none text-[var(--color-terracotta)]">←</span>
+        Ledger
+      </button>
+    </div>
+  );
+}
+
+function StatsStrip({
+  currentMonthMinor,
+  lifetimeMinor,
+  count,
+  currency,
+}: {
+  currentMonthMinor: number;
+  lifetimeMinor: number;
+  count: number;
+  currency: string;
+}) {
+  const fmt = (minor: number) =>
+    (minor / 100).toLocaleString(undefined, {
+      style: 'currency',
+      currency,
+      maximumFractionDigits: 0,
+    });
+  return (
+    <div className="grid grid-cols-3 gap-3">
+      <StatCell label="This month" value={fmt(currentMonthMinor)} />
+      <StatCell label="All-time" value={fmt(lifetimeMinor)} />
+      <StatCell label="Entries" value={String(count)} />
+    </div>
+  );
+}
+
+function StatCell({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-[16px] border border-[var(--color-rule)] bg-[var(--color-surface)] px-4 py-3">
+      <p className="text-[10px] font-medium tracking-[0.14em] uppercase text-[var(--color-ink-muted)]">
+        {label}
+      </p>
+      <p className="mt-1 font-display italic font-medium text-xl leading-none tnum">
+        {value}
+      </p>
+    </div>
+  );
+}
+
+function MerchantTxnRow({
+  tx,
+  onSelect,
+}: {
+  tx: MerchantTransactionRow;
+  onSelect?: (id: string) => void;
+}) {
+  const badge = statusBadge(tx.status);
+  const isVoided = tx.status === 'voided';
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect?.(tx.id)}
+      className="w-full text-left grid grid-cols-[1fr_auto] items-center gap-3 px-5 py-3 hover:bg-[var(--color-paper-deep)]/30 transition-colors"
+    >
+      <div className="min-w-0">
+        <p className="font-display italic font-medium text-[16px] leading-tight truncate">
+          {tx.payee ?? '—'}
+        </p>
+        <p className="mt-0.5 text-[11px] tracking-[0.04em] uppercase text-[var(--color-ink-muted)] truncate">
+          {formatDay(tx.occurred_on)}
+          {badge && (
+            <span className={cn(
+              'ml-1',
+              badge.tone === 'red' && 'text-[var(--color-stamp)]',
+              badge.tone === 'green' && 'text-[color:rgb(52,168,83)]',
+            )}>· {badge.label}</span>
+          )}
+        </p>
+      </div>
+      <span className={cn(
+        'font-display italic font-medium text-[17px] tnum',
+        isVoided && 'line-through opacity-60',
+      )}>
+        {(tx.total_minor / 100).toLocaleString(undefined, {
+          style: 'currency',
+          currency: tx.currency,
+          maximumFractionDigits: 2,
+        })}
+      </span>
+    </button>
+  );
+}
+
+function formatDay(isoDate: string): string {
+  const [y, m, d] = isoDate.split('-').map(Number);
+  if (!Number.isFinite(y) || !Number.isFinite(m) || !Number.isFinite(d)) return isoDate;
+  const dt = new Date(y, m - 1, d);
+  return dt.toLocaleString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+}

--- a/src/components/ReceiptDetail.tsx
+++ b/src/components/ReceiptDetail.tsx
@@ -24,6 +24,9 @@ import { removeTombstone } from '../lib/tombstones';
 interface ReceiptDetailProps {
   receiptId: string;
   onBack: () => void;
+  /** Navigate to the merchant aggregation page (#33). Optional so existing
+   *  callers don't break; the link affordance hides when absent. */
+  onSelectMerchant?: (brandId: string) => void;
   /** Bumped when a delete completes so the parent's transaction list
    *  refetches. */
   onAfterMutation?: () => void;
@@ -51,7 +54,7 @@ function md<T = unknown>(meta: Metadata | undefined, key: string): T | undefined
  *
  * Data source: fetchReceiptDetail → real backend. No mocks, no fixtures.
  */
-export default function ReceiptDetail({ receiptId, onBack, onAfterMutation }: ReceiptDetailProps) {
+export default function ReceiptDetail({ receiptId, onBack, onSelectMerchant, onAfterMutation }: ReceiptDetailProps) {
   const [receipt, setReceipt] = useState<ReceiptView | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -197,6 +200,11 @@ export default function ReceiptDetail({ receiptId, onBack, onAfterMutation }: Re
         occurredOn={receipt.occurred_on}
         isProcessing={isProcessing}
         voided={receipt.status === 'voided'}
+        onMerchantClick={
+          receipt.merchantBrandId && onSelectMerchant
+            ? () => onSelectMerchant(receipt.merchantBrandId!)
+            : undefined
+        }
       />
 
       <StatusRow badge={badge} paymentMethod={receipt.paymentMethod ?? null} />
@@ -459,6 +467,7 @@ function AmountHero({
   occurredOn,
   isProcessing,
   voided,
+  onMerchantClick,
 }: {
   amount: number;
   currency: string;
@@ -466,7 +475,9 @@ function AmountHero({
   occurredOn: string;
   isProcessing: boolean;
   voided: boolean;
+  onMerchantClick?: () => void;
 }) {
+  const merchantClass = 'font-display italic font-medium text-2xl sm:text-3xl leading-tight';
   return (
     <div className="text-center pt-2">
       <p
@@ -481,9 +492,21 @@ function AmountHero({
       <p className="mt-1 text-[11px] tracking-[0.14em] uppercase text-[var(--color-ink-muted)]">
         {currency}
       </p>
-      <h1 className="mt-4 font-display italic font-medium text-2xl sm:text-3xl leading-tight">
-        {merchant}
-      </h1>
+      {onMerchantClick ? (
+        <button
+          type="button"
+          onClick={onMerchantClick}
+          className={cn(
+            'mt-4 inline-flex items-baseline gap-1 transition-colors hover:text-[var(--color-terracotta)]',
+            merchantClass,
+          )}
+        >
+          {merchant}
+          <span className="font-display italic text-base leading-none text-[var(--color-terracotta)]">→</span>
+        </button>
+      ) : (
+        <h1 className={cn('mt-4', merchantClass)}>{merchant}</h1>
+      )}
       <p className="mt-1 text-[13px] text-[var(--color-ink-muted)]">
         {formatDateLong(occurredOn)}
       </p>

--- a/src/components/Transactions.tsx
+++ b/src/components/Transactions.tsx
@@ -29,6 +29,7 @@ import {
 
 interface TransactionsProps {
   onSelectReceipt?: (receiptId: string) => void;
+  onSelectMerchant?: (brandId: string) => void;
   searchQuery?: string;
   onSearchChange?: (q: string) => void;
   /** Reset the top-bar search input. The search lives in App.tsx so
@@ -53,6 +54,7 @@ interface TombstoneRow {
  */
 export default function Transactions({
   onSelectReceipt,
+  onSelectMerchant,
   searchQuery = '',
   onSearchChange,
   onClearSearch,
@@ -268,7 +270,13 @@ export default function Transactions({
             <WeekGroup
               key={wk.startIso}
               week={wk}
-              onSelect={(id) => onSelectReceipt?.(id)}
+              onSelect={(tx) => {
+                if (tx.merchantBrandId && onSelectMerchant) {
+                  onSelectMerchant(tx.merchantBrandId);
+                } else {
+                  onSelectReceipt?.(tx.id);
+                }
+              }}
               onHardDelete={handleHardDeleteRequest}
               onUnreconcile={(id) => setUnreconcileTarget(id)}
             />
@@ -414,7 +422,7 @@ function WeekGroup({
   onUnreconcile,
 }: {
   week: WeekBucket;
-  onSelect: (id: string) => void;
+  onSelect: (tx: Transaction) => void;
   onHardDelete: (id: string) => void;
   onUnreconcile: (id: string) => void;
 }) {
@@ -454,7 +462,7 @@ function LedgerRow({
   onUnreconcile,
 }: {
   tx: Transaction;
-  onSelect: (id: string) => void;
+  onSelect: (tx: Transaction) => void;
   onHardDelete: (id: string) => void;
   onUnreconcile: (id: string) => void;
 }) {
@@ -492,7 +500,7 @@ function LedgerRow({
       {/* Body */}
       <button
         type="button"
-        onClick={() => !isProcessing && onSelect(tx.id)}
+        onClick={() => !isProcessing && onSelect(tx)}
         disabled={isProcessing}
         className={cn(
           'text-left min-w-0',

--- a/src/generated/buildInfo.json
+++ b/src/generated/buildInfo.json
@@ -1,8 +1,8 @@
 {
   "service": "receipt-assistant-frontend",
   "version": "0.0.0",
-  "gitSha": "b38d74684a401fa560fffe8993898c11f2d72f4f",
-  "gitShortSha": "b38d746",
-  "gitBranch": "feat/receipt-detail-redesign-35",
-  "builtAt": "2026-05-12T07:10:59.127Z"
+  "gitSha": "e4376c75c4bdbafd18f528dc737b1e3562a7c03f",
+  "gitShortSha": "e4376c7",
+  "gitBranch": "feat/merchant-aggregation-frontend-33",
+  "builtAt": "2026-05-12T20:46:38.930Z"
 }

--- a/src/generated/buildInfo.ts
+++ b/src/generated/buildInfo.ts
@@ -1,8 +1,8 @@
 export const buildInfo = {
   "service": "receipt-assistant-frontend",
   "version": "0.0.0",
-  "gitSha": "b38d74684a401fa560fffe8993898c11f2d72f4f",
-  "gitShortSha": "b38d746",
-  "gitBranch": "feat/receipt-detail-redesign-35",
-  "builtAt": "2026-05-12T07:10:59.127Z"
+  "gitSha": "e4376c75c4bdbafd18f528dc737b1e3562a7c03f",
+  "gitShortSha": "e4376c7",
+  "gitBranch": "feat/merchant-aggregation-frontend-33",
+  "builtAt": "2026-05-12T20:46:38.930Z"
 } as const;

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -2158,6 +2158,106 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/merchants/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Merchant detail + KPIs
+         * @description `id` accepts either the merchant row's UUID or its kebab-case `brand_id`.
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Merchant with aggregated stats */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MerchantDetail"];
+                    };
+                };
+                /** @description Merchant not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/merchants/{id}/transactions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Transactions for a merchant, newest first, keyset-paginated */
+        get: {
+            parameters: {
+                query?: {
+                    limit?: number;
+                    cursor?: string;
+                };
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Paginated transactions */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MerchantTransactionsResponse"];
+                    };
+                };
+                /** @description Merchant not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -2939,6 +3039,68 @@ export interface components {
              */
             net_minor: number;
             buckets: components["schemas"]["CashflowBucket"][];
+        };
+        Merchant: {
+            /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            id: string;
+            /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            workspace_id: string;
+            brand_id: string;
+            canonical_name: string;
+            category: string | null;
+            place_id: string | null;
+            photo_url: string | null;
+            photo_attribution: string | null;
+            address: string | null;
+            lat: number | null;
+            lng: number | null;
+            /** @enum {string} */
+            enrichment_status: "pending" | "success" | "not_found" | "failed";
+            /** Format: date-time */
+            enrichment_attempted_at: string | null;
+            /** Format: date-time */
+            created_at: string;
+            /** Format: date-time */
+            updated_at: string;
+        };
+        MerchantStats: {
+            transaction_count: number;
+            lifetime_spend_minor: number;
+            current_month_spend_minor: number;
+            last_transaction_date: string | null;
+            currency: string;
+        };
+        MerchantDetail: {
+            merchant: components["schemas"]["Merchant"];
+            stats: components["schemas"]["MerchantStats"];
+        };
+        MerchantTransactionRow: {
+            /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            id: string;
+            occurred_on: string;
+            payee: string | null;
+            /** @enum {string} */
+            status: "draft" | "posted" | "voided" | "reconciled" | "error";
+            total_minor: number;
+            currency: string;
+            /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            document_id: string | null;
+        };
+        MerchantTransactionsResponse: {
+            items: components["schemas"]["MerchantTransactionRow"][];
+            next_cursor: string | null;
         };
         NewPosting: {
             /**

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -100,6 +100,9 @@ export interface ReceiptView {
   postings: BackendPosting[];
   /** Google Places entry for the merchant location, if geocoded. */
   place: BackendPlace | null;
+  /** Canonical merchant brand id (from metadata.merchant.brand_id),
+   *  used to link to the merchant aggregation page. */
+  merchantBrandId: string | null;
   etag: string | null;
 }
 
@@ -155,6 +158,19 @@ function categoryFromTxn(t: BackendTransaction): string | null {
   return typeof raw === 'string' ? raw : null;
 }
 
+/** Pull the merchant block written by the extractor (Phase 2.5) from
+ *  transaction metadata. Returns null if absent (legacy rows pre-#64). */
+function merchantFromTxn(t: BackendTransaction): { brand_id: string; canonical_name: string } | null {
+  const md = t.metadata ?? {};
+  const m = (md as Record<string, unknown>).merchant;
+  if (!m || typeof m !== 'object') return null;
+  const rec = m as Record<string, unknown>;
+  const brandId = typeof rec.brand_id === 'string' ? rec.brand_id : null;
+  const canonical = typeof rec.canonical_name === 'string' ? rec.canonical_name : null;
+  if (!brandId) return null;
+  return { brand_id: brandId, canonical_name: canonical ?? brandId };
+}
+
 function primaryDocument(t: BackendTransaction): BackendTransaction['documents'][number] | null {
   if (!t.documents || t.documents.length === 0) return null;
   const img = t.documents.find((d) => d.kind === 'receipt_image');
@@ -203,6 +219,7 @@ export function toReceiptView(t: BackendTransaction, etag: string | null = null)
     documents: t.documents,
     postings: t.postings,
     place: t.place ?? null,
+    merchantBrandId: merchantFromTxn(t)?.brand_id ?? null,
     etag,
   };
 }
@@ -213,6 +230,7 @@ export function mapTransaction(t: BackendTransaction): Transaction {
   const rawCat = normalizeCategoryKey(rv.category);
   const classification: CategoryClassification =
     (rawCat ? CATEGORY_MAP[rawCat] : undefined) ?? { category: null, transactionType: 'spending' };
+  const m = merchantFromTxn(t);
   return {
     id: t.id,
     description: rv.payee ?? rv.narration ?? 'Unknown',
@@ -224,6 +242,7 @@ export function mapTransaction(t: BackendTransaction): Transaction {
     amount: classification.transactionType === 'income' ? rv.total : -rv.total,
     rawStatus: t.status,
     documentId: rv.documentId,
+    merchantBrandId: m?.brand_id ?? null,
   };
 }
 
@@ -946,3 +965,38 @@ export async function fetchSummary(opts: {
   }));
 }
 export type SpendingSummary = LegacySummaryItem;
+
+// ── Merchant aggregation (#33) ─────────────────────────────────
+
+export type MerchantDetailResponse =
+  components['schemas']['MerchantDetail'];
+export type MerchantTransactionsResponse =
+  components['schemas']['MerchantTransactionsResponse'];
+export type MerchantTransactionRow =
+  components['schemas']['MerchantTransactionRow'];
+
+export async function fetchMerchant(id: string): Promise<MerchantDetailResponse> {
+  const { data, error, response } = await client.GET('/v1/merchants/{id}', {
+    params: { path: { id } },
+  });
+  return unwrap('fetchMerchant', data, error, response.status);
+}
+
+export async function fetchMerchantTransactions(
+  id: string,
+  opts: { limit?: number; cursor?: string } = {},
+): Promise<MerchantTransactionsResponse> {
+  const { data, error, response } = await client.GET(
+    '/v1/merchants/{id}/transactions',
+    {
+      params: {
+        path: { id },
+        query: {
+          limit: opts.limit,
+          cursor: opts.cursor,
+        },
+      },
+    },
+  );
+  return unwrap('fetchMerchantTransactions', data, error, response.status);
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,6 +41,10 @@ export interface Transaction {
   /** Primary linked document id, if any — needed for tombstone toggle and
    *  delete-receipt cascade flows from the list. */
   documentId?: string | null;
+  /** Canonical merchant brand id (kebab-case, e.g. "costco"). Populated
+   *  from `metadata.merchant.brand_id` on rows ingested after #64. Drives
+   *  navigation from list rows → merchant aggregation page. */
+  merchantBrandId?: string | null;
 }
 
 export interface Metric {


### PR DESCRIPTION
Closes #33. Stacked on #37 (which is stacked on #36); reviews unblock in that order.

Pairs with `TINKPA/receipt-assistant#66` (backend) — built against that branch's `openapi.json` ahead of merge.

## What lands
- **New `MerchantDetail.tsx`**: photo hero (with category-color fallback when Places enrichment hasn't run yet), 3-cell stats strip, tappable address row, full transaction history with status-aware rendering (strikethrough on voided).
- **Navigation reversal**: Ledger row tap and Dashboard "recent" tap now route to `/merchant/:brandId` when present. Falls back to `ReceiptDetail` for legacy rows where `metadata.merchant` isn't populated yet.
- **ReceiptDetail `AmountHero` merchant name**: tappable link (with → affordance) when `receipt.merchantBrandId` is set — threads navigation the other direction.
- **`api-types.ts` regenerated** from #66's local `openapi.json` so the merchant types are wired in before that PR merges. After merge, `npm run api:types` will pull the same shape from `main`.

## Data flow
Backend writes `transactions.metadata.merchant = { canonical_name, brand_id, category }` via the Phase 2.5 prompt change in #66, and writes `transactions.merchant_id` via the new UPSERT CTE. The frontend reads `metadata.merchant.brand_id` (not `merchant_id`) because the endpoint exposes brand_id as the URL identifier and that's also what the routes accept. `merchant_id` (the UUID) is internal.

## Verification
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean (0 warnings, `--max-warnings 0`)
- [x] `npm run build` clean (920 kB, +3 kB from #37 baseline)
- [x] Backend smoke test in #66 confirmed `GET /v1/merchants/costco` returns merged stats from 3 Costco-variant receipts (one merchant row, three transactions, lifetime_spend_minor=10343)
- [ ] Manual: tap a Costco row in the Ledger → lands on merchant page with all three transactions, stats correct, hero shows shopping-color fallback (no Places photo yet)
- [ ] Manual: tap a transaction inside the merchant page → ReceiptDetail; tap merchant name in the hero → back to merchant page

## Out of scope (separate follow-ups)
- Sticky bottom totals bar (the stats strip serves the role for now)
- Inline category quick-edit popover on the merchant page
- "Top merchants" module on the Dashboard
- Manual merchant merge/split UI when the LLM mis-canonicalizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)