### PR TITLE
feat(ui): Re-extract + Refresh-from-source affordances (#49)

### DIFF
--- a/src/components/MerchantDetail.tsx
+++ b/src/components/MerchantDetail.tsx
@@ -7,9 +7,11 @@ import {
   patchPlace,
   pickCjk,
   placeName,
+  postRefreshPlace,
   type MerchantDetailResponse,
   type MerchantTransactionRow,
   type PlaceFull,
+  type RefreshPlaceResult,
 } from '../lib/api';
 import { CATEGORY_META } from '../categoryMeta';
 import type { Category } from '../types';
@@ -29,6 +31,16 @@ export default function MerchantDetail({ brandId, onBack, onSelectReceipt }: Mer
   const [place, setPlace] = useState<PlaceFull | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  // "Refresh from source" state machine. `idle` (the button is
+  // armed), `pending` (Google call in flight, ~5-10s), `success`
+  // (banner with `changed_keys`, auto-fades), `error` (banner with
+  // problem-detail message, manual dismiss).
+  const [refreshState, setRefreshState] = useState<
+    | { kind: 'idle' }
+    | { kind: 'pending' }
+    | { kind: 'success'; changedKeys: string[] }
+    | { kind: 'error'; message: string }
+  >({ kind: 'idle' });
 
   useEffect(() => {
     let cancelled = false;
@@ -64,6 +76,33 @@ export default function MerchantDetail({ brandId, onBack, onSelectReceipt }: Mer
       cancelled = true;
     };
   }, [brandId]);
+
+  const onRefreshFromSource = async () => {
+    if (!place) return;
+    if (refreshState.kind === 'pending') return;
+    setRefreshState({ kind: 'pending' });
+    try {
+      const result: RefreshPlaceResult = await postRefreshPlace(place.id);
+      // Pull the refreshed place so subtitle / Chinese name reflect the
+      // new data; the backend already returns derivation_event_id but
+      // the actual row contents come from a re-fetch.
+      const fresh = await fetchPlace(place.id);
+      setPlace(fresh);
+      setRefreshState({ kind: 'success', changedKeys: result.changed_keys });
+      // Auto-dismiss the banner after 5s; user can still scroll the
+      // page in the meantime. Cleared on next refresh attempt too.
+      setTimeout(() => {
+        setRefreshState((s) =>
+          s.kind === 'success' ? { kind: 'idle' } : s,
+        );
+      }, 5000);
+    } catch (e) {
+      setRefreshState({
+        kind: 'error',
+        message: extractProblemMessage(e),
+      });
+    }
+  };
 
   const onEditChineseName = async () => {
     if (!place) return;
@@ -213,6 +252,54 @@ export default function MerchantDetail({ brandId, onBack, onSelectReceipt }: Mer
         </a>
       )}
 
+      {/* Refresh from Google source. Only when a place is linked —
+          without one there's nothing to re-fetch. Wears the same
+          editorial italic-display + hand-written aesthetic as the
+          rest of the page. */}
+      {place && (
+        <div className="space-y-2">
+          <button
+            type="button"
+            onClick={onRefreshFromSource}
+            disabled={refreshState.kind === 'pending'}
+            className={cn(
+              'group inline-flex items-center gap-2 text-[11px] uppercase tracking-[0.16em]',
+              'text-[var(--color-ink-muted)] hover:text-[var(--color-terracotta)]',
+              'transition-colors disabled:opacity-50 disabled:cursor-wait',
+            )}
+            title="Re-fetch Google data and re-derive multilingual fields"
+          >
+            <span className="font-display italic text-base leading-none text-[var(--color-terracotta)] group-hover:translate-x-px transition-transform">
+              ↻
+            </span>
+            {refreshState.kind === 'pending'
+              ? 'refreshing from Google…'
+              : 'Refresh from source'}
+          </button>
+
+          {refreshState.kind === 'success' && (
+            <RefreshBanner
+              tone="success"
+              onDismiss={() => setRefreshState({ kind: 'idle' })}
+            >
+              {refreshState.changedKeys.length === 0
+                ? 'Google had nothing new.'
+                : `Updated ${refreshState.changedKeys.length} field${
+                    refreshState.changedKeys.length === 1 ? '' : 's'
+                  }: ${refreshState.changedKeys.join(', ')}.`}
+            </RefreshBanner>
+          )}
+          {refreshState.kind === 'error' && (
+            <RefreshBanner
+              tone="error"
+              onDismiss={() => setRefreshState({ kind: 'idle' })}
+            >
+              {refreshState.message}
+            </RefreshBanner>
+          )}
+        </div>
+      )}
+
       {/* Transaction history */}
       <div className="space-y-3">
         <h2 className="font-display italic font-medium text-xl leading-none">
@@ -339,4 +426,41 @@ function formatDay(isoDate: string): string {
   if (!Number.isFinite(y) || !Number.isFinite(m) || !Number.isFinite(d)) return isoDate;
   const dt = new Date(y, m - 1, d);
   return dt.toLocaleString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+}
+
+/**
+ * Reprocess feedback banner. Matches the editorial / handwritten
+ * aesthetic of the page — terracotta success accent, stamped red for
+ * errors. Used by both refresh (here) and re-extract (ReceiptDetail).
+ */
+function RefreshBanner({
+  tone,
+  children,
+  onDismiss,
+}: {
+  tone: 'success' | 'error';
+  children: React.ReactNode;
+  onDismiss: () => void;
+}) {
+  return (
+    <div
+      className={cn(
+        'flex items-start justify-between gap-3 rounded-[14px] px-4 py-3 text-sm',
+        tone === 'success' &&
+          'border border-[var(--color-terracotta)]/30 bg-[var(--color-terracotta)]/8 text-[var(--color-ink)]',
+        tone === 'error' &&
+          'border border-[var(--color-stamp)]/40 bg-[var(--color-stamp)]/5 text-[var(--color-stamp)]',
+      )}
+    >
+      <p className="font-hand text-base leading-snug">{children}</p>
+      <button
+        type="button"
+        onClick={onDismiss}
+        className="text-[11px] uppercase tracking-[0.16em] opacity-60 hover:opacity-100 transition-opacity shrink-0 mt-0.5"
+        aria-label="Dismiss"
+      >
+        dismiss
+      </button>
+    </div>
+  );
 }

--- a/src/components/ReceiptDetail.tsx
+++ b/src/components/ReceiptDetail.tsx
@@ -6,11 +6,13 @@ import {
   documentContentUrl,
   extractProblemMessage,
   getTransaction,
+  postReExtractDocument,
   toReceiptView,
   voidTransaction,
   restoreDocument,
   type ReceiptView,
   type BackendTransaction,
+  type ReExtractDocumentResult,
 } from '../lib/api';
 import { statusBadge } from '../lib/transactionStatus';
 import { cn } from '../lib/utils';
@@ -61,6 +63,16 @@ export default function ReceiptDetail({ receiptId, onBack, onSelectMerchant, onA
   const [activeDialog, setActiveDialog] = useState<'edit' | 'void' | 'delete' | null>(null);
   const [restoring, setRestoring] = useState(false);
   const [restoreError, setRestoreError] = useState<string | null>(null);
+  // Re-extract state machine. `idle` armed; `pending` (~30-60s — the
+  // agent re-OCRs the image); `success` shows `changed_keys` toast;
+  // `error` flashes the problem-detail message. Mirrors the
+  // refresh-from-source pattern on MerchantDetail.
+  const [reExtractState, setReExtractState] = useState<
+    | { kind: 'idle' }
+    | { kind: 'pending' }
+    | { kind: 'success'; changedKeys: string[]; ocrChanged: boolean }
+    | { kind: 'error'; message: string }
+  >({ kind: 'idle' });
 
   const loadReceipt = () => {
     fetchReceiptDetail(receiptId)
@@ -105,6 +117,36 @@ export default function ReceiptDetail({ receiptId, onBack, onSelectMerchant, onA
       setRestoreError(extractProblemMessage(err));
     } finally {
       setRestoring(false);
+    }
+  };
+
+  const handleReExtract = async () => {
+    if (!receipt?.documentId) return;
+    if (reExtractState.kind === 'pending') return;
+    setReExtractState({ kind: 'pending' });
+    try {
+      const result: ReExtractDocumentResult = await postReExtractDocument(
+        receipt.documentId,
+      );
+      // Reload the transaction so the UI reflects any field changes the
+      // agent committed (payee, occurred_on, occurred_at, etc).
+      loadReceipt();
+      onAfterMutation?.();
+      setReExtractState({
+        kind: 'success',
+        changedKeys: result.changed_keys,
+        ocrChanged: result.ocr_text_changed,
+      });
+      setTimeout(() => {
+        setReExtractState((s) =>
+          s.kind === 'success' ? { kind: 'idle' } : s,
+        );
+      }, 6000);
+    } catch (err: unknown) {
+      setReExtractState({
+        kind: 'error',
+        message: extractProblemMessage(err),
+      });
     }
   };
 
@@ -237,6 +279,55 @@ export default function ReceiptDetail({ receiptId, onBack, onSelectMerchant, onA
       {!isProcessing && receipt.documentId && (
         <OriginalReceiptCollapsible documentId={receipt.documentId} />
       )}
+
+      {/* Re-extract affordance. Only on active (non-voided) receipts
+          that have a linked document. Wall-time is ~30-60s for vision
+          OCR, so we make the pending state visible. */}
+      {!isProcessing &&
+        receipt.documentId &&
+        receipt.status !== 'voided' && (
+          <div className="space-y-2">
+            <button
+              type="button"
+              onClick={handleReExtract}
+              disabled={reExtractState.kind === 'pending'}
+              className={cn(
+                'group inline-flex items-center gap-2 text-[11px] uppercase tracking-[0.16em]',
+                'text-[var(--color-ink-muted)] hover:text-[var(--color-terracotta)]',
+                'transition-colors disabled:opacity-50 disabled:cursor-wait',
+              )}
+              title="Re-run OCR with the current model and prompt"
+            >
+              <span className="font-display italic text-base leading-none text-[var(--color-terracotta)] group-hover:translate-x-px transition-transform">
+                ↺
+              </span>
+              {reExtractState.kind === 'pending'
+                ? 're-extracting… (~30-60s)'
+                : 'Re-extract'}
+            </button>
+
+            {reExtractState.kind === 'success' && (
+              <ReExtractBanner
+                tone="success"
+                onDismiss={() => setReExtractState({ kind: 'idle' })}
+              >
+                {reExtractState.changedKeys.length === 0 && !reExtractState.ocrChanged
+                  ? 'No changes — the agent produced the same output.'
+                  : reExtractState.changedKeys.length === 0
+                    ? 'OCR text refreshed; no transaction fields changed.'
+                    : `Updated ${reExtractState.changedKeys.join(', ')}.`}
+              </ReExtractBanner>
+            )}
+            {reExtractState.kind === 'error' && (
+              <ReExtractBanner
+                tone="error"
+                onDismiss={() => setReExtractState({ kind: 'idle' })}
+              >
+                {reExtractState.message}
+              </ReExtractBanner>
+            )}
+          </div>
+        )}
 
       {!isProcessing && (rawText || confidence != null) && (
         <ExtractionDetailsCollapsible
@@ -814,6 +905,44 @@ function Banner({
       )}
     >
       {children}
+    </div>
+  );
+}
+
+/**
+ * Feedback banner for re-extract. Mirrors the RefreshBanner pattern
+ * in MerchantDetail — same aesthetic, separate copy to avoid pulling
+ * a tiny presentational helper across the file boundary. If a third
+ * surface needs the same widget, factor it out then.
+ */
+function ReExtractBanner({
+  tone,
+  children,
+  onDismiss,
+}: {
+  tone: 'success' | 'error';
+  children: React.ReactNode;
+  onDismiss: () => void;
+}) {
+  return (
+    <div
+      className={cn(
+        'flex items-start justify-between gap-3 rounded-[14px] px-4 py-3 text-sm',
+        tone === 'success' &&
+          'border border-[var(--color-terracotta)]/30 bg-[var(--color-terracotta)]/8 text-[var(--color-ink)]',
+        tone === 'error' &&
+          'border border-[var(--color-stamp)]/40 bg-[var(--color-stamp)]/5 text-[var(--color-stamp)]',
+      )}
+    >
+      <p className="font-hand text-base leading-snug">{children}</p>
+      <button
+        type="button"
+        onClick={onDismiss}
+        className="text-[11px] uppercase tracking-[0.16em] opacity-60 hover:opacity-100 transition-opacity shrink-0 mt-0.5"
+        aria-label="Dismiss"
+      >
+        dismiss
+      </button>
     </div>
   );
 }

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -1462,6 +1462,65 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/documents/{id}/re-extract": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Re-OCR the receipt and UPDATE the linked transaction in place.
+         * @description Phase 4c of the 3-layer rollout (#80 / #91). Spawns `claude -p` with a narrow re-extract prompt; the agent reads the cached image bytes and refreshes `transactions.{payee, occurred_on, occurred_at, metadata.extraction}` plus `documents.{ocr_text, ocr_model_version}`. **Out of scope**: postings, place_id, merchant_id, document_links — those have their own paths. **Layer-3 shielded**: HARD fields (status, narration, trip_id, identity columns) never touched; SOFT fields (occurred_on, occurred_at, payee) protected by `metadata.user_edited.<field>` CASE expressions, so user PATCH overrides survive. Returns 422 if the document has zero or >1 linked transactions.
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Re-extract committed */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ReExtractDocumentResponse"];
+                    };
+                };
+                /** @description Document not found or soft-deleted */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+                /** @description Document not linked to exactly one transaction, or has no file_path */
+                422: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/ingest/batch": {
         parameters: {
             query?: never;
@@ -2346,6 +2405,133 @@ export interface paths {
         };
         trace?: never;
     };
+    "/v1/places/{id}/re-derive": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Re-run Layer 2 projection over cached raw_response.
+         * @description Re-applies the current projection logic to the cached Google Places response, overwriting derived columns. Layer 3 user-truth (`custom_name_zh`) is never touched. OCR-sourced zh fields (`display_name_zh_source IN ('photo_ocr','receipt_ocr')`) are preserved verbatim. Every run inserts a `derivation_events` row with a `before`/`after` jsonb diff; the returned `derivation_event_id` lets you correlate. Returns 422 when `raw_response` is NULL.
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Re-derive committed */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ReDerivePlaceResponse"];
+                    };
+                };
+                /** @description Place not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+                /** @description Place has no raw_response — nothing to project from */
+                422: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/places/{id}/refresh": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Re-fetch Google v1 + re-derive Layer 2 in one step.
+         * @description Calls Google Places v1 (dual-language, FieldMask=*), appends a `place_snapshots` row, overwrites `places.raw_response`, then delegates to `/v1/places/{id}/re-derive` so Layer 2 columns reflect the new body. Layer 3 (`custom_name_zh`) and OCR-sourced zh fields are shielded by the re-derive step. Yelp re-fetch is deferred until a Yelp client lands (separate epic). Returns 503 when `GOOGLE_MAPS_API_KEY` is unset and 502 on upstream errors.
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Refresh committed */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["RefreshPlaceResponse"];
+                    };
+                };
+                /** @description Place not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+                /** @description Google v1 upstream error */
+                502: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+                /** @description GOOGLE_MAPS_API_KEY not configured */
+                503: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/places/{id}/photos/{rank}/content": {
         parameters: {
             query?: never;
@@ -2391,6 +2577,56 @@ export interface paths {
         };
         put?: never;
         post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/re-derive": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Re-run Layer 2 projection across every row in scope.
+         * @description Phase 2 (#89): scope=places walks every `places` row and re-runs the projection over its cached `raw_response`. Rows with `raw_response IS NULL` are counted as `skipped` (not errored). Each updated row produces a `derivation_events` entry — including no-op runs that match the current state, so a version bump is auditable even when nothing visibly changes. Sync execution at current corpus scale (<1 s for tens to low hundreds of places).
+         */
+        post: {
+            parameters: {
+                query?: {
+                    scope?: "places";
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Batch summary */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ReDeriveBatchResponse"];
+                    };
+                };
+                /** @description Invalid scope */
+                422: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+            };
+        };
         delete?: never;
         options?: never;
         head?: never;
@@ -2796,6 +3032,8 @@ export interface components {
             mime_type: string | null;
             sha256: string;
             ocr_text: string | null;
+            /** @description Model identifier under which ocr_text was produced. NULL on legacy rows. */
+            ocr_model_version: string | null;
             extraction_meta: {
                 [key: string]: unknown;
             } | null;
@@ -3400,8 +3638,76 @@ export interface components {
             amount_base_minor?: number;
             memo?: string | null;
         };
+        ReExtractDocumentResponse: {
+            /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            document_id: string;
+            /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            transaction_id: string;
+            /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            derivation_event_id: string;
+            changed_keys: string[];
+            ocr_text_changed: boolean;
+            /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            session_id: string;
+        };
         UpdatePlaceRequest: {
             custom_name_zh?: string | null;
+        };
+        ReDerivePlaceResponse: {
+            /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            place_id: string;
+            changed_keys: string[];
+            /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            derivation_event_id: string;
+        };
+        RefreshPlaceResponse: {
+            /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            place_id: string;
+            google_place_id: string;
+            /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            snapshot_id: string;
+            /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            derivation_event_id: string;
+            changed_keys: string[];
+        };
+        ReDeriveBatchResponse: {
+            /** @enum {string} */
+            scope: "places";
+            total: number;
+            updated: number;
+            skipped: number;
+            errors: {
+                id: string;
+                message: string;
+            }[];
+            ran_at: string;
         };
     };
     responses: never;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1150,6 +1150,59 @@ export async function patchPlace(
   return unwrap('patchPlace', data, error, response.status);
 }
 
+export type RefreshPlaceResult = components['schemas']['RefreshPlaceResponse'];
+
+/**
+ * Re-fetch a place from Google v1 and re-derive Layer 2 (Phase 4a / #91).
+ *
+ * Triggers one round of Google API quota usage per call; the merchant /
+ * place detail page surfaces this as "Refresh from source" so the user
+ * understands it's a quota-spending operation.
+ *
+ * Errors surface as RFC 7807 problem+json:
+ *  - 404 — place not found
+ *  - 503 — server has no GOOGLE_MAPS_API_KEY configured
+ *  - 502 — upstream Google error (status passed through in `upstream_status`)
+ *
+ * Layer-3 protections inherited from the backend:
+ *  - `custom_name_zh` and OCR-sourced zh fields survive
+ *  - `derivation_events` row written even on no-op refresh
+ */
+export async function postRefreshPlace(id: string): Promise<RefreshPlaceResult> {
+  const { data, error, response } = await client.POST(
+    '/v1/places/{id}/refresh',
+    { params: { path: { id } } },
+  );
+  return unwrap('postRefreshPlace', data, error, response.status);
+}
+
+export type ReExtractDocumentResult =
+  components['schemas']['ReExtractDocumentResponse'];
+
+/**
+ * Re-OCR a document and UPDATE the linked transaction in place (Phase
+ * 4c / #91). Wall-time ~30-60s — callers should show a pending state.
+ *
+ * Layer-3 protections inherited from the backend:
+ *  - HARD fields (status, void state, narration, trip_id) never touched
+ *  - SOFT fields (payee, occurred_on, occurred_at) preserved if the user
+ *    PATCHed them via `patchTransaction` (the `metadata.user_edited`
+ *    flag is set automatically by that path)
+ *
+ * Errors surface as RFC 7807 problem+json:
+ *  - 404 — document not found or soft-deleted
+ *  - 422 — zero or >1 linked transactions, or document has no file_path
+ */
+export async function postReExtractDocument(
+  id: string,
+): Promise<ReExtractDocumentResult> {
+  const { data, error, response } = await client.POST(
+    '/v1/documents/{id}/re-extract',
+    { params: { path: { id } } },
+  );
+  return unwrap('postReExtractDocument', data, error, response.status);
+}
+
 /**
  * Fallback chain for rendering a place's name in the UI:
  *   custom_name_zh  → user override (always wins)


### PR DESCRIPTION
## Summary

Wave 0 Phase 5 — frontend slice of the 3-layer data-model rollout ([TINKPA/receipt-assistant#80](https://github.com/TINKPA/receipt-assistant/issues/80)). Surfaces the now-live backend endpoints `POST /v1/places/{id}/refresh` (Phase 4a) and `POST /v1/documents/{id}/re-extract` (Phase 4c) as user-clickable affordances.

Two buttons, same pattern, same banner aesthetic — both calls inherit the backend's Layer-3 shielding so user edits and explicit state changes survive automatically.

## What's in

**ReceiptDetail — `↺ Re-extract`** (under the Original Receipt card):
- Hidden on voided receipts (status is HARD Layer 3; calling re-extract there is wasted credits)
- Pending state: "re-extracting… (~30-60s)" — vision OCR is slow, the UI says so
- On success: receipt reloads (so payee / date / OCR text refresh in the UI) and banner reports `changed_keys` or "OCR text refreshed; no transaction fields changed."

**MerchantDetail — `↻ Refresh from source`** (under the address row):
- Only renders when a linked place exists
- Pending state: "refreshing from Google…"
- On success: re-fetches the place so Chinese name / subtitle / hours reflect the new data; banner shows the diff

**Banner aesthetic**: matches the existing editorial / handwritten vibe (font-display italic ornament + font-hand body, terracotta success accent, stamp-red error). Auto-dismisses success after 5-6s; errors require manual dismiss so the problem-detail message stays readable.

## Files

- `src/lib/api.ts` — `postRefreshPlace`, `postReExtractDocument` wrappers with full docstrings explaining the inherited backend Layer-3 protections
- `src/lib/api-types.ts` — regenerated from backend OpenAPI spec (now includes `RefreshPlaceResponse`, `ReExtractDocumentResponse`, `ReDerivePlaceResponse`)
- `src/components/MerchantDetail.tsx` — refresh state machine (`idle | pending | success | error`) + button + `RefreshBanner` helper
- `src/components/ReceiptDetail.tsx` — re-extract state machine + button + `ReExtractBanner` (mirrors `RefreshBanner`; factor into shared file if a third surface needs it)

## Design choices

**Why two parallel state machines instead of a shared hook.** The two flows have subtly different cosmetic states (`refreshing from Google` vs `re-extracting`, 5s vs 6s auto-dismiss). Two near-identical state machines in different components is cheaper to read than a generic hook with branching for two callsites. If a third reprocess surface lands, that's the right time to factor.

**Why banner-not-toast.** The existing app has no global toast system; reusing the local `Banner` pattern keeps the per-page feedback colocated with the action that produced it. Toasts would require a new app-level provider.

**Why hide Re-extract on voided receipts.** Voided is HARD Layer 3 on the backend — re-extract would run, write the audit row, and produce no visible change. Hiding the button is honest about what the user can affect.

**Why only manual dismiss on errors.** The user needs time to read the problem-detail message (e.g. "Document linked to multiple transactions" with a transaction_ids array). Auto-dismissing would lose information.

## Browser smoke verification

All on chrome-devtools against the running dev server. Screenshots saved to outer-repo `notes/` per the project's UI evidence rule (CLAUDE.md "UI issues are closed with browser evidence, not code analysis"):

| Flow | Result | Screenshot |
|---|---|---|
| ReceiptDetail — button rendered | ✓ "↺ RE-EXTRACT" visible under Original receipt | `49-receipt-reextract-button.png` |
| ReceiptDetail — pending state | ✓ "↺ RE-EXTRACTING… (~30-60S)", disabled | `49-receipt-reextract-pending.png` |
| ReceiptDetail — success banner | ✓ "Updated occurred_at, metadata_extraction, ocr_text." with Dismiss after ~30s wall time | `49-receipt-reextract-success.png` |
| MerchantDetail — button rendered | ✓ "↻ REFRESH FROM SOURCE" visible | `49-merchant-refresh-button.png` |
| MerchantDetail — success banner | ✓ "Google had nothing new." (Layer-2 idempotent — we refreshed via curl earlier in the day) | `49-merchant-refresh-success.png` |

Console clean throughout (no errors logged). No 500s on `/api/v1/places/.../refresh` or `/api/v1/documents/.../re-extract`.

## Test plan

- [x] `npm run build` passes
- [x] OpenAPI types regenerated (`npm run api:types` against committed backend spec)
- [x] Re-extract: button visible → pending → success → button restored
- [x] Refresh: button visible → success (idempotent path)
- [x] Console clean
- [ ] Post-merge: keep the dev / prod parity check on a fresh open of either detail page

## Out of scope per the issue body

- **Admin batch view** ("stale rows" list + bulk reprocess) — issue body marks it "secondary". The backend endpoint exists (`POST /v1/admin/re-derive?scope=places`); when the admin page becomes a real need, file a follow-up issue with the table shape.
- **"Undo" CTA on success** — would require prompt-version-aware re-extract (re-run with a prior `prompt_version`), which the backend doesn't currently support.
- **Diff preview before apply** — explicitly out per the #80 design decision ("destructive is the default").

Refs TINKPA/receipt-assistant#80.

🤖 Generated with [Claude Code](https://claude.com/claude-code)