### PR TITLE
feat(dashboard): Apple-Wallet-style 'City, ST' subtitle in recent

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -322,7 +322,11 @@ function RecentList({
           : tx.transactionType !== 'spending'
             ? prettyCategory(tx.transactionType)
             : '';
-        const subtitle = tx.paymentMethod?.trim() || categoryLine;
+        // Apple-Wallet style: location wins over payment method when
+        // the receipt has a geocoded place. Payment method only shows
+        // for online/no-location entries; category is the last resort.
+        const subtitle =
+          tx.placeCity ?? tx.paymentMethod?.trim() ?? categoryLine;
         return (
           <li
             key={tx.id}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -261,6 +261,38 @@ export function displayName(
   return fallback ?? 'Unknown';
 }
 
+/**
+ * Parse a "City, ST" subtitle out of a Google `formatted_address`
+ * (e.g. "1757 W Carson St, Torrance, CA 90501, USA" → "Torrance, CA").
+ *
+ * Indexed from the *end* of the comma-split so address lines with
+ * extra components (suites, building names) still find the city /
+ * state-zip pair. US-only — for non-US places, falls back to the
+ * second-to-last component (typically a region/prefecture name),
+ * which is good enough for an Apple-Wallet-style row subtitle.
+ *
+ * Returns null when there's no place, no formatted_address, or the
+ * address is too short to parse — caller decides the next fallback.
+ */
+export function formatPlaceCity(
+  place:
+    | { formatted_address?: string | null; country_code?: string | null }
+    | null
+    | undefined,
+): string | null {
+  const addr = place?.formatted_address?.trim();
+  if (!addr) return null;
+  const parts = addr.split(',').map((s) => s.trim()).filter(Boolean);
+  if (parts.length < 2) return null;
+  if (place?.country_code === 'US' && parts.length >= 4) {
+    const city = parts[parts.length - 3];
+    const stateZip = parts[parts.length - 2];
+    const state = stateZip.split(/\s+/)[0];
+    if (city && state) return `${city}, ${state}`;
+  }
+  return parts[parts.length - 2] || null;
+}
+
 function primaryDocument(t: BackendTransaction): BackendTransaction['documents'][number] | null {
   if (!t.documents || t.documents.length === 0) return null;
   const img = t.documents.find((d) => d.kind === 'receipt_image');
@@ -326,10 +358,11 @@ export function mapTransaction(t: BackendTransaction): Transaction {
   return {
     id: t.id,
     description: displayName(t.place, rv.payee ?? rv.narration ?? null),
+    placeCity: formatPlaceCity(t.place),
     category: classification.category,
     transactionType: classification.transactionType,
     date: rv.occurred_on,
-    paymentMethod: rv.paymentMethod ?? 'Unknown',
+    paymentMethod: rv.paymentMethod ?? null,
     // UI convention: expenses render as negative; income stays positive.
     amount: classification.transactionType === 'income' ? rv.total : -rv.total,
     rawStatus: t.status,

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,7 +33,15 @@ export interface Transaction {
   category: Category | null;
   transactionType: TransactionType;
   date: string;
-  paymentMethod: string;
+  /** Null when the receipt's OCR didn't extract a payment method
+   *  (e.g. cash, illegible, missing footer). UI views fall back to
+   *  `placeCity` or category in that case. */
+  paymentMethod: string | null;
+  /** "City, ST" derived from `place.formatted_address` when the
+   *  transaction has a geocoded place (US-only heuristic; non-US
+   *  best-effort). Used as a row-subtitle fallback in Apple-Wallet
+   *  style when `paymentMethod` is unavailable. */
+  placeCity?: string | null;
   amount: number;
   /** Single source of truth for state. UI-visible status labels are derived
    *  via `statusBadge(rawStatus)` from `src/lib/transactionStatus.ts`. */


### PR DESCRIPTION
## Summary

- Dashboard recent rows now show "City, ST" (e.g. "Torrance, CA") as the row subtitle when the transaction has a geocoded `place`, matching Apple Card "Latest Transactions" behavior.
- Payment method (when present) and category now sit second and third in the fallback chain; the literal "Unknown" string never reaches the row.

Closes #52.

## Subtitle priority

```
tx.placeCity ?? tx.paymentMethod?.trim() ?? categoryLine
```

Rationale: Apple Card shows location for in-person purchases regardless of which card was used; the card-tail / "Apple Pay" subtitle only adds info when there's no physical location (online, transfers). Putting `placeCity` first matches that.

## Helper: `formatPlaceCity(place)`

Indexed from the **end** of the comma-split `formatted_address` so suite numbers, building names, or any extra component before the city don't break the parse:

| `formatted_address` | Parsed |
|---|---|
| "1757 W Carson St, Torrance, CA 90501, USA" | "Torrance, CA" |
| "1757 W Carson St, Suite 100, Torrance, CA 90501, USA" | "Torrance, CA" |
| "5-2-1 Asakusa, Taito City, Tokyo 111-0032, Japan" | "Tokyo 111-0032" (non-US best-effort) |

US-specific "City, ST" extraction is gated on `place.country_code === 'US'` and ≥4 parts; non-US falls to `parts[parts.length - 2]`.

## Type cleanup

`Transaction.paymentMethod` was typed `string` and hardcoded to `"Unknown"` when null in `mapTransaction`. That was a smell — the string "Unknown" was being used as a magic sentinel by Dashboard's subtitle logic, which made the fallback `|| categoryLine` effectively dead. Relaxed the type to `string | null` and pass through what the backend actually delivers; consumers now control their own fallback explicitly.

## Test plan

- [x] Dashboard recent on `https://localhost:5173`:
  - Torihei Yakitori Robata Dining ×2 → "Torrance, CA"
  - Tokyo Central → "Gardena, CA" (previously "Visa ****1307")
  - MARU KOREAN BBQ → "Torrance, CA"
- [x] No literal "Unknown" anywhere in the recent list.
- [x] Type-check passes (`paymentMethod: string | null` is consistent with all consumers — `ReceiptDetail` already uses `receipt.paymentMethod ?? null`).
- [ ] Non-US transaction subtitle — n/a in current dataset; helper falls through to `parts[-2]` safely on the cases I could trace.

## Browser evidence

Screenshot attached in conversation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)