### PR TITLE
feat(merchants): consume /v1/merchants/:id/photo proxy on hero (#67 frontend)

### DIFF
--- a/src/components/MerchantDetail.tsx
+++ b/src/components/MerchantDetail.tsx
@@ -157,12 +157,18 @@ export default function MerchantDetail({ brandId, onBack, onSelectReceipt }: Mer
       <BackBar onBack={onBack} />
 
       {/* Hero */}
+      {/* `photo_url` post-#67 is a relative server path
+          (`/v1/merchants/:id/photo`); prefix `/api` so the Vite proxy
+          forwards it to the backend. Absolute URLs (legacy Google
+          attribution paths) pass through unchanged. */}
       <div
         className="relative rounded-[20px] overflow-hidden h-[180px] sm:h-[220px] flex items-end p-5"
         style={
           m.photo_url
             ? {
-                backgroundImage: `linear-gradient(180deg, transparent 0%, rgba(0,0,0,0.55) 100%), url(${m.photo_url})`,
+                backgroundImage: `linear-gradient(180deg, transparent 0%, rgba(0,0,0,0.55) 100%), url(${
+                  m.photo_url.startsWith('http') ? m.photo_url : `/api${m.photo_url}`
+                })`,
                 backgroundSize: 'cover',
                 backgroundPosition: 'center',
               }

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -2267,6 +2267,56 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/merchants/{id}/photo": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Stream the cached hero photo for a merchant (#67).
+         * @description Resolves to the merchant's linked `places.id` and serves the first `place_photos` row with cached bytes. Returns 404 when the merchant has no linked place or no cached photos for that place. Reuses the `place_photos` cache from #74 — no separate merchant_photos table.
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Image bytes */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "image/jpeg": string;
+                    };
+                };
+                /** @description Merchant or photo not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/merchants/{id}/transactions": {
         parameters: {
             query?: never;


### PR DESCRIPTION
## Summary

Frontend half of [TINKPA/receipt-assistant#67](https://github.com/TINKPA/receipt-assistant/issues/67). Backend [TINKPA/receipt-assistant#104](https://github.com/TINKPA/receipt-assistant/pull/104) (commit 67bb68a) made \`merchants.photo_url\` a relative proxy URL when a Google place_id is linked. This PR adapts the MerchantDetail hero to load that path through Vite's \`/api\` proxy.

## What's in

\`MerchantDetail.tsx\` hero \`backgroundImage\`:
- Before: \`url(\${m.photo_url})\` — broke for relative URLs since CSS resolves them against the page URL, missing the Vite proxy
- After: \`url(\${m.photo_url.startsWith('http') ? m.photo_url : \`/api\${m.photo_url}\`})\` — prefixes \`/api\` for relative paths so Vite forwards them to the backend

\`api-types.ts\` regenerated (\`npm run api:types\`) — picks up the backend's new endpoint and updated response shape.

## Browser smoke

chrome-devtools navigated Books → Ledger → KFC row → MerchantDetail (screenshot at outer-repo \`notes/67-merchant-hero-photo.png\`):

\`\`\`js
getComputedStyle(hero).backgroundImage
// => 'linear-gradient(...), url("https://localhost:5173/api/v1/merchants/bb826eb7-.../photo")'
\`\`\`

- KFC hero photo loads from the cached \`place_photos.rank=0\` (385KB JPEG)
- For merchants with no linked place_id, \`m.photo_url\` is null → existing category-color fallback engages
- Console clean throughout, no errors

## Out of scope

- Workspace-scoped hero override (Option B from explore report; needs separate \`merchant_photos\` table)
- Multi-photo carousels
- Hero refresh / invalidation UI — backend serves whatever \`place_photos.rank=0\` currently has; refresh happens through existing photo-OCR enrichment on receipt ingest

Refs TINKPA/receipt-assistant#67.

🤖 Generated with [Claude Code](https://claude.com/claude-code)