### PR TITLE
feat(merchants): Chinese place-name subtitle + inline override (#74)

### DIFF
--- a/src/components/MerchantDetail.tsx
+++ b/src/components/MerchantDetail.tsx
@@ -3,8 +3,12 @@ import {
   extractProblemMessage,
   fetchMerchant,
   fetchMerchantTransactions,
+  fetchPlace,
+  patchPlace,
+  placeName,
   type MerchantDetailResponse,
   type MerchantTransactionRow,
+  type PlaceFull,
 } from '../lib/api';
 import { CATEGORY_META } from '../categoryMeta';
 import type { Category } from '../types';
@@ -21,6 +25,7 @@ interface MerchantDetailProps {
 export default function MerchantDetail({ brandId, onBack, onSelectReceipt }: MerchantDetailProps) {
   const [detail, setDetail] = useState<MerchantDetailResponse | null>(null);
   const [txns, setTxns] = useState<MerchantTransactionRow[] | null>(null);
+  const [place, setPlace] = useState<PlaceFull | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -35,6 +40,19 @@ export default function MerchantDetail({ brandId, onBack, onSelectReceipt }: Mer
         setDetail(d);
         setTxns(t.items);
         setLoading(false);
+        // Pull the linked place separately so its multilingual fields
+        // are available for the name fallback chain (#74). Best-effort —
+        // a missing place_id or 404 just leaves Chinese rendering off.
+        const pid = d.merchant.place_id;
+        if (pid) {
+          fetchPlace(pid)
+            .then((p) => {
+              if (!cancelled) setPlace(p);
+            })
+            .catch(() => {
+              /* ignore — Chinese subtitle just won't render */
+            });
+        }
       })
       .catch((e: unknown) => {
         if (cancelled) return;
@@ -45,6 +63,24 @@ export default function MerchantDetail({ brandId, onBack, onSelectReceipt }: Mer
       cancelled = true;
     };
   }, [brandId]);
+
+  const onEditChineseName = async () => {
+    if (!place) return;
+    const current = place.custom_name_zh ?? place.display_name_zh ?? '';
+    const next = window.prompt(
+      'Chinese name for this merchant (clear to remove override):',
+      current,
+    );
+    if (next === null) return; // user cancelled
+    try {
+      const updated = await patchPlace(place.id, {
+        custom_name_zh: next.trim() === '' ? null : next.trim(),
+      });
+      setPlace(updated);
+    } catch (e) {
+      window.alert(`Could not save: ${extractProblemMessage(e)}`);
+    }
+  };
 
   if (loading) {
     return (
@@ -105,6 +141,46 @@ export default function MerchantDetail({ brandId, onBack, onSelectReceipt }: Mer
           )}>
             {m.canonical_name}
           </h1>
+          {(() => {
+            // Chinese-name subtitle. Renders when the linked place has
+            // any source of a non-English display name (Google zh-CN,
+            // photo-OCR fallback, or user override). When the place has
+            // no Chinese yet, offer an "+ add" affordance so the user
+            // can supply one. Either path opens an inline prompt.
+            if (!place) return null;
+            const zh = place.custom_name_zh ?? place.display_name_zh ?? null;
+            if (zh && zh === m.canonical_name) return null;
+            const source = zh
+              ? place.custom_name_zh
+                ? 'you'
+                : place.display_name_zh_source === 'photo_ocr'
+                  ? 'storefront'
+                  : 'Google'
+              : null;
+            return (
+              <button
+                type="button"
+                onClick={onEditChineseName}
+                className="mt-1 inline-flex items-center gap-2 group"
+                title={zh ? `Source: ${source}. Click to edit.` : 'Add Chinese name'}
+              >
+                {zh ? (
+                  <>
+                    <span className="font-display text-lg sm:text-xl text-white/90 group-hover:text-white">
+                      {zh}
+                    </span>
+                    <span className="text-[10px] uppercase tracking-[0.15em] text-white/60 group-hover:text-white/80">
+                      ✎ {source}
+                    </span>
+                  </>
+                ) : (
+                  <span className="text-[11px] uppercase tracking-[0.15em] text-white/55 group-hover:text-white/85">
+                    + add Chinese name
+                  </span>
+                )}
+              </button>
+            );
+          })()}
         </div>
         {m.photo_url && m.photo_attribution && (
           <p className="absolute right-3 bottom-2 z-10 text-[10px] text-white/70">

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -1215,8 +1215,8 @@ export interface paths {
         put?: never;
         post?: never;
         /**
-         * Delete a document. Soft-deletes by default; ?hard=true removes the row + file; ?cascade=true also handles linked transactions.
-         * @description Default: soft delete (sets deleted_at). ?hard=true: hard delete (row + file); requires no remaining links unless ?cascade=true is also set. ?cascade=true: linked posted transactions are voided, draft/error transactions are hard-deleted, voided transactions are left intact, reconciled transactions abort the operation with 409. ?cascade=true&hard=true: every linked transaction is hard-deleted (postings cascade), the document is hard-deleted, and the image file is removed. Reconciled transactions always block hard cascades — unreconcile first.
+         * Delete a document. Soft-deletes by default; ?hard=true removes the row and quarantines the file under .trash/; ?cascade=true also handles linked transactions.
+         * @description Default: soft delete (sets deleted_at). ?hard=true: hard delete (row removed; file moved to <uploads_dir>/.trash/<timestamp>__<basename>, NOT unlinked); requires no remaining links unless ?cascade=true is also set. ?cascade=true: linked posted transactions are voided, draft/error transactions are hard-deleted, voided transactions are left intact, reconciled transactions abort the operation with 409. ?cascade=true&hard=true: every linked transaction is hard-deleted (postings cascade), the document row is removed, and the image file is moved to .trash/ (never unlinked). Reconciled transactions always block hard cascades — unreconcile first.
          */
         delete: {
             parameters: {
@@ -2258,6 +2258,145 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/places/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get a place by id (full multilingual record).
+         * @description Returns the place row with all multilingual columns plus refs to any cached photos. Photo bytes are streamed separately via /v1/places/{id}/photos/{rank}/content.
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Place */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Place"] & Record<string, never>;
+                    };
+                };
+                /** @description Not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /**
+         * Update user-overridable place fields.
+         * @description Currently exposes only `custom_name_zh` — the user override that wins over `display_name_zh` in the UI fallback chain. Pass null to clear.
+         */
+        patch: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["UpdatePlaceRequest"];
+                };
+            };
+            responses: {
+                /** @description Updated */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Place"] & Record<string, never>;
+                    };
+                };
+                /** @description Not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+            };
+        };
+        trace?: never;
+    };
+    "/v1/places/{id}/photos/{rank}/content": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Stream the binary of a cached Google Places photo.
+         * @description 0-based rank within the place's photos[] (as returned by the v1 Places API at first fetch). 404 if the rank is out of range or the local file copy is missing.
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                    rank: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Image bytes */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "image/jpeg": string;
+                    };
+                };
+                /** @description Not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -2547,8 +2686,36 @@ export interface components {
             formatted_address: string;
             lat: number;
             lng: number;
-            /** @enum {string} */
-            source: "google_geocode" | "google_places";
+            source: string;
+            display_name_en: string | null;
+            display_name_zh: string | null;
+            display_name_zh_locale: string | null;
+            /** @enum {string|null} */
+            display_name_zh_source: "google_text" | "photo_ocr" | "user_override" | null;
+            custom_name_zh: string | null;
+            primary_type: string | null;
+            primary_type_display_zh: string | null;
+            maps_type_label_zh: string | null;
+            types: string[] | null;
+            formatted_address_en: string | null;
+            formatted_address_zh: string | null;
+            postal_code: string | null;
+            country_code: string | null;
+            business_status: string | null;
+            business_hours?: unknown;
+            time_zone: string | null;
+            rating: number | null;
+            user_rating_count: number | null;
+            national_phone_number: string | null;
+            website_uri: string | null;
+            google_maps_uri: string | null;
+            photos: {
+                rank: number;
+                width_px: number | null;
+                height_px: number | null;
+                has_local_copy: boolean;
+                ocr_extracted?: unknown;
+            }[] | null;
         } | null;
         Transaction: {
             /**
@@ -3231,6 +3398,9 @@ export interface components {
              */
             amount_base_minor?: number;
             memo?: string | null;
+        };
+        UpdatePlaceRequest: {
+            custom_name_zh?: string | null;
         };
     };
     responses: never;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -989,3 +989,50 @@ export async function fetchMerchantTransactions(
   );
   return unwrap('fetchMerchantTransactions', data, error, response.status);
 }
