### PR TITLE
feat(ui): place-map thumbnail on Ledger + Dashboard rows (#96 frontend)

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -9,6 +9,7 @@ import type { Transaction, Category } from '../types';
 import { isProcessing as txIsProcessing } from '../lib/transactionStatus';
 import { cn } from '../lib/utils';
 import { CategoryIcon } from './CategoryIcon';
+import { PlaceThumbnail } from './PlaceThumbnail';
 
 interface DashboardProps {
   onSelectReceipt?: (receiptId: string) => void;
@@ -335,11 +336,26 @@ function RecentList({
               idx > 0 && 'border-t border-[var(--color-rule-soft)]',
             )}
           >
-            <CategoryIcon
-              category={tx.category}
-              transactionType={tx.transactionType}
-              size={44}
-            />
+            {tx.placeMapUrl ? (
+              <PlaceThumbnail
+                src={tx.placeMapUrl}
+                alt={tx.description}
+                size={44}
+                fallback={
+                  <CategoryIcon
+                    category={tx.category}
+                    transactionType={tx.transactionType}
+                    size={44}
+                  />
+                }
+              />
+            ) : (
+              <CategoryIcon
+                category={tx.category}
+                transactionType={tx.transactionType}
+                size={44}
+              />
+            )}
             <button
               type="button"
               onClick={() => !isProcessing && onSelect?.(tx)}

--- a/src/components/PlaceThumbnail.tsx
+++ b/src/components/PlaceThumbnail.tsx
@@ -1,0 +1,57 @@
+import { useState } from 'react';
+import { cn } from '../lib/utils';
+
+/**
+ * Tiny map thumbnail for row icons (#96). Fetches a cached PNG from
+ * the backend's `GET /v1/places/:id/map` proxy. Skeleton placeholder
+ * while loading; falls back to the parent's category-icon path if the
+ * image errors (e.g. place row deleted server-side after the
+ * transaction was already in the list).
+ *
+ * The image is square; the caller controls outer dimensions via
+ * `size`. Backend serves 256×256 @2× scale so it stays crisp even at
+ * the 64px ledger row dimension.
+ */
+interface PlaceThumbnailProps {
+  src: string;
+  alt?: string;
+  size?: number;
+  className?: string;
+  /** Render fallback when the image fails to load. */
+  fallback?: React.ReactNode;
+}
+
+export function PlaceThumbnail({
+  src,
+  alt = '',
+  size = 48,
+  className,
+  fallback,
+}: PlaceThumbnailProps) {
+  const [errored, setErrored] = useState(false);
+
+  if (errored && fallback) {
+    return <>{fallback}</>;
+  }
+
+  return (
+    <div
+      className={cn(
+        'relative overflow-hidden rounded-[12px] bg-[var(--color-paper-deep)]/40',
+        className,
+      )}
+      style={{ width: size, height: size }}
+    >
+      <img
+        src={src}
+        alt={alt}
+        loading="lazy"
+        decoding="async"
+        width={size}
+        height={size}
+        onError={() => setErrored(true)}
+        className="h-full w-full object-cover"
+      />
+    </div>
+  );
+}

--- a/src/components/Transactions.tsx
+++ b/src/components/Transactions.tsx
@@ -15,6 +15,7 @@ import { cn } from '../lib/utils';
 import type { Transaction } from '../types';
 import { isProcessing as txIsProcessing, statusBadge } from '../lib/transactionStatus';
 import { CategoryIcon } from './CategoryIcon';
+import { PlaceThumbnail } from './PlaceThumbnail';
 import TransactionRowMenu from './TransactionRowMenu';
 import ConfirmActionDialog from './ConfirmActionDialog';
 import UnreconcileDialog from './UnreconcileDialog';
@@ -477,13 +478,29 @@ function LedgerRow({
         'rounded-[16px] border border-[var(--color-rule)] bg-[var(--color-surface)] p-3 pr-2',
       )}
     >
-      {/* Category icon (with optional has-receipt ✦ badge) */}
+      {/* Place thumbnail when geocoded; category icon otherwise (#96).
+          Optional has-receipt ✦ badge sits on top of either. */}
       <div className="relative h-12 w-12 flex-shrink-0">
-        <CategoryIcon
-          category={tx.category}
-          transactionType={tx.transactionType}
-          size={48}
-        />
+        {tx.placeMapUrl ? (
+          <PlaceThumbnail
+            src={tx.placeMapUrl}
+            alt={tx.description}
+            size={48}
+            fallback={
+              <CategoryIcon
+                category={tx.category}
+                transactionType={tx.transactionType}
+                size={48}
+              />
+            }
+          />
+        ) : (
+          <CategoryIcon
+            category={tx.category}
+            transactionType={tx.transactionType}
+            size={48}
+          />
+        )}
         {hasDoc && (
           <span
             className={cn(

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -2532,6 +2532,94 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/places/{id}/map": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Stream a Google Static Maps thumbnail for a place (#96).
+         * @description Proxies Google Static Maps. Server-side caches the PNG to disk keyed on (place_id, lat, lng, size, zoom, marker) so subsequent requests don't hit Google. Image is rendered at 2× scale for retina; POI text labels suppressed. Marker is an orange dot at the place's coords. Returns 404 when the place has no lat/lng, 400 for bad size/zoom, 502 on Google upstream error, 503 when the server has no GOOGLE_MAPS_API_KEY configured.
+         */
+        get: {
+            parameters: {
+                query?: {
+                    size?: string;
+                    zoom?: string;
+                    marker?: string;
+                };
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description PNG image bytes */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "image/png": string;
+                    };
+                };
+                /** @description Not modified — ETag matched */
+                304: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Bad size or zoom */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+                /** @description Place not found or has no lat/lng */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+                /** @description Google Static Maps upstream error */
+                502: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+                /** @description GOOGLE_MAPS_API_KEY not configured */
+                503: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/places/{id}/photos/{rank}/content": {
         parameters: {
             query?: never;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -365,6 +365,13 @@ export function mapTransaction(t: BackendTransaction): Transaction {
     id: t.id,
     description: displayName(t.place, rv.payee ?? rv.narration ?? null),
     placeCity: formatPlaceCity(t.place),
+    // `placeMapUrl` is the proxied Static Maps endpoint that the
+    // row renderer hits via `<PlaceThumbnail>` (#96). Only set when
+    // the place has lat/lng — null falls back to `<CategoryIcon>`.
+    placeMapUrl:
+      t.place?.id && t.place.lat != null && t.place.lng != null
+        ? `/api/v1/places/${t.place.id}/map`
+        : null,
     category: classification.category,
     transactionType: classification.transactionType,
     date: rv.occurred_on,

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,6 +42,11 @@ export interface Transaction {
    *  best-effort). Used as a row-subtitle fallback in Apple-Wallet
    *  style when `paymentMethod` is unavailable. */
   placeCity?: string | null;
+  /** Proxied Google Static Maps URL (#96) for a small map thumbnail
+   *  of the place. Null when the transaction has no linked place or
+   *  no lat/lng. Row renderers swap `<CategoryIcon />` for
+   *  `<PlaceThumbnail src={placeMapUrl} />` when this is set. */
+  placeMapUrl?: string | null;
   amount: number;
   /** Single source of truth for state. UI-visible status labels are derived
    *  via `statusBadge(rawStatus)` from `src/lib/transactionStatus.ts`. */


### PR DESCRIPTION
## Summary

Frontend half of [TINKPA/receipt-assistant#96](https://github.com/TINKPA/receipt-assistant/issues/96). Backend Static-Maps proxy shipped in [TINKPA/receipt-assistant#103](https://github.com/TINKPA/receipt-assistant/pull/103) (commit 8cd76d0); this PR consumes it.

Every Ledger row and Dashboard "recent" row with a geocoded place now shows a tiny map of the place instead of a generic category icon. Rows without a place keep the category icon — no new fallback state to design.

## What's in

**New** \`src/components/PlaceThumbnail.tsx\`:
- 48px (Ledger) / 44px (Dashboard recent) rounded square
- Wraps a lazy-loaded \`<img>\` pointing at \`/api/v1/places/{id}/map\`
- \`onError\` falls back to the \`fallback\` prop (the original \`CategoryIcon\`) so a deleted place or transient 5xx doesn't leave a broken icon

Wired into:
- \`Transactions.tsx\` LedgerRow — 48px, with the existing has-receipt ✦ badge still overlaying
- \`Dashboard.tsx\` RecentList — 44px

**Plumbing**: \`src/lib/api.ts ::mapTransaction\` derives \`Transaction.placeMapUrl\` from \`t.place.id\` when \`lat\`/\`lng\` present (null otherwise). Types pulled from regenerated OpenAPI.

## Browser smoke

A11y snapshot before vs. after:

**Before** (category icons only):
\`\`\`
generic "Food & Drinks"
button "Torihei Yakitori Robata Dining ..."
\`\`\`

**After** (this PR):
\`\`\`
image "Torihei Yakitori Robata Dining" url="https://localhost:5173/api/v1/places/<uuid>/map"
button "Torihei Yakitori Robata Dining ..."
\`\`\`

Screenshots in outer-repo notes/:
- \`96-dashboard-thumbs.png\` — Dashboard "recent" list with map thumbs for all 4 cards
- \`96-ledger-thumbs.png\` — Ledger view with thumbs on every place-having row

Console clean throughout, no errors.

## Test plan

- [x] \`npm run build\` passes
- [x] OpenAPI types regenerated (\`npm run api:types\`)
- [x] Dashboard renders thumbs for all 4 recent cards
- [x] Ledger renders thumbs for every place-having row
- [x] Console clean
- [ ] Post-merge: verify \`X-Cache: HIT\` on second page load via DevTools Network panel
- [ ] iOS PWA visual check (deferred — the existing dashboard / ledger paths are already PWA-tested)

## Out of scope

- MerchantDetail page hero — separate visual question; the thumb is too small to replace the existing hero photo
- macOS native list view — picks up the new endpoint via swift-openapi-generator codegen; separate visual question per the issue body

Refs TINKPA/receipt-assistant#96.

🤖 Generated with [Claude Code](https://claude.com/claude-code)