### PR TITLE
feat: brand-level rename UI for #79 Phase C

### DIFF
--- a/src/components/MerchantDetail.tsx
+++ b/src/components/MerchantDetail.tsx
@@ -4,6 +4,7 @@ import {
   fetchMerchant,
   fetchMerchantTransactions,
   fetchPlace,
+  patchMerchant,
   patchPlace,
   pickCjk,
   placeName,
@@ -104,16 +105,17 @@ export default function MerchantDetail({ brandId, onBack, onSelectReceipt }: Mer
     }
   };
 
-  // The legacy hero "pencil" affordance. Originally Chinese-only;
-  // post-#79 the column is language-agnostic, so any string is fine.
-  // A dedicated inline-rename modal from transaction rows lands in
-  // a follow-up PR (#79 MVP A).
-  const onEditName = async () => {
+  // Place-level rename (#79 Phase B). Targets a SINGLE branch's
+  // display name. Use this only when one location specifically needs
+  // a different name from the brand-wide rename — e.g. "Costco
+  // Wholesale Burbank" specifically vs. "Costco" everywhere else.
+  // Most users want the brand-level rename below instead.
+  const onEditPlaceName = async () => {
     if (!place) return;
     const current =
       place.custom_name ?? place.custom_name_zh ?? pickCjk(place.display_name_zh) ?? '';
     const next = window.prompt(
-      'Your name for this merchant (clear to remove override):',
+      'Override the name FOR THIS LOCATION only (clear to remove):',
       current,
     );
     if (next === null) return; // user cancelled
@@ -122,6 +124,32 @@ export default function MerchantDetail({ brandId, onBack, onSelectReceipt }: Mer
         custom_name: next.trim() === '' ? null : next.trim(),
       });
       setPlace(updated);
+    } catch (e) {
+      window.alert(`Could not save: ${extractProblemMessage(e)}`);
+    }
+  };
+
+  // Brand-level rename (#79 Phase C). Propagates to every place row
+  // sharing this brand_id within the workspace. Works even when
+  // `place_id IS NULL` (Phase D effect). One rename here is the
+  // typical user intent — fixes "Costco" everywhere instead of
+  // having to override 5 separate place rows.
+  const onEditBrandName = async () => {
+    if (!detail) return;
+    const current = detail.merchant.custom_name ?? detail.merchant.canonical_name ?? '';
+    const next = window.prompt(
+      `Rename "${detail.merchant.canonical_name}" everywhere (clear to remove override):`,
+      current,
+    );
+    if (next === null) return; // user cancelled
+    try {
+      const updated = await patchMerchant(detail.merchant.id, {
+        custom_name: next.trim() === '' ? null : next.trim(),
+      });
+      setDetail({
+        ...detail,
+        merchant: { ...detail.merchant, ...updated },
+      });
     } catch (e) {
       window.alert(`Could not save: ${extractProblemMessage(e)}`);
     }
@@ -186,12 +214,21 @@ export default function MerchantDetail({ brandId, onBack, onSelectReceipt }: Mer
               {category}
             </p>
           )}