+
+// ── Multilingual place cache (#74) ─────────────────────────────
+
+export type PlaceFull = components['schemas']['Place'];
+
+/** Single-place fetch including the photo refs. */
+export async function fetchPlace(id: string): Promise<PlaceFull> {
+  const { data, error, response } = await client.GET('/v1/places/{id}', {
+    params: { path: { id } },
+  });
+  return unwrap('fetchPlace', data, error, response.status);
+}
+
+/** Update the user-overridable `custom_name_zh`. Pass `null` to clear. */
+export async function patchPlace(
+  id: string,
+  patch: { custom_name_zh?: string | null },
+): Promise<PlaceFull> {
+  const { data, error, response } = await client.PATCH('/v1/places/{id}', {
+    params: { path: { id } },
+    body: patch,
+  });
+  return unwrap('patchPlace', data, error, response.status);
+}
+
+/**
+ * Fallback chain for rendering a place's name in the UI:
+ *   custom_name_zh  → user override (always wins)
+ *   display_name_zh → Google v1 zh-CN call or photo-OCR fallback
+ *   display_name_en → English fallback (never disappears)
+ *
+ * Receipts arrive in English transliteration (`Wing On Market`), but
+ * the user may know the merchant as the Chinese name (`永安`). The
+ * cascade keeps both visible: render the primary in the user's
+ * preferred language and the alternate as a subtitle if it differs.
+ */
+export function placeName(p: PlaceFull | null | undefined): {
+  primary: string;
+  alternate: string | null;
+} | null {
+  if (!p) return null;
+  const zh = p.custom_name_zh ?? p.display_name_zh ?? null;
+  const en = p.display_name_en ?? p.formatted_address ?? null;
+  if (!zh && !en) return null;
+  if (zh && en && zh !== en) return { primary: zh, alternate: en };
+  return { primary: zh ?? en ?? '', alternate: null };
+}


