### PR TITLE
feat(catalog): Wave 2 frontend catch-up — items, products, brands

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Boxes, Tag, ChevronRight } from 'lucide-react';
 import Layout from './components/Layout';
 import type { DockDestination } from './components/FloatingDock';
 import Dashboard from './components/Dashboard';
@@ -12,6 +13,8 @@ import ProcessingToast from './components/ProcessingToast';
 import { useProcessingJobs } from './components/useProcessingJobs';
 import ReceiptDetail from './components/ReceiptDetail';
 import MerchantDetail from './components/MerchantDetail';
+import Products from './components/Products';
+import Brands from './components/Brands';
 import BuildInfoPanel from './components/BuildInfoPanel';
 import { fetchBackendBuildInfo, type BuildInfo } from './lib/api';
 
@@ -22,13 +25,16 @@ type ActiveTab =
   | 'monthly'
   | 'yearly'
   | 'settings'
+  | 'products'
+  | 'brands'
   | 'add';
 
 /** Map App.tsx's fine-grained tab state onto the 3-pill dock. */
 function dockDestinationFor(tab: ActiveTab): DockDestination {
   if (tab === 'add') return 'add';
   if (tab === 'monthly' || tab === 'yearly') return 'review';
-  // dashboard / transactions / batches / settings → Books
+  if (tab === 'settings' || tab === 'products' || tab === 'brands') return 'settings';
+  // dashboard / transactions / batches → Books
   return 'books';
 }
 
