### PR TITLE
feat(transactions): show Chinese place name in Ledger rows (#74 follow-up)

### DIFF
--- a/src/components/Transactions.tsx
+++ b/src/components/Transactions.tsx
@@ -509,6 +509,11 @@ function LedgerRow({
       >
         <p className="font-display italic font-medium text-[17px] leading-tight tracking-tight truncate">
           {tx.description}
+          {tx.placeChineseName && tx.placeChineseName !== tx.description && (
+            <span className="ml-1.5 font-sans not-italic font-normal text-[13px] text-[var(--color-ink-muted)]">
+              {tx.placeChineseName}
+            </span>
+          )}
         </p>
         <p className="mt-0.5 text-[11px] tracking-[0.04em] uppercase text-[var(--color-ink-muted)] truncate">
           {rowLabelPrefix(tx)}{formatDay(tx.date)}


### PR DESCRIPTION
## Summary
- Adds inline Chinese alias to the Ledger row in `Transactions.tsx`, mirroring the Dashboard Recent-list treatment from #46.
- Uses `font-sans not-italic` overrides because the parent description text is italic display font.
- Same equality guard as Dashboard: only render if `placeChineseName` is non-empty and not identical to `description`.

## Test plan
- [x] Type check (\`npm run build\` in frontend)
- [x] Verified in browser via chrome-devtools MCP — Jiu Ji Dessert / Wing On Market / Starbucks / etc. now show their Chinese aliases inline in the Ledger view.

## Follow-up
Some Google zh-CN responses embed verbose mixed strings (e.g. \`Wing Hop Fung(永合豐)Monterey Park Store\`) which the simple equality guard doesn't dedupe. Visible on Wing Hop Fung rows. Will file a separate issue for data-quality cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)