-          <h1 className={cn(
-            'font-display italic font-medium text-3xl sm:text-4xl leading-tight tracking-tight',
-            m.photo_url ? 'text-white' : 'text-white',
-          )}>
-            {m.canonical_name}
-          </h1>
+          <button
+            type="button"
+            onClick={onEditBrandName}
+            title={
+              m.custom_name
+                ? `You renamed this brand to "${m.custom_name}". Click to edit.`
+                : `Click to rename "${m.canonical_name}" everywhere.`
+            }
+            className={cn(
+              'block text-left font-display italic font-medium text-3xl sm:text-4xl leading-tight tracking-tight transition-colors',
+              m.photo_url ? 'text-white hover:text-white/80' : 'text-white hover:text-white/80',
+            )}
+          >
+            {m.custom_name ?? m.canonical_name}
+          </button>
           {(() => {
             // Chinese-name subtitle. Renders when the linked place has
             // any source of a non-English display name (Google zh-CN,
@@ -217,9 +254,9 @@ export default function MerchantDetail({ brandId, onBack, onSelectReceipt }: Mer
             return (
               <button
                 type="button"
-                onClick={onEditName}
+                onClick={onEditPlaceName}
                 className="mt-1 inline-flex items-center gap-2 group"
-                title={zh ? `Source: ${source}. Click to edit.` : 'Add a name override'}
+                title={zh ? `Source: ${source}. Click to edit (per-location override).` : 'Add a per-location override'}
               >
                 {zh ? (
                   <>

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -1691,7 +1691,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Resolve the preferred icon and stream it (501 until #101 Phase 2) */
+        /**
+         * Stream the brand's preferred icon bytes
+         * @description Resolves preferred_asset_id and streams the file. 404 when the brand is missing, no asset is preferred, the asset is retired, or the file is missing on disk. Frontend falls back to CategoryIcon on 404 — never to a different candidate.
+         */
         get: {
             parameters: {
                 query?: never;
@@ -1710,17 +1713,8 @@ export interface paths {
                     };
                     content?: never;
                 };
-                /** @description Brand or preferred asset missing */
+                /** @description Brand or icon unavailable */
                 404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/problem+json": components["schemas"]["ProblemDetails"];
-                    };
-                };
-                /** @description Streaming not implemented yet */
-                501: {
                     headers: {
                         [name: string]: unknown;
                     };
@@ -2992,7 +2986,55 @@ export interface paths {
         delete?: never;
         options?: never;
         head?: never;
-        patch?: never;
+        /**
+         * Update a merchant — brand-level Layer-3 custom_name override (#79)
+         * @description Currently only `custom_name` is editable. Other merchant fields are agent-owned via the ingest extractor and not user-editable from this endpoint. Pass `custom_name: null` to clear the override.
+         */
+        patch: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["UpdateMerchantRequest"];
+                    "application/merge-patch+json": components["schemas"]["UpdateMerchantRequest"];
+                };
+            };
+            responses: {
+                /** @description Updated merchant */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Merchant"];
+                    };
+                };
+                /** @description No editable fields supplied */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+                /** @description Merchant not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+            };
+        };
         trace?: never;
     };
     "/v1/merchants/{id}/photo": {
@@ -4644,6 +4686,7 @@ export interface components {
             enrichment_status: "pending" | "success" | "not_found" | "failed";
             /** Format: date-time */
             enrichment_attempted_at: string | null;
+            custom_name: string | null;
             /** Format: date-time */
             created_at: string;
             /** Format: date-time */
@@ -4681,6 +4724,9 @@ export interface components {
         MerchantTransactionsResponse: {
             items: components["schemas"]["MerchantTransactionRow"][];
             next_cursor: string | null;
+        };
+        UpdateMerchantRequest: {
+            custom_name?: string | null;
         };
         NewPosting: {
             /**

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -235,13 +235,45 @@ export function displayName(
       }
     | null
     | undefined,
-  fallback: string | null,
-  userLangs: readonly ('zh' | 'en')[] = ['zh', 'en'],
+  fallbackOrMerchant:
+    | string
+    | null
+    | { custom_name?: string | null; canonical_name?: string | null }
+    | undefined,
+  fallbackOrLangs?: string | null | readonly ('zh' | 'en')[],
+  userLangsArg: readonly ('zh' | 'en')[] = ['zh', 'en'],
 ): string {
+  // Backward-compat: original signature was (place, fallback, userLangs).
+  // Phase C of #79 adds an optional merchant arg ahead of fallback for
+  // brand-level overrides. Disambiguate based on the type of the
+  // second arg.
+  let merchant:
+    | { custom_name?: string | null; canonical_name?: string | null }
+    | null
+    | undefined;
+  let fallback: string | null;
+  let userLangs: readonly ('zh' | 'en')[];
+  if (
+    fallbackOrMerchant &&
+    typeof fallbackOrMerchant === 'object' &&
+    !Array.isArray(fallbackOrMerchant)
+  ) {
+    merchant = fallbackOrMerchant;
+    fallback = typeof fallbackOrLangs === 'string' ? fallbackOrLangs : null;
+    userLangs = Array.isArray(fallbackOrLangs) ? fallbackOrLangs : userLangsArg;
+  } else {
+    merchant = null;
+    fallback = typeof fallbackOrMerchant === 'string' ? fallbackOrMerchant : null;
+    userLangs = Array.isArray(fallbackOrLangs) ? fallbackOrLangs : userLangsArg;
+  }
+
+  // Layer-3 cascade per #79: per-place override → brand-level override
+  // → derived (Google/OCR) → fallback.
   if (place?.custom_name) return place.custom_name;
   // Backward-compat fallback while the deprecated alias is still
   // emitted by the backend (#79 transition window).
   if (place?.custom_name_zh) return place.custom_name_zh;
+  if (merchant?.custom_name) return merchant.custom_name;
   for (const lang of userLangs) {
     if (lang === 'zh') {
       const zh =
@@ -368,11 +400,12 @@ export function mapTransaction(t: BackendTransaction): Transaction {
   const m = merchantFromTxn(t);
   // Single-name policy (see receipt-assistant-frontend#?): list
   // rows show ONE name, picked by displayName(). No subtitle, no
-  // pinyin alongside. The choice cascades user override → native
-  // CJK → English → glossed CJK → address → receipt payee.
+  // pinyin alongside. The cascade is: place.custom_name →
+  // merchant.custom_name (#79 Phase C) → native CJK → English →
+  // glossed CJK → address → receipt payee.
   return {
     id: t.id,
-    description: displayName(t.place, rv.payee ?? rv.narration ?? null),
+    description: displayName(t.place, m, rv.payee ?? rv.narration ?? null),
     placeCity: formatPlaceCity(t.place),
     // `placeMapUrl` is the proxied Static Maps endpoint that the
     // row renderer hits via `<PlaceThumbnail>` (#96). Only set when
@@ -1146,6 +1179,24 @@ export async function fetchMerchantTransactions(
     },
   );
   return unwrap('fetchMerchantTransactions', data, error, response.status);
+}
+
+/**
+ * Update the user-overridable `custom_name` on a merchant (#79 Phase C).
+ * One rename propagates to every place row under this brand_id within
+ * the workspace — solves the "I've been to 5 Costcos and renamed it 5
+ * times" pain. Per-place override (`patchPlace`) still wins when set.
+ * Pass `null` to clear.
+ */
+export async function patchMerchant(
+  id: string,
+  patch: { custom_name?: string | null },
+): Promise<components['schemas']['Merchant']> {
+  const { data, error, response } = await client.PATCH('/v1/merchants/{id}', {
+    params: { path: { id } },
+    body: patch,
+  });
+  return unwrap('patchMerchant', data, error, response.status);
 }
 
 // ── Multilingual place cache (#74) ─────────────────────────────


### PR DESCRIPTION
## Summary

Frontend companion for `TINKPA/receipt-assistant#79` Phase C (backend PR #114, merged). Wires the brand-level `merchant.custom_name` override into the UI:

- `MerchantDetail` hero h1 becomes a click target → renames the brand globally (one rename propagates to every place row sharing this brand_id within the workspace).
- The pre-existing Chinese-subtitle pencil stays, now explicitly scoped to per-location overrides (rare case where one branch needs a different name than the brand).
- `displayName()` cascade is extended to consider the merchant override after place override but before derived names — picked up automatically by ledger rows.

## Cascade (post-#79 full picture)

```
place.custom_name           (per-location override, Phase B — pencil on the subtitle)
  → merchant.custom_name    (brand-level override, Phase C — click the h1, this PR)
  → place native CJK        (Google zh-CN / photo OCR)
  → place English           (Google en)
  → glossed CJK / address
  → receipt OCR payee
```

Per-place override still wins over brand override when both are set (covers the "one branch genuinely needs a different name" edge case).

## Changes

- `lib/api.ts`
  - `patchMerchant(id, { custom_name })` — new helper that PATCHes the merchant row.
  - `displayName(place, merchant?, fallback, userLangs?)` — extended to accept an optional merchant arg as the second position. Backward-compatible via runtime type discrimination, so the existing 3-arg call sites keep working.
  - `mapTransaction` — passes the merchant to displayName so ledger / list rows pick up brand-level renames automatically.
- `components/MerchantDetail.tsx`
  - `onEditBrandName` — new handler, wired to a click target on the hero `<h1>`. Works even when `place_id IS NULL` (the (D) side-effect from #79).
  - `onEditPlaceName` (renamed from `onEditName`) — now explicitly targeted at per-location overrides; tooltip clarifies scope.
- `lib/api-types.ts` — regenerated from the post-#114 openapi.json (adds `Merchant.custom_name`, `UpdateMerchantRequest`, the `PATCH /v1/merchants/{id}` route).

## Verification

Production build + typecheck clean. Manual click-through to validate AC items (long-press / inline rename modal from a transaction row — the original (A) bullet on #79 — is a follow-up; this PR closes the (C) gap which was the actual blocker for the user pain.)

## Relation

- Closes the frontend half of `TINKPA/receipt-assistant#79`. The backend half was #114 (merged 2026-05-16).
- (A) inline rename from transaction row — follow-up. Not in this PR; the hero click is the higher-ROI surface and unblocks the user pain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)