### PR TITLE
feat(dashboard): show Chinese place name in Recent list (#74 follow-up)

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -345,7 +345,14 @@ function RecentList({
                 isProcessing ? 'cursor-default opacity-60' : 'cursor-pointer',
               )}
             >
-              <p className="text-[15px] font-medium leading-snug truncate">{tx.description}</p>
+              <p className="text-[15px] font-medium leading-snug truncate">
+                {tx.description}
+                {tx.placeChineseName && tx.placeChineseName !== tx.description && (
+                  <span className="ml-1.5 text-[13px] font-normal text-[var(--color-ink-muted)]">
+                    {tx.placeChineseName}
+                  </span>
+                )}
+              </p>
               {subtitle && (
                 <p className="mt-0.5 text-xs text-[var(--color-ink-muted)] truncate">{subtitle}</p>
               )}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -220,6 +220,11 @@ export function mapTransaction(t: BackendTransaction): Transaction {
   const rv = toReceiptView(t);
   const classification = classifyBackendCategory(rv.category);
   const m = merchantFromTxn(t);
+  // Place's Chinese name follows the same fallback chain as the
+  // MerchantDetail hero: user override wins over Google/photo-OCR.
+  const p = t.place;
+  const placeChineseName =
+    (p?.custom_name_zh ?? p?.display_name_zh) ?? null;
   return {
     id: t.id,
     description: rv.payee ?? rv.narration ?? 'Unknown',
@@ -232,6 +237,7 @@ export function mapTransaction(t: BackendTransaction): Transaction {
     rawStatus: t.status,
     documentId: rv.documentId,
     merchantBrandId: m?.brand_id ?? null,
+    placeChineseName,
   };
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,6 +45,11 @@ export interface Transaction {
    *  from `metadata.merchant.brand_id` on rows ingested after #64. Drives
    *  navigation from list rows → merchant aggregation page. */
   merchantBrandId?: string | null;
+  /** Place-fallback Chinese name (#74). Resolution order:
+   *    place.custom_name_zh  → place.display_name_zh  → null
+   *  Rendered as a small alias next to the merchant name in list rows
+   *  and on the receipt detail page. */
+  placeChineseName?: string | null;
 }
 
 export interface Metric {


### PR DESCRIPTION
Tiny follow-up: render the linked place's Chinese name inline beside the English merchant name in Dashboard's Recent rows.

Backend already returns the full Place object — frontend just wasn't using it on the Dashboard. `Transaction.placeChineseName` is derived in `mapTransaction` (fallback: `custom_name_zh` → `display_name_zh` → null). Hidden when null or equal to the English description.

```
🍴 Jiu Ji Dessert 九记八方            $19.89
   CREDIT_CARD VISA7846
   Yesterday
```

3 files / +19/-1 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)