### PR DESCRIPTION
Companion to TINKPA/receipt-assistant#75 for issue #74.

## What renders

On MerchantDetail, beneath the canonical (English) merchant name, the linked place's Chinese name is shown as a subtitle when one is available:

\`\`\`
                Wing Hop Fung
              永合豐 (蒙特利公园)   ✎ you
\`\`\`

The \`✎ <source>\` tag tells the user where the Chinese came from:

| Tag | Meaning |
|---|---|
| `✎ Google` | from Google Places v1 `zh-CN` (e.g. Dong Ting Xian → 洞庭鲜湘菜餐厅) |
| `✎ storefront` | from the photo-OCR fallback (Wing On Market → 永安, once Phase 3d fires on a new ingest) |
| `✎ you` | user-supplied override (`custom_name_zh`) |

Click anywhere on the row → \`prompt()\` opens with the current value → PATCH \`/v1/places/:id\` with \`custom_name_zh\`. Empty input clears the override (Google's value comes back).

When the place has no Chinese yet, an \`+ add Chinese name\` affordance appears instead — single-click to type in the canonical Chinese for places Google doesn't have natively.

## Fallback chain

The \`placeName(p)\` helper in lib/api.ts encodes the rule:

\`\`\`
custom_name_zh   (user override, always wins)
  ↓
display_name_zh  (Google zh-CN OR photo-OCR fallback)
  ↓
display_name_en  (English fallback — never disappears)
\`\`\`

## API additions

\`\`\`ts
fetchPlace(id):                Promise<PlaceFull>
patchPlace(id, { custom_name_zh }): Promise<PlaceFull>
placeName(p):                  { primary, alternate } | null
\`\`\`

\`api-types.ts\` regenerated from the backend openapi.json. Adds \`Place\` (multilingual) and \`UpdatePlaceRequest\` schemas.

## Scope

- MerchantDetail only — that's the natural place-y page. ReceiptDetail / Dashboard / Transactions don't currently render the place subobject; trivial to add later via the same \`placeName()\` helper.
- No service-worker / cache invalidation changes — Place fetches are per-merchant-page-load, small payload.

## Smoke test

Manually verified against the dev backend after merging TINKPA/receipt-assistant#75:

1. Navigate to a merchant with Google-zh data (Tao's Kitchen) → see \`小涛家麻辣雞\` with \`✎ Google\`.
2. Click → prompt opens with current value → type `小涛家` → save → display updates with \`✎ you\`.
3. Click again → blank the input → save → falls back to \`小涛家麻辣雞\` with \`✎ Google\`.
4. Navigate to a merchant with no zh (UNIQLO Westfield) → \`+ add Chinese name\` button → click → type \`优衣库\` → save → \`✎ you\`.

## Dependencies

This PR requires TINKPA/receipt-assistant#75 to be merged AND deployed first — without the backend Place endpoint the MerchantDetail page will get 404 on \`fetchPlace\`. Failure is caught silently (the Chinese subtitle just won't render) so it degrades gracefully if deployed out of order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)