@@ -148,13 +154,39 @@ export default function App() {
         return <MonthlyReview />;
       case 'yearly':
         return <YearlyReview />;
+      case 'products':
+        return <Products onBack={() => goToTab('settings')} />;
+      case 'brands':
+        return <Brands onBack={() => goToTab('settings')} />;
       case 'settings':
         return (
           <div className="space-y-6">
             <div className="space-y-2">
-              <h2 className="font-display text-3xl italic font-medium tracking-tight">Build &amp; Deploy</h2>
+              <h2 className="font-display text-3xl italic font-medium tracking-tight">Settings</h2>
               <p className="text-[color:var(--color-ink-muted)] max-w-2xl">
-                Verify which frontend and backend build is currently deployed.
+                Catalog management and deployment metadata.
+              </p>
+            </div>
+
+            <div className="grid sm:grid-cols-2 gap-3">
+              <SettingsCard
+                icon={<Boxes size={18} />}
+                title="Products"
+                subtitle="Catalog SSOT, owned items, merge duplicates"
+                onClick={() => setActiveTab('products')}
+              />
+              <SettingsCard
+                icon={<Tag size={18} />}
+                title="Brands"
+                subtitle="Brand registry + icon asset picker"
+                onClick={() => setActiveTab('brands')}
+              />
+            </div>
+
+            <div className="space-y-2 pt-4">
+              <h3 className="font-display text-xl italic font-medium tracking-tight">Build &amp; Deploy</h3>
+              <p className="text-[color:var(--color-ink-muted)] text-sm">
+                Which frontend / backend build is currently deployed.
               </p>
             </div>
             <BuildInfoPanel backendBuildInfo={backendBuildInfo} />
@@ -171,6 +203,7 @@ export default function App() {
         dockActive={dockDestinationFor(activeTab)}
         onDockNavigate={handleDockNavigate}
         onAddTransaction={() => goToTab('add')}
+        onSettings={() => goToTab('settings')}
         dockHidden={activeTab === 'add'}
       >
         {renderContent()}
@@ -182,5 +215,33 @@ export default function App() {
         onRefresh={() => setRefreshKey((k) => k + 1)}
       />
     </>
+  );
+}
+
+function SettingsCard({
+  icon,
+  title,
+  subtitle,
+  onClick,
+}: {
+  icon: React.ReactNode;
+  title: string;
+  subtitle: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className="text-left rounded-[18px] border border-[color:var(--color-rule)] bg-[color:var(--color-surface)] px-5 py-4 flex items-center gap-4 hover:bg-[color:var(--color-paper-deep)]/30 transition-colors"
+    >
+      <div className="shrink-0 w-10 h-10 rounded-full bg-[color:var(--color-paper-deep)] flex items-center justify-center text-[color:var(--color-ink)]">
+        {icon}
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="font-medium text-[15px]">{title}</div>
+        <div className="text-[12px] text-[color:var(--color-ink-muted)] mt-0.5">{subtitle}</div>
+      </div>
+      <ChevronRight size={16} className="text-[color:var(--color-ink-muted)]" />
+    </button>
   );
 }

--- a/src/components/Brands.tsx
+++ b/src/components/Brands.tsx
@@ -1,0 +1,392 @@
+import React, { useEffect, useState } from 'react';
+import { ChevronRight, ArrowLeft, Lock, Globe } from 'lucide-react';
+import {
+  listBrands,
+  getBrand,
+  patchBrand,
+  listBrandAssets,
+  extractProblemMessage,
+  type BackendBrand,
+  type BackendBrandAsset,
+} from '../lib/api';
+import { cn } from '../lib/utils';
+
+/**
+ * Brands page (#101 Phase 1). Brand layer + multi-candidate icon assets.
+ *
+ * Phase 1 surfaces only:
+ *  - Browse all brands (global, workspace-agnostic).
+ *  - View each brand's candidate icon assets (`brand_assets`).
+ *  - Pick a `preferred_asset_id` → stamps `user_chose_at`, which Layer-3
+ *    locks against re-extract overrides.
+ *
+ * Phase 2 (deferred) will plug in agent acquisition (iTunes / svgl /
+ * logo.dev / simple_icons sources) and `GET /v1/brands/:id/icon`
+ * streaming — right now that endpoint returns 501 so we display the
+ * asset's `source_url` / `local_path` instead of an `<img>` for now.
+ */
+
+interface BrandsProps {
+  onBack: () => void;
+}
+
+export default function Brands({ onBack }: BrandsProps) {
+  const [brands, setBrands] = useState<BackendBrand[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [search, setSearch] = useState('');
+  const [selected, setSelected] = useState<string | null>(null);
+
+  useEffect(() => {
+    listBrands()
+      .then(setBrands)
+      .catch((e: unknown) => setError(extractProblemMessage(e)));
+  }, []);
+
+  if (selected) {
+    return (
+      <BrandDetail
+        brandId={selected}
+        onBack={() => setSelected(null)}
+        onPatched={(b) => {
+          // Update the cached list in-place so the locked indicator
+          // refreshes without a roundtrip.
+          setBrands((prev) =>
+            prev ? prev.map((x) => (x.brand_id === b.brand_id ? b : x)) : prev,
+          );
+        }}
+      />
+    );
+  }
+
+  const filtered = brands?.filter((b) =>
+    search.trim() === ''
+      ? true
+      : b.name.toLowerCase().includes(search.toLowerCase()) ||
+        b.brand_id.toLowerCase().includes(search.toLowerCase()),
+  );
+
+  return (
+    <div className="space-y-5">
+      <BackBar onBack={onBack} title="Brands" subtitle="Global brand registry + icon asset picker (#101 Phase 1)" />
+
+      <input
+        type="search"
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        placeholder="Search brands by name or id…"
+        className="w-full px-4 py-2.5 rounded-[14px] border border-[var(--color-rule)] bg-[var(--color-surface)] text-sm focus:outline-none focus:border-[var(--color-ink)]"
+      />
+
+      {error && (
+        <div className="rounded-[14px] border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-900">
+          {error}
+        </div>
+      )}
+
+      {brands === null && !error && (
+        <div className="rounded-[18px] border border-[var(--color-rule)] bg-[var(--color-surface)] py-12 text-center text-[var(--color-ink-muted)]">
+          Loading…
+        </div>
+      )}
+
+      {brands && filtered && filtered.length === 0 && (
+        <div className="rounded-[18px] border border-[var(--color-rule)] bg-[var(--color-surface)] py-12 text-center text-[var(--color-ink-muted)]">
+          {search.trim() ? 'No brands match that search.' : 'No brands yet.'}
+        </div>
+      )}
+
+      {brands && filtered && filtered.length > 0 && (
+        <ul className="rounded-[18px] border border-[var(--color-rule)] bg-[var(--color-surface)] overflow-hidden divide-y divide-[var(--color-rule-soft)]">
+          {filtered.map((b) => (
+            <li key={b.brand_id}>
+              <button
+                onClick={() => setSelected(b.brand_id)}
+                className="w-full px-5 py-4 flex items-center gap-4 text-left hover:bg-[var(--color-paper-deep)]/30 transition-colors"
+              >
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2">
+                    <span className="text-sm font-medium truncate">{b.name}</span>
+                    {b.user_chose_at && (
+                      <Lock size={11} className="text-[var(--color-ink-muted)]" aria-label="locked by user" />
+                    )}
+                  </div>
+                  <div className="mt-0.5 text-[11px] text-[var(--color-ink-muted)] tnum truncate">
+                    {b.brand_id}
+                    {b.domain && (
+                      <>
+                        <span className="mx-1.5">·</span>
+                        {b.domain}
+                      </>
+                    )}
+                  </div>
+                </div>
+                {b.preferred_asset_id ? (
+                  <span className="text-[10px] uppercase tracking-wider text-[var(--color-ink-muted)]">
+                    asset set
+                  </span>
+                ) : (
+                  <span className="text-[10px] uppercase tracking-wider text-stone-400">
+                    no asset
+                  </span>
+                )}
+                <ChevronRight size={16} className="text-[var(--color-ink-muted)]" />
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+// ─── Detail ──────────────────────────────────────────────────────────
+
+const TIER_LABEL: Record<BackendBrandAsset['tier'], string> = {
+  itunes: 'iTunes',
+  svgl: 'SVGL',
+  logo_dev: 'logo.dev',
+  simple_icons: 'Simple Icons',
+  user_upload: 'User upload',
+  manual_url: 'Manual URL',
+};
+
+const TIER_BADGE: Record<BackendBrandAsset['tier'], string> = {
+  itunes: 'bg-rose-50 text-rose-900',
+  svgl: 'bg-violet-50 text-violet-900',
+  logo_dev: 'bg-emerald-50 text-emerald-900',
+  simple_icons: 'bg-stone-100 text-stone-700',
+  user_upload: 'bg-amber-50 text-amber-900',
+  manual_url: 'bg-sky-50 text-sky-900',
+};
+
+function BrandDetail({
+  brandId,
+  onBack,
+  onPatched,
+}: {
+  brandId: string;
+  onBack: () => void;
+  onPatched: (b: BackendBrand) => void;
+}) {
+  const [brand, setBrand] = useState<BackendBrand | null>(null);
+  const [assets, setAssets] = useState<BackendBrandAsset[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [banner, setBanner] = useState<{ tone: 'ok' | 'err'; text: string } | null>(null);
+
+  const loadAll = () => {
+    Promise.all([getBrand(brandId), listBrandAssets(brandId)])
+      .then(([b, a]) => {
+        setBrand(b);
+        setAssets(a);
+      })
+      .catch((e: unknown) => setError(extractProblemMessage(e)));
+  };
+
+  useEffect(loadAll, [brandId]);
+
+  const setPreferred = async (assetId: string | null) => {
+    if (!brand) return;
+    setBusy(assetId ?? 'clear');
+    setBanner(null);
+    try {
+      const updated = await patchBrand(brand.brand_id, { preferred_asset_id: assetId });
+      setBrand(updated);
+      onPatched(updated);
+      setBanner({
+        tone: 'ok',
+        text: assetId
+          ? 'Preferred asset set — locked from re-extract overrides.'
+          : 'Preferred asset cleared.',
+      });
+    } catch (e: unknown) {
+      setBanner({ tone: 'err', text: extractProblemMessage(e) });
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  if (error) {
+    return (
+      <div className="space-y-4">
+        <BackBar onBack={onBack} title="Brand" />
+        <div className="rounded-[18px] border border-rose-200 bg-rose-50 px-5 py-4 text-sm text-rose-900">
+          {error}
+        </div>
+      </div>
+    );
+  }
+
+  if (!brand) {
+    return (
+      <div className="space-y-4">
+        <BackBar onBack={onBack} title="Brand" />
+        <div className="rounded-[18px] border border-[var(--color-rule)] bg-[var(--color-surface)] py-12 text-center text-[var(--color-ink-muted)]">
+          Loading…
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-5">
+      <BackBar onBack={onBack} title="Brand" />
+
+      <div className="rounded-[18px] border border-[var(--color-rule)] bg-[var(--color-surface)] px-5 py-5 space-y-3">
+        <div className="flex items-baseline justify-between gap-3">
+          <h2 className="font-display italic font-medium text-2xl leading-tight">{brand.name}</h2>
+          {brand.user_chose_at && (
+            <span className="inline-flex items-center gap-1 text-[10px] uppercase tracking-wider text-[var(--color-ink-muted)]">
+              <Lock size={11} /> locked
+            </span>
+          )}
+        </div>
+        <div className="text-[12px] text-[var(--color-ink-muted)] tnum">{brand.brand_id}</div>
+        {brand.domain && (
+          <div className="flex items-center gap-1.5 text-[12px] text-[var(--color-ink-muted)]">
+            <Globe size={11} />
+            <a
+              href={`https://${brand.domain}`}
+              target="_blank"
+              rel="noreferrer"
+              className="underline-offset-2 hover:underline"
+            >
+              {brand.domain}
+            </a>
+          </div>
+        )}
+        {brand.parent_id && (
+          <div className="text-[12px] text-[var(--color-ink-muted)]">
+            parent: <span className="tnum">{brand.parent_id}</span>
+          </div>
+        )}
+      </div>
+
+      {banner && (
+        <div
+          className={cn(
+            'rounded-[14px] px-4 py-3 text-sm',
+            banner.tone === 'ok'
+              ? 'border border-emerald-200 bg-emerald-50 text-emerald-900'
+              : 'border border-rose-200 bg-rose-50 text-rose-900',
+          )}
+        >
+          {banner.text}
+        </div>
+      )}
+
+      <Section title={`Candidate assets (${assets?.length ?? 0})`}>
+        <p className="text-[12px] text-[var(--color-ink-muted)] mb-3">
+          Pick one to set <code className="tnum">preferred_asset_id</code> — re-extract will respect your choice.
+          Icon streaming (<code className="tnum">GET /v1/brands/:id/icon</code>) is a 501 stub in Phase 1; we
+          display the raw asset metadata until Phase 2 lands.
+        </p>
+
+        {assets === null && (
+          <p className="text-sm text-[var(--color-ink-muted)]">Loading…</p>
+        )}
+
+        {assets && assets.length === 0 && (
+          <p className="text-sm text-[var(--color-ink-muted)]">
+            No candidate assets yet. Phase 2 will populate via agent acquisition (iTunes / SVGL / logo.dev / Simple Icons).
+          </p>
+        )}
+
+        {assets && assets.length > 0 && (
+          <ul className="space-y-2">
+            {assets.map((a) => {
+              const isPreferred = a.id === brand.preferred_asset_id;
+              return (
+                <li
+                  key={a.id}
+                  className={cn(
+                    'rounded-[14px] border px-4 py-3 flex items-start gap-3',
+                    isPreferred
+                      ? 'border-[var(--color-ink)] bg-[var(--color-paper-deep)]/40'
+                      : 'border-[var(--color-rule)] bg-[var(--color-surface)]',
+                  )}
+                >
+                  <div className="min-w-0 flex-1 space-y-1.5">
+                    <div className="flex items-center gap-2">
+                      <span className={cn('inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-medium leading-none', TIER_BADGE[a.tier])}>
+                        {TIER_LABEL[a.tier]}
+                      </span>
+                      {a.user_uploaded && (
+                        <span className="text-[10px] uppercase tracking-wider text-[var(--color-ink-muted)]">
+                          user-uploaded
+                        </span>
+                      )}
+                      {a.retired_at && (
+                        <span className="text-[10px] uppercase tracking-wider text-[var(--color-stamp)]">
+                          retired
+                        </span>
+                      )}
+                    </div>
+                    <div className="text-[11px] text-[var(--color-ink-muted)] tnum break-all">
+                      {a.source_url ?? a.local_path}
+                    </div>
+                    <div className="text-[11px] text-[var(--color-ink-muted)] tnum">
+                      {a.content_type}
+                      {a.width != null && a.height != null && ` · ${a.width}×${a.height}`}
+                      {a.bytes != null && ` · ${(a.bytes / 1024).toFixed(1)}kb`}
+                      {a.agent_relevance != null && ` · agent rel. ${a.agent_relevance.toFixed(2)}`}
+                    </div>
+                    {a.agent_notes && (
+                      <div className="text-[11px] italic text-[var(--color-ink-muted)]">{a.agent_notes}</div>
+                    )}
+                  </div>
+                  <button
+                    onClick={() => setPreferred(isPreferred ? null : a.id)}
+                    disabled={busy !== null}
+                    className={cn(
+                      'shrink-0 px-3 py-1.5 rounded-full text-[12px] font-medium transition-colors disabled:opacity-40',
+                      isPreferred
+                        ? 'bg-[var(--color-ink)] text-[var(--color-paper)]'
+                        : 'border border-[var(--color-rule)] text-[var(--color-ink-muted)] hover:text-[var(--color-ink)]',
+                    )}
+                  >
+                    {busy === a.id ? '…' : isPreferred ? 'Preferred' : 'Pick'}
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </Section>
+    </div>
+  );
+}
+
+// ─── Shared bits ─────────────────────────────────────────────────────
+
+function BackBar({
+  onBack,
+  title,
+  subtitle,
+}: {
+  onBack: () => void;
+  title: string;
+  subtitle?: string;
+}) {
+  return (
+    <div className="space-y-1">
+      <button
+        onClick={onBack}
+        className="inline-flex items-center gap-1 text-[12px] tracking-[0.14em] uppercase text-[var(--color-ink-muted)] hover:text-[var(--color-ink)] transition-colors"
+      >
+        <ArrowLeft size={14} /> Back
+      </button>
+      <h1 className="font-display italic font-medium text-3xl tracking-tight">{title}</h1>
+      {subtitle && <p className="text-[13px] text-[var(--color-ink-muted)]">{subtitle}</p>}
+    </div>
+  );
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="rounded-[18px] border border-[var(--color-rule)] bg-[var(--color-surface)] px-5 py-4">
+      <h3 className="font-display italic font-medium text-lg leading-none mb-3">{title}</h3>
+      {children}
+    </div>
+  );
+}

--- a/src/components/FloatingDock.tsx
+++ b/src/components/FloatingDock.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
+import { Settings as SettingsIcon } from 'lucide-react';
 import { cn } from '../lib/utils';
 
-export type DockDestination = 'books' | 'add' | 'review';
+export type DockDestination = 'books' | 'add' | 'review' | 'settings';
 
 interface FloatingDockProps {
   active: DockDestination;
   onNavigate: (dest: 'books' | 'review') => void;
   onAdd: () => void;
+  onSettings: () => void;
 }
 
 /**
@@ -18,7 +20,7 @@ interface FloatingDockProps {
  *   Add     ← navigates to the full-screen Capture route
  *   Review  ← monthly / yearly
  */
-export default function FloatingDock({ active, onNavigate, onAdd }: FloatingDockProps) {
+export default function FloatingDock({ active, onNavigate, onAdd, onSettings }: FloatingDockProps) {
   return (
     <nav
       aria-label="Primary"
@@ -47,6 +49,20 @@ export default function FloatingDock({ active, onNavigate, onAdd }: FloatingDock
         isActive={active === 'review'}
         onClick={() => onNavigate('review')}
       />
+      <button
+        type="button"
+        onClick={onSettings}
+        aria-current={active === 'settings' ? 'page' : undefined}
+        aria-label="Settings"
+        className={cn(
+          'flex items-center justify-center w-9 h-9 rounded-full transition-colors duration-200 ease-out',
+          active === 'settings'
+            ? 'bg-[var(--color-terracotta)] text-white'
+            : 'text-[color:rgba(250,246,236,0.7)] hover:text-[color:rgba(250,246,236,1)]',
+        )}
+      >
+        <SettingsIcon size={16} aria-hidden="true" />
+      </button>
     </nav>
   );
 }

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -6,6 +6,7 @@ interface LayoutProps {
   dockActive: DockDestination;
   onDockNavigate: (dest: 'books' | 'review') => void;
   onAddTransaction: () => void;
+  onSettings: () => void;
   /** When true the floating dock is omitted — full-bleed surfaces like
    *  the Capture route own the whole viewport. */
   dockHidden?: boolean;
@@ -24,6 +25,7 @@ export default function Layout({
   dockActive,
   onDockNavigate,
   onAddTransaction,
+  onSettings,
   dockHidden = false,
 }: LayoutProps) {
   return (
@@ -46,6 +48,7 @@ export default function Layout({
           active={dockActive}
           onNavigate={onDockNavigate}
           onAdd={onAddTransaction}
+          onSettings={onSettings}
         />
       )}
     </div>

--- a/src/components/Products.tsx
+++ b/src/components/Products.tsx
@@ -1,0 +1,489 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { ChevronRight, ArrowLeft, RotateCw, GitMerge } from 'lucide-react';
+import {
+  listProducts,
+  getProduct,
+  patchProduct,
+  mergeProductInto,
+  recomputeProduct,
+  listOwnedItems,
+  extractProblemMessage,
+  type BackendProduct,
+  type BackendOwnedItem,
+} from '../lib/api';
+import { cn } from '../lib/utils';
+
+/**
+ * Products page (#84). Catalog SSOT — every line item with an extracted
+ * normalized name is aggregated here, with `purchase_count` and
+ * `total_spent_minor` recomputed from `transaction_items`.
+ *
+ * Surfaces:
+ *  - Filter by item_class.
+ *  - Search by canonical / custom name.
+ *  - Detail: aggregates, owned_items list, edit custom_name / notes,
+ *    Merge into another product, Recompute stats.
+ */
+
+type ProductClass = BackendProduct['item_class'];
+
+const CLASSES: Array<{ value: ProductClass | 'all'; label: string }> = [
+  { value: 'all', label: 'All' },
+  { value: 'durable', label: 'Durable' },
+  { value: 'consumable', label: 'Consumable' },
+  { value: 'food_drink', label: 'Food & drink' },
+  { value: 'service', label: 'Service' },
+  { value: 'other', label: 'Other' },
+];
+
+const CLASS_BADGE: Record<ProductClass, string> = {
+  durable: 'bg-[var(--color-paper-deep)] text-[var(--color-ink)]',
+  consumable: 'bg-amber-50 text-amber-900',
+  food_drink: 'bg-rose-50 text-rose-900',
+  service: 'bg-sky-50 text-sky-900',
+  other: 'bg-stone-100 text-stone-700',
+};
+
+function formatMinor(minor: number, currency: string = 'USD'): string {
+  const sym = currency === 'USD' ? '$' : '';
+  return `${sym}${(minor / 100).toFixed(2)}`;
+}
+
+interface ProductsProps {
+  onBack: () => void;
+}
+
+export default function Products({ onBack }: ProductsProps) {
+  const [klass, setKlass] = useState<ProductClass | 'all'>('all');
+  const [search, setSearch] = useState('');
+  const [products, setProducts] = useState<BackendProduct[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  useEffect(() => {
+    setProducts(null);
+    setError(null);
+    listProducts({
+      class: klass === 'all' ? undefined : klass,
+      search: search.trim() || undefined,
+      limit: 100,
+    })
+      .then(setProducts)
+      .catch((e: unknown) => setError(extractProblemMessage(e)));
+  }, [klass, search]);
+
+  if (selectedId) {
+    return (
+      <ProductDetail
+        productId={selectedId}
+        onBack={() => setSelectedId(null)}
+        onMerged={() => {
+          setSelectedId(null);
+          // Trigger refetch by twiddling the filter (cheap idempotent).
+          setProducts(null);
+          listProducts({ class: klass === 'all' ? undefined : klass, limit: 100 })
+            .then(setProducts)
+            .catch((e: unknown) => setError(extractProblemMessage(e)));
+        }}
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-5">
+      <BackBar onBack={onBack} title="Products" subtitle="Catalog SSOT — aggregated from receipt line items" />
+
+      <div className="space-y-3">
+        <input
+          type="search"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Search products…"
+          className="w-full px-4 py-2.5 rounded-[14px] border border-[var(--color-rule)] bg-[var(--color-surface)] text-sm focus:outline-none focus:border-[var(--color-ink)]"
+        />
+        <div className="flex flex-wrap gap-2">
+          {CLASSES.map((c) => (
+            <button
+              key={c.value}
+              onClick={() => setKlass(c.value)}
+              className={cn(
+                'px-3 py-1 rounded-full text-[12px] font-medium transition-colors',
+                klass === c.value
+                  ? 'bg-[var(--color-ink)] text-[var(--color-paper)]'
+                  : 'bg-[var(--color-surface)] border border-[var(--color-rule)] text-[var(--color-ink-muted)] hover:text-[var(--color-ink)]',
+              )}
+            >
+              {c.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {error && (
+        <div className="rounded-[14px] border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-900">
+          {error}
+        </div>
+      )}
+
+      {products === null && !error && (
+        <div className="rounded-[18px] border border-[var(--color-rule)] bg-[var(--color-surface)] py-12 text-center text-[var(--color-ink-muted)]">
+          Loading…
+        </div>
+      )}
+
+      {products && products.length === 0 && (
+        <div className="rounded-[18px] border border-[var(--color-rule)] bg-[var(--color-surface)] py-12 text-center text-[var(--color-ink-muted)]">
+          No products yet. Upload receipts with extracted line items to populate the catalog.
+        </div>
+      )}
+
+      {products && products.length > 0 && (
+        <ul className="rounded-[18px] border border-[var(--color-rule)] bg-[var(--color-surface)] overflow-hidden divide-y divide-[var(--color-rule-soft)]">
+          {products.map((p) => (
+            <li key={p.id}>
+              <button
+                onClick={() => setSelectedId(p.id)}
+                className="w-full px-5 py-4 flex items-center gap-4 text-left hover:bg-[var(--color-paper-deep)]/30 transition-colors"
+              >
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2">
+                    <span className="text-sm font-medium truncate">
+                      {p.custom_name || p.canonical_name}
+                    </span>
+                    <span
+                      className={cn(
+                        'inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-medium leading-none',
+                        CLASS_BADGE[p.item_class],
+                      )}
+                    >
+                      {p.item_class.replace('_', ' ')}
+                    </span>
+                  </div>
+                  <div className="mt-0.5 text-[12px] text-[var(--color-ink-muted)] tnum">
+                    {p.purchase_count}× · spent {formatMinor(p.total_spent_minor)}
+                    {p.last_purchased_on && ` · last ${p.last_purchased_on}`}
+                  </div>
+                </div>
+                <ChevronRight size={16} className="text-[var(--color-ink-muted)]" />
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+// ─── Detail ──────────────────────────────────────────────────────────
+
+function ProductDetail({
+  productId,
+  onBack,
+  onMerged,
+}: {
+  productId: string;
+  onBack: () => void;
+  onMerged: () => void;
+}) {
+  const [product, setProduct] = useState<BackendProduct | null>(null);
+  const [owned, setOwned] = useState<BackendOwnedItem[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [customName, setCustomName] = useState('');
+  const [notes, setNotes] = useState('');
+  const [editDirty, setEditDirty] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [mergeTarget, setMergeTarget] = useState('');
+  const [mergeBusy, setMergeBusy] = useState(false);
+  const [recomputing, setRecomputing] = useState(false);
+  const [banner, setBanner] = useState<{ tone: 'ok' | 'err'; text: string } | null>(null);
+
+  const loadAll = () => {
+    Promise.all([getProduct(productId), listOwnedItems({ product_id: productId, limit: 50 })])
+      .then(([p, o]) => {
+        setProduct(p);
+        setOwned(o);
+        setCustomName(p.custom_name ?? '');
+        setNotes(p.notes ?? '');
+        setEditDirty(false);
+      })
+      .catch((e: unknown) => setError(extractProblemMessage(e)));
+  };
+
+  useEffect(loadAll, [productId]);
+
+  const onSave = async () => {
+    if (!product) return;
+    setSaving(true);
+    setBanner(null);
+    try {
+      const patch: { custom_name?: string | null; notes?: string | null } = {};
+      if (customName !== (product.custom_name ?? '')) {
+        patch.custom_name = customName.trim() === '' ? null : customName.trim();
+      }
+      if (notes !== (product.notes ?? '')) {
+        patch.notes = notes.trim() === '' ? null : notes.trim();
+      }
+      const updated = await patchProduct(product.id, patch);
+      setProduct(updated);
+      setEditDirty(false);
+      setBanner({ tone: 'ok', text: 'Saved.' });
+    } catch (e: unknown) {
+      setBanner({ tone: 'err', text: extractProblemMessage(e) });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const onMerge = async () => {
+    const target = mergeTarget.trim();
+    if (!target || !product) return;
+    setMergeBusy(true);
+    setBanner(null);
+    try {
+      const r = await mergeProductInto(product.id, target);
+      setBanner({
+        tone: 'ok',
+        text: `Merged → moved ${r.moved_transaction_items} line items, ${r.moved_owned_items} owned items.`,
+      });
+      setMergeTarget('');
+      setTimeout(onMerged, 800);
+    } catch (e: unknown) {
+      setBanner({ tone: 'err', text: extractProblemMessage(e) });
+    } finally {
+      setMergeBusy(false);
+    }
+  };
+
+  const onRecompute = async () => {
+    if (!product) return;
+    setRecomputing(true);
+    setBanner(null);
+    try {
+      const r = await recomputeProduct(product.id);
+      setProduct({ ...product, purchase_count: r.purchase_count, total_spent_minor: r.total_spent_minor, first_purchased_on: r.first_purchased_on, last_purchased_on: r.last_purchased_on });
+      setBanner({ tone: 'ok', text: `Recomputed: ${r.purchase_count}× / ${formatMinor(r.total_spent_minor)}.` });
+    } catch (e: unknown) {
+      setBanner({ tone: 'err', text: extractProblemMessage(e) });
+    } finally {
+      setRecomputing(false);
+    }
+  };
+
+  if (error) {
+    return (
+      <div className="space-y-4">
+        <BackBar onBack={onBack} title="Product" />
+        <div className="rounded-[18px] border border-rose-200 bg-rose-50 px-5 py-4 text-sm text-rose-900">
+          {error}
+        </div>
+      </div>
+    );
+  }
+
+  if (!product) {
+    return (
+      <div className="space-y-4">
+        <BackBar onBack={onBack} title="Product" />
+        <div className="rounded-[18px] border border-[var(--color-rule)] bg-[var(--color-surface)] py-12 text-center text-[var(--color-ink-muted)]">
+          Loading…
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-5">
+      <BackBar onBack={onBack} title="Product" />
+
+      <div className="rounded-[18px] border border-[var(--color-rule)] bg-[var(--color-surface)] px-5 py-5 space-y-3">
+        <div className="flex items-baseline justify-between gap-3">
+          <h2 className="font-display italic font-medium text-2xl leading-tight">
+            {product.custom_name || product.canonical_name}
+          </h2>
+          <span className={cn('inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-medium', CLASS_BADGE[product.item_class])}>
+            {product.item_class.replace('_', ' ')}
+          </span>
+        </div>
+        {product.custom_name && product.canonical_name && product.custom_name !== product.canonical_name && (
+          <p className="text-[12px] text-[var(--color-ink-muted)]">canonical: {product.canonical_name}</p>
+        )}
+        <div className="grid grid-cols-3 gap-3 pt-2">
+          <Stat label="Purchases" value={String(product.purchase_count)} />
+          <Stat label="Total spent" value={formatMinor(product.total_spent_minor)} />
+          <Stat label="Last on" value={product.last_purchased_on ?? '—'} />
+        </div>
+        <p className="text-[11px] uppercase tracking-[0.14em] text-[var(--color-ink-muted)] pt-1">
+          product_key: <span className="tnum">{product.product_key}</span>
+        </p>
+      </div>
+
+      {banner && (
+        <div
+          className={cn(
+            'rounded-[14px] px-4 py-3 text-sm',
+            banner.tone === 'ok'
+              ? 'border border-emerald-200 bg-emerald-50 text-emerald-900'
+              : 'border border-rose-200 bg-rose-50 text-rose-900',
+          )}
+        >
+          {banner.text}
+        </div>
+      )}
+
+      <Section title="Customize">
+        <label className="block text-[11px] tracking-[0.14em] uppercase text-[var(--color-ink-muted)]">
+          Custom name (your label)
+        </label>
+        <input
+          type="text"
+          value={customName}
+          onChange={(e) => {
+            setCustomName(e.target.value);
+            setEditDirty(true);
+          }}
+          placeholder={product.canonical_name}
+          className="mt-1 w-full px-4 py-2 rounded-[14px] border border-[var(--color-rule)] bg-[var(--color-surface)] text-sm focus:outline-none focus:border-[var(--color-ink)]"
+        />
+        <label className="block text-[11px] tracking-[0.14em] uppercase text-[var(--color-ink-muted)] mt-3">
+          Notes
+        </label>
+        <textarea
+          value={notes}
+          onChange={(e) => {
+            setNotes(e.target.value);
+            setEditDirty(true);
+          }}
+          rows={2}
+          className="mt-1 w-full px-4 py-2 rounded-[14px] border border-[var(--color-rule)] bg-[var(--color-surface)] text-sm focus:outline-none focus:border-[var(--color-ink)]"
+        />
+        <div className="mt-3 flex gap-2">
+          <button
+            onClick={onSave}
+            disabled={!editDirty || saving}
+            className="px-4 py-2 rounded-full bg-[var(--color-ink)] text-[var(--color-paper)] text-sm font-medium disabled:opacity-40"
+          >
+            {saving ? 'Saving…' : 'Save'}
+          </button>
+          <button
+            onClick={onRecompute}
+            disabled={recomputing}
+            className="px-4 py-2 rounded-full border border-[var(--color-rule)] text-sm flex items-center gap-1.5 disabled:opacity-40"
+          >
+            <RotateCw size={14} /> {recomputing ? 'Recomputing…' : 'Recompute stats'}
+          </button>
+        </div>
+      </Section>
+
+      <Section title={`Owned items (${owned?.length ?? 0})`}>
+        {owned === null && (
+          <p className="text-sm text-[var(--color-ink-muted)]">Loading…</p>
+        )}
+        {owned && owned.length === 0 && (
+          <p className="text-sm text-[var(--color-ink-muted)]">
+            No physical instances tracked. Owned items are auto-created from receipt lines tagged as durable.
+          </p>
+        )}
+        {owned && owned.length > 0 && (
+          <ul className="divide-y divide-[var(--color-rule-soft)] -mx-5">
+            {owned.map((o) => (
+              <li key={o.id} className="px-5 py-2.5 grid grid-cols-[1fr_auto] items-baseline gap-3">
+                <div className="min-w-0">
+                  <div className="text-sm">
+                    {o.location ?? <span className="text-[var(--color-ink-muted)]">no location</span>}
+                    {o.serial_number && (
+                      <span className="ml-2 text-[11px] text-[var(--color-ink-muted)] tnum">
+                        s/n {o.serial_number}
+                      </span>
+                    )}
+                    {o.condition && (
+                      <span className="ml-2 text-[10px] uppercase tracking-wider text-[var(--color-ink-muted)]">
+                        {o.condition}
+                      </span>
+                    )}
+                  </div>
+                  {(o.acquired_on || o.warranty_until) && (
+                    <div className="text-[11px] text-[var(--color-ink-muted)]">
+                      {o.acquired_on && `acquired ${o.acquired_on}`}
+                      {o.acquired_on && o.warranty_until && ' · '}
+                      {o.warranty_until && `warranty → ${o.warranty_until}`}
+                    </div>
+                  )}
+                </div>
+                {o.retired_at && (
+                  <span className="text-[10px] uppercase tracking-wider text-[var(--color-stamp)]">
+                    retired
+                  </span>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </Section>
+
+      <Section title="Merge into another product">
+        <p className="text-[12px] text-[var(--color-ink-muted)] mb-2">
+          Re-points all transaction_items and owned_items to the target, retires this product, recomputes the target. Cannot be undone (but you can manually re-add).
+        </p>
+        <div className="flex gap-2">
+          <input
+            type="text"
+            value={mergeTarget}
+            onChange={(e) => setMergeTarget(e.target.value)}
+            placeholder="Target product UUID"
+            className="flex-1 px-4 py-2 rounded-[14px] border border-[var(--color-rule)] bg-[var(--color-surface)] text-sm tnum focus:outline-none focus:border-[var(--color-ink)]"
+          />
+          <button
+            onClick={onMerge}
+            disabled={!mergeTarget.trim() || mergeBusy}
+            className="px-4 py-2 rounded-full bg-[var(--color-stamp)]/10 text-[var(--color-stamp)] border border-[var(--color-stamp)]/20 text-sm font-medium flex items-center gap-1.5 disabled:opacity-40"
+          >
+            <GitMerge size={14} /> {mergeBusy ? 'Merging…' : 'Merge'}
+          </button>
+        </div>
+      </Section>
+    </div>
+  );
+}
+
+// ─── Shared bits ─────────────────────────────────────────────────────
+
+function BackBar({
+  onBack,
+  title,
+  subtitle,
+}: {
+  onBack: () => void;
+  title: string;
+  subtitle?: string;
+}) {
+  return (
+    <div className="space-y-1">
+      <button
+        onClick={onBack}
+        className="inline-flex items-center gap-1 text-[12px] tracking-[0.14em] uppercase text-[var(--color-ink-muted)] hover:text-[var(--color-ink)] transition-colors"
+      >
+        <ArrowLeft size={14} /> Back
+      </button>
+      <h1 className="font-display italic font-medium text-3xl tracking-tight">{title}</h1>
+      {subtitle && <p className="text-[13px] text-[var(--color-ink-muted)]">{subtitle}</p>}
+    </div>
+  );
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="rounded-[18px] border border-[var(--color-rule)] bg-[var(--color-surface)] px-5 py-4">
+      <h3 className="font-display italic font-medium text-lg leading-none mb-3">{title}</h3>
+      {children}
+    </div>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <p className="text-[10px] tracking-[0.14em] uppercase text-[var(--color-ink-muted)]">{label}</p>
+      <p className="mt-0.5 font-display italic font-medium text-lg tnum">{value}</p>
+    </div>
+  );
+}

--- a/src/components/ReceiptDetail.tsx
+++ b/src/components/ReceiptDetail.tsx
@@ -12,6 +12,7 @@ import {
   restoreDocument,
   type ReceiptView,
   type BackendTransaction,
+  type BackendTransactionItem,
   type ReExtractDocumentResult,
 } from '../lib/api';
 import { statusBadge } from '../lib/transactionStatus';
@@ -196,7 +197,30 @@ export default function ReceiptDetail({ receiptId, onBack, onSelectMerchant, onA
   const tax = md<number>(legacy, 'tax');
   const tip = md<number>(legacy, 'tip');
   const rawText = md<string>(legacy, 'raw_text');
-  const items = md<Array<{ name: string; quantity?: number; unit_price?: number; total_price?: number }>>(legacy, 'items');
+  // #81: prefer transaction_items table (relational, with item_class /
+  // unit_price_minor / line_total_minor); fall back to legacy
+  // metadata.items JSON for transactions ingested before the lift.
+  const legacyItems = md<Array<{ name: string; quantity?: number; unit_price?: number; total_price?: number }>>(legacy, 'items');
+  const items: BackendTransactionItem[] = receipt.items.length > 0
+    ? receipt.items
+    : (legacyItems ?? []).map((i, idx) => ({
+        line_no: idx + 1,
+        raw_name: i.name,
+        normalized_name: null,
+        quantity: i.quantity ?? 1,
+        unit: null,
+        unit_price_minor: i.unit_price != null ? Math.round(i.unit_price * 100) : null,
+        line_total_minor: i.total_price != null ? Math.round(i.total_price * 100) : 0,
+        currency: receipt.currency,
+        item_class: 'other',
+        confidence: 'low',
+        line_type: 'product',
+        product_id: null,
+        tax_minor: null,
+        tip_share_minor: null,
+        discount_share_minor: null,
+        effective_total_minor: i.total_price != null ? Math.round(i.total_price * 100) : 0,
+      } satisfies BackendTransactionItem));
   const confidence = md<number>(
     (legacy.quality as Metadata | undefined) ?? {},
     'confidence_score',
@@ -265,8 +289,8 @@ export default function ReceiptDetail({ receiptId, onBack, onSelectMerchant, onA
         isProcessing={isProcessing}
       />
 
-      {!isProcessing && items && items.length > 0 && (
-        <LineItemsCard items={items} />
+      {!isProcessing && items.length > 0 && (
+        <LineItemsCard items={items} currency={receipt.currency} />
       )}
 
       {receipt.narration && !isProcessing && (
@@ -772,33 +796,84 @@ function SmallFieldCard({
   );
 }
 
+// Subtle background per item class — keeps the badge informative
+// without screaming. Matches the paper palette.
+const ITEM_CLASS_STYLE: Record<BackendTransactionItem['item_class'], string> = {
+  durable: 'bg-[var(--color-paper-deep)] text-[var(--color-ink)]',
+  consumable: 'bg-amber-50 text-amber-900',
+  food_drink: 'bg-rose-50 text-rose-900',
+  service: 'bg-sky-50 text-sky-900',
+  other: 'bg-stone-100 text-stone-700',
+};
+
+const ITEM_CLASS_LABEL: Record<BackendTransactionItem['item_class'], string> = {
+  durable: 'durable',
+  consumable: 'consumable',
+  food_drink: 'food',
+  service: 'service',
+  other: 'other',
+};
+
+function formatMinor(minor: number | null, currency: string): string {
+  if (minor == null) return '—';
+  const sym = currency === 'USD' ? '$' : '';
+  return `${sym}${(minor / 100).toFixed(2)}`;
+}
+
 function LineItemsCard({
   items,
+  currency,
 }: {
-  items: Array<{ name: string; quantity?: number; unit_price?: number; total_price?: number }>;
+  items: BackendTransactionItem[];
+  currency: string;
 }) {
   return (
     <div className="rounded-[18px] border border-[var(--color-rule)] bg-[var(--color-surface)] overflow-hidden">
-      <div className="px-5 py-4 border-b border-[var(--color-rule)]">
+      <div className="px-5 py-4 border-b border-[var(--color-rule)] flex items-baseline justify-between">
         <h3 className="font-display italic font-medium text-lg leading-none">
           Items <span className="text-[var(--color-ink-muted)]">({items.length})</span>
         </h3>
+        <span className="text-[10px] tracking-[0.16em] uppercase text-[var(--color-ink-muted)]">
+          from transaction_items
+        </span>
       </div>
       <ul className="divide-y divide-[var(--color-rule-soft)]">
-        {items.map((item, i) => (
-          <li
-            key={i}
-            className="grid grid-cols-[1fr_auto_auto] items-baseline gap-4 px-5 py-3"
-          >
-            <span className="text-sm font-medium truncate">{item.name}</span>
-            <span className="text-xs text-[var(--color-ink-muted)] tnum">
-              {item.quantity ?? 1}×
-            </span>
-            <span className="font-display italic font-medium text-base tnum">
-              {item.total_price != null ? `$${item.total_price.toFixed(2)}` : '—'}
-            </span>
-          </li>
-        ))}
+        {items.map((item) => {
+          const name = item.normalized_name?.trim() || item.raw_name;
+          return (
+            <li
+              key={item.line_no}
+              className="grid grid-cols-[1fr_auto] items-start gap-4 px-5 py-3"
+            >
+              <div className="min-w-0">
+                <div className="flex items-center gap-2">
+                  <span className="text-sm font-medium truncate">{name}</span>
+                  <span
+                    className={cn(
+                      'inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-medium leading-none',
+                      ITEM_CLASS_STYLE[item.item_class],
+                    )}
+                  >
+                    {ITEM_CLASS_LABEL[item.item_class]}
+                  </span>
+                  {item.line_type !== 'product' && (
+                    <span className="text-[10px] text-[var(--color-ink-muted)] uppercase tracking-wider">
+                      {item.line_type}
+                    </span>
+                  )}
+                </div>
+                {item.unit_price_minor != null && item.quantity !== 1 && (
+                  <div className="mt-0.5 text-[11px] text-[var(--color-ink-muted)] tnum">
+                    {item.quantity} × {formatMinor(item.unit_price_minor, item.currency || currency)}
+                  </div>
+                )}
+              </div>
+              <span className="font-display italic font-medium text-base tnum">
+                {formatMinor(item.line_total_minor, item.currency || currency)}
+              </span>
+            </li>
+          );
+        })}
       </ul>
     </div>
   );

--- a/src/generated/buildInfo.json
+++ b/src/generated/buildInfo.json
@@ -1,8 +1,8 @@
 {
   "service": "receipt-assistant-frontend",
   "version": "0.0.0",
-  "gitSha": "e4376c75c4bdbafd18f528dc737b1e3562a7c03f",
-  "gitShortSha": "e4376c7",
-  "gitBranch": "feat/merchant-aggregation-frontend-33",
-  "builtAt": "2026-05-12T20:46:38.930Z"
+  "gitSha": "2cb72d1146cef091064688be9d2c4c78e4321d32",
+  "gitShortSha": "2cb72d1",
+  "gitBranch": "main",
+  "builtAt": "2026-05-16T09:31:49.516Z"
 }

--- a/src/generated/buildInfo.ts
+++ b/src/generated/buildInfo.ts
@@ -1,8 +1,8 @@
 export const buildInfo = {
   "service": "receipt-assistant-frontend",
   "version": "0.0.0",
-  "gitSha": "e4376c75c4bdbafd18f528dc737b1e3562a7c03f",
-  "gitShortSha": "e4376c7",
-  "gitBranch": "feat/merchant-aggregation-frontend-33",
-  "builtAt": "2026-05-12T20:46:38.930Z"
+  "gitSha": "2cb72d1146cef091064688be9d2c4c78e4321d32",
+  "gitShortSha": "2cb72d1",
+  "gitBranch": "main",
+  "builtAt": "2026-05-16T09:31:49.516Z"
 } as const;

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -1010,6 +1010,734 @@ export interface paths {
         };
         trace?: never;
     };
+    "/v1/items": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List transaction items (admin / aggregation) */
+        get: {
+            parameters: {
+                query?: {
+                    class?: "durable" | "consumable" | "food_drink" | "service" | "other";
+                    from?: string;
+                    to?: string;
+                    transaction_id?: string;
+                    tag?: string;
+                    cursor?: string;
+                    limit?: number;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            items: components["schemas"]["ListedTransactionItem"][];
+                            next_cursor: string | null;
+                        };
+                    };
+                };
+                /** @description Bad request */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/products": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List products in the workspace catalog */
+        get: {
+            parameters: {
+                query?: {
+                    class?: "durable" | "consumable" | "food_drink" | "service" | "other";
+                    brand_id?: string;
+                    merchant_id?: string;
+                    q?: string;
+                    include_retired?: boolean | null;
+                    cursor?: string;
+                    limit?: number;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            items: components["schemas"]["Product"][];
+                            next_cursor: string | null;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/products/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Fetch a single product */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Product"];
+                    };
+                };
+                /** @description Not Found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /** Patch product user-truth fields */
+        patch: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/merge-patch+json": components["schemas"]["UpdateProductRequest"];
+                    "application/json": components["schemas"]["UpdateProductRequest"];
+                };
+            };
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Product"];
+                    };
+                };
+                /** @description Not Found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+            };
+        };
+        trace?: never;
+    };
+    "/v1/products/{id}/merge_into": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Merge this product into the target — re-points transaction_items + owned_items, retires source */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["MergeProductRequest"];
+                };
+            };
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MergeProductResponse"];
+                    };
+                };
+                /** @description Bad request (e.g. self-merge) */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+                /** @description Source or target not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+                /** @description Source already retired */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/products/{id}/recompute": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Recompute aggregate stats from the live transaction_items set */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /**
+                             * Format: uuid
+                             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+                             */
+                            id: string;
+                            purchase_count: number;
+                            total_spent_minor: number;
+                            first_purchased_on: string | null;
+                            last_purchased_on: string | null;
+                        };
+                    };
+                };
+                /** @description Not Found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/owned-items": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List owned physical-instance items */
+        get: {
+            parameters: {
+                query?: {
+                    product_id?: string;
+                    location?: string;
+                    include_retired?: boolean | null;
+                    cursor?: string;
+                    limit?: number;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            items: components["schemas"]["OwnedItem"][];
+                            next_cursor: string | null;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        /** Manually add an owned item (gift / secondhand / inherited) */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["CreateOwnedItemRequest"];
+                };
+            };
+            responses: {
+                /** @description Created */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["OwnedItem"];
+                    };
+                };
+                /** @description Validation failed */
+                422: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/owned-items/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Fetch one owned item */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["OwnedItem"];
+                    };
+                };
+                /** @description Not Found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        /** Hard-delete an owned item (typically used by undo of manual create) */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Deleted */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Not Found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        /** Patch serial / location / warranty / condition / notes */
+        patch: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/merge-patch+json": components["schemas"]["UpdateOwnedItemRequest"];
+                    "application/json": components["schemas"]["UpdateOwnedItemRequest"];
+                };
+            };
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["OwnedItem"];
+                    };
+                };
+                /** @description Not Found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+            };
+        };
+        trace?: never;
+    };
+    "/v1/brands": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List brands (global registry) */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            items: components["schemas"]["Brand"][];
+                            next_cursor: string | null;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/brands/{brandId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Fetch one brand */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    brandId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Brand"];
+                    };
+                };
+                /** @description Not Found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /** Update a brand — name / domain / Layer-3 preferred_asset_id override */
+        patch: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    brandId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/merge-patch+json": components["schemas"]["UpdateBrandRequest"];
+                    "application/json": components["schemas"]["UpdateBrandRequest"];
+                };
+            };
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Brand"];
+                    };
+                };
+                /** @description Not Found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+            };
+        };
+        trace?: never;
+    };
+    "/v1/brands/{brandId}/assets": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List candidate icons for a brand */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    brandId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            items: components["schemas"]["BrandAsset"][];
+                            next_cursor: string | null;
+                        };
+                    };
+                };
+                /** @description Not Found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/brands/{brandId}/icon": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Resolve the preferred icon and stream it (501 until #101 Phase 2) */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    brandId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Icon bytes */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Brand or preferred asset missing */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+                /** @description Streaming not implemented yet */
+                501: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/postings": {
         parameters: {
             query?: never;
@@ -3093,6 +3821,40 @@ export interface components {
                 ocr_extracted?: unknown;
             }[] | null;
         } | null;
+        TransactionItem: {
+            line_no: number;
+            raw_name: string;
+            normalized_name: string | null;
+            quantity: number | null;
+            unit: string | null;
+            unit_price_minor: number | null;
+            line_total_minor: number;
+            currency: string;
+            /** @enum {string} */
+            item_class: "durable" | "consumable" | "food_drink" | "service" | "other";
+            /** @enum {string|null} */
+            durability_tier?: "luxury" | "standard" | null;
+            /** @enum {string|null} */
+            food_kind?: "restaurant_dish" | "grocery_food" | "beverage" | null;
+            tags?: string[] | null;
+            /** @enum {string} */
+            confidence: "high" | "medium" | "low";
+            /** @default product */
+            line_type: string;
+            /**
+             * Format: uuid
+             * @default null
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            product_id: string | null;
+            /** @default null */
+            tax_minor: number | null;
+            /** @default null */
+            tip_share_minor: number | null;
+            /** @default null */
+            discount_share_minor: number | null;
+            effective_total_minor: number;
+        };
         Transaction: {
             /**
              * Format: uuid
@@ -3145,6 +3907,7 @@ export interface components {
             postings: components["schemas"]["Posting"][];
             documents: components["schemas"]["TransactionDocumentRef"][];
             place: components["schemas"]["Place"];
+            items: components["schemas"]["TransactionItem"][];
         };
         BulkResultItem: {
             index: number;
@@ -3153,6 +3916,278 @@ export interface components {
         };
         BulkResponse: {
             results: components["schemas"]["BulkResultItem"][];
+        };
+        ListedTransactionItem: components["schemas"]["TransactionItem"] & {
+            /** Format: uuid */
+            id: string;
+            /** Format: uuid */
+            transaction_id: string;
+            created_at: string;
+        };
+        Product: {
+            /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            id: string;
+            /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            workspace_id: string;
+            product_key: string;
+            canonical_name: string;
+            /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            merchant_id: string | null;
+            brand_id: string | null;
+            /** @enum {string} */
+            item_class: "durable" | "consumable" | "food_drink" | "service" | "other";
+            model: string | null;
+            color: string | null;
+            size: string | null;
+            variant: string | null;
+            sku: string | null;
+            manufacturer: string | null;
+            /**
+             * Format: date
+             * @example 2026-04-19
+             */
+            first_purchased_on: string | null;
+            /**
+             * Format: date
+             * @example 2026-04-19
+             */
+            last_purchased_on: string | null;
+            purchase_count: number;
+            total_spent_minor: number;
+            custom_name: string | null;
+            notes: string | null;
+            /** Format: date-time */
+            retired_from_catalog_at: string | null;
+            /**
+             * @description User-defined JSON object; not schema-validated.
+             * @default {}
+             */
+            metadata: {
+                [key: string]: unknown;
+            };
+            /** Format: date-time */
+            created_at: string;
+            /** Format: date-time */
+            updated_at: string;
+        };
+        UpdateProductRequest: {
+            custom_name?: string | null;
+            notes?: string | null;
+            brand_id?: string | null;
+            /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            merchant_id?: string | null;
+            /** Format: date-time */
+            retired_from_catalog_at?: string | null;
+        };
+        MergeProductRequest: {
+            /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            target_id: string;
+        };
+        MergeProductResponse: {
+            /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            source_id: string;
+            /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            target_id: string;
+            moved_transaction_items: number;
+            moved_owned_items: number;
+            /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            derivation_event_id: string;
+        };
+        OwnedItem: {
+            /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            id: string;
+            /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            workspace_id: string;
+            /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            product_id: string;
+            /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            transaction_item_id: string | null;
+            instance_index: number;
+            serial_number: string | null;
+            location: string | null;
+            /**
+             * Format: date
+             * @example 2026-04-19
+             */
+            acquired_on: string | null;
+            /**
+             * Format: date
+             * @example 2026-04-19
+             */
+            warranty_until: string | null;
+            condition: string | null;
+            /** Format: date-time */
+            retired_at: string | null;
+            notes: string | null;
+            /**
+             * @description User-defined JSON object; not schema-validated.
+             * @default {}
+             */
+            metadata: {
+                [key: string]: unknown;
+            };
+            /** Format: date-time */
+            created_at: string;
+            /** Format: date-time */
+            updated_at: string;
+        };
+        CreateOwnedItemRequest: {
+            /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            product_id: string;
+            /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            transaction_item_id?: string;
+            instance_index?: number;
+            serial_number?: string;
+            location?: string;
+            /**
+             * Format: date
+             * @example 2026-04-19
+             */
+            acquired_on?: string;
+            /**
+             * Format: date
+             * @example 2026-04-19
+             */
+            warranty_until?: string;
+            condition?: string;
+            notes?: string;
+            /**
+             * @description User-defined JSON object; not schema-validated.
+             * @default {}
+             */
+            metadata: {
+                [key: string]: unknown;
+            };
+        };
+        UpdateOwnedItemRequest: {
+            serial_number?: string | null;
+            location?: string | null;
+            /**
+             * Format: date
+             * @example 2026-04-19
+             */
+            acquired_on?: string | null;
+            /**
+             * Format: date
+             * @example 2026-04-19
+             */
+            warranty_until?: string | null;
+            condition?: string | null;
+            notes?: string | null;
+            /** Format: date-time */
+            retired_at?: string | null;
+            /**
+             * @description User-defined JSON object; not schema-validated.
+             * @default {}
+             */
+            metadata: {
+                [key: string]: unknown;
+            };
+        };
+        Brand: {
+            brand_id: string;
+            parent_id: string | null;
+            name: string;
+            domain: string | null;
+            /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            preferred_asset_id: string | null;
+            icon_url: string | null;
+            /** Format: date-time */
+            user_chose_at: string | null;
+            /** Format: date-time */
+            created_at: string;
+            /** Format: date-time */
+            updated_at: string;
+        };
+        BrandAsset: {
+            /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            id: string;
+            brand_id: string;
+            /** @enum {string} */
+            tier: "itunes" | "svgl" | "logo_dev" | "simple_icons" | "user_upload" | "manual_url";
+            source_url: string | null;
+            local_path: string;
+            content_hash: string;
+            content_type: string;
+            width: number | null;
+            height: number | null;
+            bytes: number | null;
+            /** Format: date-time */
+            acquired_at: string;
+            /** Format: date-time */
+            last_seen_at: string;
+            agent_relevance: number | null;
+            agent_notes: string | null;
+            extraction_version: number;
+            user_rating: number | null;
+            user_uploaded: boolean;
+            user_notes: string | null;
+            /** Format: date-time */
+            retired_at: string | null;
+            /**
+             * @description User-defined JSON object; not schema-validated.
+             * @default {}
+             */
+            metadata: {
+                [key: string]: unknown;
+            };
+        };
+        UpdateBrandRequest: {
+            /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            preferred_asset_id?: string | null;
+            name?: string;
+            domain?: string | null;
         };
         Document: {
             /**

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -42,6 +42,11 @@ export type BackendTransaction = components['schemas']['Transaction'];
 export type BackendPosting = components['schemas']['Posting'];
 export type BackendPlace = components['schemas']['Place'];
 export type BackendDocument = components['schemas']['Document'];
+export type BackendTransactionItem = components['schemas']['TransactionItem'];
+export type BackendProduct = components['schemas']['Product'];
+export type BackendOwnedItem = components['schemas']['OwnedItem'];
+export type BackendBrand = components['schemas']['Brand'];
+export type BackendBrandAsset = components['schemas']['BrandAsset'];
 export type BackendBatch = components['schemas']['Batch'];
 export type BackendBatchSummary = components['schemas']['BatchSummary'];
 export type BackendIngest = components['schemas']['Ingest'];
@@ -104,6 +109,9 @@ export interface ReceiptView {
   /** Canonical merchant brand id (from metadata.merchant.brand_id),
    *  used to link to the merchant aggregation page. */
   merchantBrandId: string | null;
+  /** Line items lifted from transaction_items (#81). Empty array
+   *  for transactions without extracted lines. */
+  items: BackendTransactionItem[];
   etag: string | null;
 }
 
@@ -348,6 +356,7 @@ export function toReceiptView(t: BackendTransaction, etag: string | null = null)
     postings: t.postings,
     place: t.place ?? null,
     merchantBrandId: merchantFromTxn(t)?.brand_id ?? null,
+    items: t.items ?? [],
     etag,
   };
 }
@@ -1249,4 +1258,117 @@ export function placeName(p: PlaceFull | null | undefined): {
   if (!zh && !en) return null;
   if (zh && en && zh !== en) return { primary: zh, alternate: en };
   return { primary: zh ?? en ?? '', alternate: null };
+}
+
+// ── Products / OwnedItems / Brands (#84, #101) ──────────────────
+//
+// Vertical-slice frontend for three backend features shipped 2026-05-16:
+//   - #81 transaction_items (consumed via Transaction.items above)
+//   - #84 products SSOT + owned_items physical-inventory
+//   - #101 brands + brand_assets
+//
+// Helpers below are intentionally thin pass-throughs to openapi-fetch;
+// no business logic in the client. UI lives in src/components/.
+
+export interface ListProductsOptions {
+  class?: 'durable' | 'consumable' | 'food_drink' | 'service' | 'other';
+  brand_id?: string;
+  merchant_id?: string;
+  search?: string;
+  limit?: number;
+}
+
+export async function listProducts(opts: ListProductsOptions = {}): Promise<BackendProduct[]> {
+  const { data, error, response } = await client.GET('/v1/products', {
+    params: { query: opts },
+  });
+  return unwrap('listProducts', data, error, response.status).items;
+}
+
+export async function getProduct(id: string): Promise<BackendProduct> {
+  const { data, error, response } = await client.GET('/v1/products/{id}', {
+    params: { path: { id } },
+  });
+  return unwrap('getProduct', data, error, response.status);
+}
+
+export async function patchProduct(
+  id: string,
+  patch: components['schemas']['UpdateProductRequest'],
+): Promise<BackendProduct> {
+  const { data, error, response } = await client.PATCH('/v1/products/{id}', {
+    params: { path: { id } },
+    body: patch,
+  });
+  return unwrap('patchProduct', data, error, response.status);
+}
+
+export type MergeProductResult = components['schemas']['MergeProductResponse'];
+
+export async function mergeProductInto(
+  sourceId: string,
+  targetId: string,
+): Promise<MergeProductResult> {
+  const { data, error, response } = await client.POST('/v1/products/{id}/merge_into', {
+    params: { path: { id: sourceId } },
+    body: { target_id: targetId },
+  });
+  return unwrap('mergeProductInto', data, error, response.status);
+}
+
+export interface RecomputeProductResult {
+  id: string;
+  purchase_count: number;
+  total_spent_minor: number;
+  first_purchased_on: string | null;
+  last_purchased_on: string | null;
+}
+
+export async function recomputeProduct(id: string): Promise<RecomputeProductResult> {
+  const { data, error, response } = await client.POST('/v1/products/{id}/recompute', {
+    params: { path: { id } },
+  });
+  return unwrap('recomputeProduct', data, error, response.status);
+}
+
+export async function listOwnedItems(opts: {
+  product_id?: string;
+  location?: string;
+  include_retired?: boolean;
+  limit?: number;
+} = {}): Promise<BackendOwnedItem[]> {
+  const { data, error, response } = await client.GET('/v1/owned-items', {
+    params: { query: opts },
+  });
+  return unwrap('listOwnedItems', data, error, response.status).items;
+}
+
+export async function listBrands(): Promise<BackendBrand[]> {
+  const { data, error, response } = await client.GET('/v1/brands', {});
+  return unwrap('listBrands', data, error, response.status).items;
+}
+
+export async function getBrand(brandId: string): Promise<BackendBrand> {
+  const { data, error, response } = await client.GET('/v1/brands/{brandId}', {
+    params: { path: { brandId } },
+  });
+  return unwrap('getBrand', data, error, response.status);
+}
+
+export async function listBrandAssets(brandId: string): Promise<BackendBrandAsset[]> {
+  const { data, error, response } = await client.GET('/v1/brands/{brandId}/assets', {
+    params: { path: { brandId } },
+  });
+  return unwrap('listBrandAssets', data, error, response.status).items;
+}
+
+export async function patchBrand(
+  brandId: string,
+  patch: { name?: string; domain?: string | null; preferred_asset_id?: string | null },
+): Promise<BackendBrand> {
+  const { data, error, response } = await client.PATCH('/v1/brands/{brandId}', {
+    params: { path: { brandId } },
+    body: patch,
+  });
+  return unwrap('patchBrand', data, error, response.status);
 }


### PR DESCRIPTION
## Summary

Three vertical-slice UIs that finally surface the Wave 1 backend work (#81 transaction_items, #84 products SSOT + owned_items, #101 Phase 1 brands) to actual users in a browser. Each slice is end-to-end: real OCR data → DB → typed API → UI → tested in Chrome.

This closes the gap flagged earlier today: backend shipped 11 PRs that night with only 4 of them having any frontend consumption. After this PR, every Wave 1 backend capability (except #101 Phase 2 agent acquisition) has a UI you can actually click through.

## What's new

**Slice #81 — line items on ReceiptDetail**
- ReceiptDetail now prefers the relational `transaction_items` field over the legacy `metadata.items` JSON, with a backfill path so older receipts still render
- Each line shows: name, `item_class` color pill (durable / consumable / food / service / other), `line_type` secondary label for tax / surcharge / discount rows, qty × unit_price math on multi-quantity lines

**Slice #84 — Products page** (`/components/Products.tsx` new)
- Catalog list with class filter chips + search
- Detail: hero stats (purchases / total spent / last on), `product_key`, Customize (`custom_name` + `notes`), Recompute stats, Owned items list, Merge into another product
- API helpers: `listProducts` / `getProduct` / `patchProduct` / `mergeProductInto` / `recomputeProduct` / `listOwnedItems`

**Slice #101 Phase 1 — Brands page** (`/components/Brands.tsx` new)
- List + detail with `brand_assets` picker that PATCHes `preferred_asset_id`
- Honest about Phase 1 limits: `/v1/brands/:id/icon` returns 501 stub today, so the picker displays raw asset metadata (source_url, tier, dimensions, agent_relevance) until Phase 2 streams real icons

**Nav gap fixed**
- Settings was an `ActiveTab` with no entry point in the dock — added a small cog button as the 4th dock item. Settings is now a hub with Products + Brands cards alongside Build & Deploy.

## Test plan

Browser-verified via `frontend-test-runner` against live backend `af2adb4` + real OCR data from a generated Apple Store receipt (agent extracted 5 line items spanning durable / service / tax / surcharge):

- [x] Receipt with extracted items shows `Items (16)` card with `FROM TRANSACTION_ITEMS` subtitle, multi-qty math correct ("Meatballs 2 × \$4.25 \$8.50")
- [x] Apple receipt detail shows mixed-class lines (MacBook durable + AppleCare service + Cable durable + Sales Tax + Recycling Fee surcharge) with correct pills
- [x] Settings reachable from new dock cog → Products card → catalog with 20 products + 6 class filter chips
- [x] Click MacBook Pro → detail with `product_key=MACBOOK-PRO-14-M4-PRO-24GB-1TB-SPACE-BLACK` (extractor-derived), 1× / \$2736.40 / 2026-05-10
- [x] PATCH custom_name round-trips: save shows "Saved." banner, hero title updates, `canonical:` subline appears; revert + save again clears
- [x] POST recompute returns updated aggregates → "Recomputed: 1× / \$4.50." banner
- [x] Brands page renders documented empty state (#101 Phase 2 deferred)
- [x] No console errors from new endpoints; only pre-existing MerchantDetail 404s (Google Place ID lookup + missing photo cache, unrelated)

Full report with screenshots: `test-reports/2026-05-16_wave-2-catch-up-items-products-brands.html`.

## Consumes (cross-repo)
- TINKPA/receipt-assistant#81 (Phase 1 + 2)
- TINKPA/receipt-assistant#84 (Phase 1 + 2 + 3)
- TINKPA/receipt-assistant#101 (Phase 1)

No backend changes needed — `api-types.ts` regenerated via `npm run api:types` against the committed `openapi.json` at `af2adb4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)