### PR TITLE
fix(categories+nginx): retail/cafe/other map + 7-only labels + index.html no-cache

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -42,6 +42,17 @@ server {
     root  /usr/share/nginx/html;
     index index.html;
 
+    # index.html must NEVER be long-cached. /assets/* below is
+    # `immutable, max-age=30d`, so if the browser holds onto a stale
+    # index.html it keeps referencing hashed bundles from the previous
+    # deploy and the UI shows pre-deploy code until users hard-refresh.
+    # Force a revalidation on every page load — index.html is tiny
+    # (~2 kB), the cost is negligible vs the staleness bug it prevents.
+    location = /index.html {
+        add_header Cache-Control "no-store, no-cache, must-revalidate";
+        expires off;
+    }
+
     location / {
         try_files $uri $uri/ /index.html;
     }

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -348,7 +348,11 @@ function RecentList({
             >
               <p className="text-[15px] font-medium truncate">{tx.description}</p>
               <p className="mt-0.5 text-xs text-[var(--color-ink-muted)] truncate">
-                {prettyCategory(tx.category ?? tx.transactionType)}
+                {tx.category
+                  ? prettyCategory(tx.category)
+                  : tx.transactionType !== 'spending'
+                    ? prettyCategory(tx.transactionType)
+                    : ''}
               </p>
             </button>
             <span className="font-display italic font-medium text-[17px] tnum">

--- a/src/components/Transactions.tsx
+++ b/src/components/Transactions.tsx
@@ -511,7 +511,7 @@ function LedgerRow({
           {tx.description}
         </p>
         <p className="mt-0.5 text-[11px] tracking-[0.04em] uppercase text-[var(--color-ink-muted)] truncate">
-          {tx.category ?? tx.transactionType} · {formatDay(tx.date)}
+          {rowLabelPrefix(tx)}{formatDay(tx.date)}
           {badge && (
             <span
               className={cn(
@@ -706,4 +706,17 @@ function formatDay(isoDate: string): string {
   const dow = dt.toLocaleString('en-US', { weekday: 'short' });
   const mo = dt.toLocaleString('en-US', { month: 'short' });
   return `${dow.toUpperCase()} · ${mo} ${d}`;
+}
+
+/** Build the leading "<Category> · " (or "<Type> · ") label on a row.
+ *  Spending rows with a known category render the category; spending
+ *  rows with no category drop the label entirely rather than fall back
+ *  to "spending". Non-spending rows show the transactionType (Income /
+ *  Transfer / Investment), which IS meaningful for those flows. */
+function rowLabelPrefix(tx: Transaction): string {
+  if (tx.category) return `${tx.category} · `;
+  if (tx.transactionType !== 'spending') {
+    return `${tx.transactionType.charAt(0).toUpperCase()}${tx.transactionType.slice(1)} · `;
+  }
+  return '';
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -22,7 +22,8 @@
 import imageCompression from 'browser-image-compression';
 import createClient from 'openapi-fetch';
 import type { components, paths } from '@/lib/api-types';
-import type { Transaction } from '@/types';
+import type { Category, Transaction } from '@/types';
+import { CATEGORIES } from '@/types';
 
 const client = createClient<paths>({ baseUrl: '/api' });
 
@@ -115,26 +116,55 @@ export interface CategoryClassification {
 
 /** Classify a raw backend category string into our 7-category + transactionType
  *  model. Used by mapTransaction (per-row) and by aggregate consumers
- *  (e.g. Dashboard summary) that get raw category strings from the backend. */
+ *  (e.g. Dashboard summary) that get raw category strings from the backend.
+ *
+ *  Three paths:
+ *    1. Input is already one of the 7 canonical names ("Food & Drinks",
+ *       "Transportation", …) — returned verbatim. This is the common
+ *       case post-#64 because the Phase 2.5 merchant block emits 7-class
+ *       names directly.
+ *    2. Input is a legacy hint (groceries/dining/retail/cafe/…) — looked
+ *       up in CATEGORY_MAP after normalization.
+ *    3. Unknown — returns {category:null, transactionType:'spending'}.
+ *       Callers MUST NOT render `transactionType` as a category label;
+ *       the UI shows "no category" or the type-pill instead. */
 export function classifyBackendCategory(raw: string | null | undefined): CategoryClassification {
+  if (typeof raw === 'string') {
+    const trimmed = raw.trim();
+    if ((CATEGORIES as readonly string[]).includes(trimmed)) {
+      return { category: trimmed as Category, transactionType: 'spending' };
+    }
+  }
   const key = normalizeCategoryKey(raw);
   return (key ? CATEGORY_MAP[key] : undefined) ?? { category: null, transactionType: 'spending' };
 }
 
 const CATEGORY_MAP: Record<string, CategoryClassification> = {
+  // Backend extractor's category_hint enum (src/ingest/prompt.ts Phase 2):
+  //   groceries | dining | retail | cafe | transport | other
+  // ALL six MUST map here, otherwise classifyBackendCategory returns
+  // {category:null, transactionType:'spending'} and the Ledger row body
+  // falls back to rendering "spending" — that was the post-deploy bug
+  // where every retail/cafe/other receipt showed e.g. "Uniqlo · spending".
   food: { category: 'Food & Drinks', transactionType: 'spending' },
   dining: { category: 'Food & Drinks', transactionType: 'spending' },
+  cafe: { category: 'Food & Drinks', transactionType: 'spending' },
   restaurants: { category: 'Food & Drinks', transactionType: 'spending' },
   groceries: { category: 'Food & Drinks', transactionType: 'spending' },
-  transport: { category: 'Transportation', transactionType: 'spending' },
+  retail: { category: 'Shopping', transactionType: 'spending' },
   shopping: { category: 'Shopping', transactionType: 'spending' },
+  transport: { category: 'Transportation', transactionType: 'spending' },
+  travel: { category: 'Travel', transactionType: 'spending' },
   utilities: { category: 'Services', transactionType: 'spending' },
+  housing: { category: 'Services', transactionType: 'spending' },
+  education: { category: 'Services', transactionType: 'spending' },
+  // Backend hint "other" doesn't map cleanly — leave category null so
+  // the UI falls back to the neutral "Uncategorized" CategoryIcon
+  // rather than silently mis-bucketing into Shopping.
+  other: { category: null, transactionType: 'spending' },
   entertainment: { category: 'Entertainment', transactionType: 'spending' },
   fun: { category: 'Entertainment', transactionType: 'spending' },
   health: { category: 'Health', transactionType: 'spending' },
-  education: { category: 'Services', transactionType: 'spending' },
-  travel: { category: 'Travel', transactionType: 'spending' },
-  housing: { category: 'Services', transactionType: 'spending' },
   income: { category: null, transactionType: 'income' },
   investments: { category: null, transactionType: 'investment' },
   real_estate: { category: null, transactionType: 'investment' },
@@ -146,10 +176,18 @@ function normalizeCategoryKey(raw: string | null | undefined): string | null {
 }
 
 function categoryFromTxn(t: BackendTransaction): string | null {
-  // The backend doesn't attach a direct "category" field — infer from
-  // metadata first (extractor often stashes one under `category_hint`
-  // or `category`), fall back to null.
+  // Prefer the Phase 2.5 merchant block — it's already one of the new
+  // 7-class categories, no translation needed. Backfill (#64) populates
+  // this on every existing row, so this branch is the common case.
   const md = t.metadata ?? {};
+  const m = (md as Record<string, unknown>).merchant;
+  if (m && typeof m === 'object') {
+    const cat = (m as Record<string, unknown>).category;
+    if (typeof cat === 'string') return cat;
+  }
+  // Legacy fallback for any row that escaped the backfill or predates
+  // the merchant block. classifyBackendCategory will map the raw hint
+  // (groceries/dining/retail/cafe/transport/other) onto one of the 7.
   const raw =
     (md as Record<string, unknown>).category ??
     (md as Record<string, unknown>).category_hint ??


### PR DESCRIPTION
Three post-deploy bug fixes, batched:

1. **nginx index.html no-cache** — fixes the stale-bundle problem where browsers held onto pre-deploy code (was rendering legacy category names from the old 11-category set).
2. **CATEGORY_MAP gaps** — backend's `category_hint` enum has 6 values (groceries|dining|retail|cafe|transport|other); the map was missing retail/cafe/other so those rows resolved to `{category:null, transactionType:'spending'}` and the Ledger showed e.g. 'Uniqlo · spending'.
3. **"Only the 7" labels** — even with the map fix, the row template still fell back to rendering `transactionType` as a category-shaped label. Fixed so spending-with-no-category drops the label and non-spending rows render `Income`/`Transfer`/`Investment`.

Verified locally: `npx tsc --noEmit` clean, `npm run lint` clean (max-warnings 0), `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)