### PR TITLE
fix(#15): persistent Location card on ReceiptDetail with placeholder

### DIFF
--- a/src/components/ReceiptDetail.tsx
+++ b/src/components/ReceiptDetail.tsx
@@ -289,6 +289,10 @@ export default function ReceiptDetail({ receiptId, onBack, onSelectMerchant, onA
         isProcessing={isProcessing}
       />
 
+      {!isProcessing && (
+        <LocationCard place={receipt.place} placeId={receipt.place?.id ?? null} />
+      )}
+
       {!isProcessing && items.length > 0 && (
         <LineItemsCard items={items} currency={receipt.currency} />
       )}
@@ -713,6 +717,88 @@ function NoteCard({ text }: { text: string }) {
         your note
       </span>
       <p className="font-hand text-lg text-[var(--color-ink)]">{text}</p>
+    </div>
+  );
+}
+
+// FE#15: a persistent Location card so users can tell the difference
+// between "no location data for this receipt" (e.g. geocoding skipped
+// or denied at extract time) and "the section is broken / missing".
+// Before this fix, the only diagnostic was buried in backend container
+// logs ("Geocoding denied — skip geocoding") and the user saw nothing.
+function LocationCard({
+  place,
+  placeId,
+}: {
+  place: ReceiptView['place'];
+  placeId: string | null;
+}) {
+  // Compose what we have. `formatted_address` from Google is the
+  // typical human-friendly line ("1635 S San Gabriel Blvd, …").
+  const addr = place?.formatted_address?.trim() || null;
+  const cityState = (() => {
+    if (!addr) return null;
+    const parts = addr.split(',').map((s) => s.trim()).filter(Boolean);
+    if (parts.length < 2) return null;
+    // US format trims trailing ", USA"; non-US use second-to-last.
+    if (place?.country_code === 'US' && parts.length >= 4) {
+      const city = parts[parts.length - 3];
+      const stateZip = parts[parts.length - 2];
+      const st = stateZip?.split(/\s+/)[0];
+      return st ? `${city}, ${st}` : city ?? null;
+    }
+    return parts[parts.length - 2] ?? null;
+  })();
+  const mapUrl =
+    placeId && place && place.lat != null && place.lng != null
+      ? `/api/v1/places/${placeId}/map`
+      : null;
+
+  return (
+    <div className="rounded-[14px] border border-[var(--color-rule)] bg-[var(--color-surface)] px-4 py-3">
+      <p className="text-[11px] font-medium tracking-[0.14em] uppercase text-[var(--color-ink-muted)]">
+        Location
+      </p>
+      {place ? (
+        <div className="mt-2 flex items-start gap-3">
+          {mapUrl ? (
+            <img
+              src={mapUrl}
+              alt="Static map of merchant location"
+              loading="lazy"
+              decoding="async"
+              width={72}
+              height={72}
+              className="h-[72px] w-[72px] rounded-[10px] object-cover bg-[var(--color-paper-deep)]/40 shrink-0"
+            />
+          ) : null}
+          <div className="min-w-0 flex-1">
+            {cityState && (
+              <p className="text-[15px] font-medium">{cityState}</p>
+            )}
+            {addr && (
+              <p
+                className={cn(
+                  'text-[13px] text-[var(--color-ink-muted)]',
+                  cityState ? 'mt-0.5' : 'mt-1',
+                )}
+              >
+                {addr}
+              </p>
+            )}
+            {!cityState && !addr && (
+              <p className="text-[13px] text-[var(--color-ink-muted)]">
+                Geocoded, but no street address returned.
+              </p>
+            )}
+          </div>
+        </div>
+      ) : (
+        <p className="mt-2 text-[13px] text-[var(--color-ink-muted)]">
+          Location unavailable —{' '}
+          <span className="italic">geocoding may be disabled or failed.</span>
+        </p>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Closes #15. Before this fix the ReceiptDetail page had no Location section at all — receipts with a geocoded place looked identical to receipts where geocoding failed or was disabled, and the only diagnostic was buried in backend container logs.

Adds a `LocationCard` that always renders (when not processing). When `receipt.place` is null, shows a placeholder explaining the absence so users can self-diagnose ("geocoding may be disabled or failed") instead of assuming the feature doesn't exist.

## Behavior

- **Place present** — city / state-zip parsed from `formatted_address` (US format trims trailing `", USA"`, non-US uses second-to-last component), full address line, and the cached static-map thumbnail at `/v1/places/:id/map` when the place carries lat/lng. Geocoded-but-no-address edge case shows a brief note.
- **Place null** — placeholder: `"Location unavailable — geocoding may be disabled or failed."`

Visual treatment matches the existing `SmallFieldCard` / `FieldsGrid` pattern (`rounded-[14px]` border, muted body text, uppercase label) so the section reads as a peer of the other receipt-detail cards.

## Acceptance criteria

- [x] When `transaction.place` is null, render a "Location unavailable" placeholder card.
- [x] Visual treatment consistent with other "no data" states in the app.

## Related

- TINKPA/receipt-assistant#51 added a startup warning when `GOOGLE_MAPS_API_KEY` is unset — operator side.
- This PR — user side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)