### PR TITLE
feat(#48): MerchantIcon component consuming #101 brand icons

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -9,6 +9,7 @@ import type { Transaction, Category } from '../types';
 import { isProcessing as txIsProcessing } from '../lib/transactionStatus';
 import { cn } from '../lib/utils';
 import { CategoryIcon } from './CategoryIcon';
+import { MerchantIcon } from './MerchantIcon';
 import { PlaceThumbnail } from './PlaceThumbnail';
 
 interface DashboardProps {
@@ -342,7 +343,8 @@ function RecentList({
                 alt={tx.description}
                 size={44}
                 fallback={
-                  <CategoryIcon
+                  <MerchantIcon
+                    brandId={tx.merchantBrandId}
                     category={tx.category}
                     transactionType={tx.transactionType}
                     size={44}
@@ -350,7 +352,8 @@ function RecentList({
                 }
               />
             ) : (
-              <CategoryIcon
+              <MerchantIcon
+                brandId={tx.merchantBrandId}
                 category={tx.category}
                 transactionType={tx.transactionType}
                 size={44}

--- a/src/components/MerchantIcon.tsx
+++ b/src/components/MerchantIcon.tsx
@@ -1,0 +1,102 @@
+import { useState } from 'react';
+import { CategoryIcon } from './CategoryIcon';
+import type { Category, TransactionType } from '../types';
+
+/**
+ * FE#48 — square icon that prefers the brand's resolved icon, falling
+ * back to `CategoryIcon`. The cascade is:
+ *
+ *   brand.icon  (GET /v1/brands/:id/icon — server resolves
+ *                preferred_asset_id from #101 Phase 2 candidates)
+ *     → CategoryIcon  (final fallback — colored tile + glyph)
+ *
+ * The fallback is **always** `CategoryIcon`, never "the next entity's
+ * brand asset" — per #48's revised AC after #101 redesign: no inter-
+ * candidate cascade. If a candidate's bytes are missing on disk
+ * (`<img onError>`), or if the brand has no `preferred_asset_id` yet,
+ * we fall straight to the category glyph.
+ *
+ * `size` / `category` / `transactionType` API mirrors `CategoryIcon`
+ * exactly so this is a drop-in swap at every merchant/entity call
+ * site (Dashboard Recent rows, Ledger rows, ReceiptDetail AmountHero).
+ * Category-only slots (Dashboard category grid, filter chips,
+ * Monthly/Yearly Review breakdowns) keep using `CategoryIcon` directly.
+ */
+interface MerchantIconProps {
+  /** Brand id (kebab-case) from `merchants.brand_id` / `merchantBrandId`.
+   *  When null, skips the brand-icon attempt and renders `CategoryIcon`
+   *  directly — typical for non-spending or merchant-less rows. */
+  brandId: string | null | undefined;
+  category: Category | null;
+  transactionType?: TransactionType;
+  size?: number;
+  /** Optional className passthrough — applied to the outer wrapper. */
+  className?: string;
+}
+
+export function MerchantIcon({
+  brandId,
+  category,
+  transactionType,
+  size = 44,
+  className,
+}: MerchantIconProps) {
+  const [errored, setErrored] = useState(false);
+
+  // No brand to query OR a prior load errored → use the category
+  // fallback directly. Skipping the `<img>` tag also avoids a
+  // wasted 404 request on every render for brands without icons.
+  if (!brandId || errored) {
+    return (
+      <span className={className} style={{ display: 'inline-flex' }}>
+        <CategoryIcon
+          category={category}
+          transactionType={transactionType}
+          size={size}
+        />
+      </span>
+    );
+  }
+
+  // The brand-icon endpoint is proxied through Vite at `/api/v1/...`
+  // — same convention as merchant photos (#67) and place maps (#96).
+  const src = `/api/v1/brands/${brandId}/icon`;
+  const radius = Math.round(size * 0.32);
+
+  return (
+    <span
+      className={className}
+      style={{
+        display: 'inline-flex',
+        width: size,
+        height: size,
+        borderRadius: radius,
+        overflow: 'hidden',
+        // White backdrop so SVGs/PNGs with transparent backgrounds
+        // (the common case for clean brand marks) read on dark UI
+        // contexts (Apple Pay-ish chrome, dark mode). The brand-color
+        // surface is supplied by the icon itself.
+        background: '#fff',
+        // Light divider so the white square doesn't visually merge
+        // with the surrounding card on white themes.
+        boxShadow: 'inset 0 0 0 1px var(--color-rule)',
+        flexShrink: 0,
+      }}
+    >
+      <img
+        src={src}
+        alt=""
+        loading="lazy"
+        decoding="async"
+        width={size}
+        height={size}
+        onError={() => setErrored(true)}
+        style={{
+          width: '100%',
+          height: '100%',
+          objectFit: 'contain',
+        }}
+      />
+    </span>
+  );
+}

--- a/src/components/ReceiptDetail.tsx
+++ b/src/components/ReceiptDetail.tsx
@@ -18,6 +18,8 @@ import {
 import { statusBadge } from '../lib/transactionStatus';
 import { cn } from '../lib/utils';
 import { CategoryIcon } from './CategoryIcon';
+import { MerchantIcon } from './MerchantIcon';
+import type { Category } from '../types';
 import EditReceiptModal from './EditReceiptModal';
 import ConfirmActionDialog from './ConfirmActionDialog';
 import DeleteReceiptDialog from './DeleteReceiptDialog';
@@ -263,6 +265,8 @@ export default function ReceiptDetail({ receiptId, onBack, onSelectMerchant, onA
         amount={receipt.total}
         currency={receipt.currency}
         merchant={isProcessing ? 'Processing…' : merchantLabel}
+        merchantBrandId={receipt.merchantBrandId}
+        category={receipt.category as Category | null}
         occurredOn={receipt.occurred_on}
         isProcessing={isProcessing}
         voided={receipt.status === 'voided'}
@@ -583,6 +587,8 @@ function AmountHero({
   amount,
   currency,
   merchant,
+  merchantBrandId,
+  category,
   occurredOn,
   isProcessing,
   voided,
@@ -591,12 +597,17 @@ function AmountHero({
   amount: number;
   currency: string;
   merchant: string;
+  merchantBrandId: string | null;
+  category: Category | null;
   occurredOn: string;
   isProcessing: boolean;
   voided: boolean;
   onMerchantClick?: () => void;
 }) {
   const merchantClass = 'font-display italic font-medium text-2xl sm:text-3xl leading-tight';
+  // FE#48: small square icon next to the merchant name. Skipped while
+  // processing (the row says "Processing…", not a real merchant yet).
+  const showIcon = !isProcessing;
   return (
     <div className="text-center pt-2">
       <p
@@ -616,15 +627,25 @@ function AmountHero({
           type="button"
           onClick={onMerchantClick}
           className={cn(
-            'mt-4 inline-flex items-baseline gap-1 transition-colors hover:text-[var(--color-terracotta)]',
+            'mt-4 inline-flex items-center gap-2 transition-colors hover:text-[var(--color-terracotta)]',
             merchantClass,
           )}
         >
-          {merchant}
-          <span className="font-display italic text-base leading-none text-[var(--color-terracotta)]">→</span>
+          {showIcon && (
+            <MerchantIcon brandId={merchantBrandId} category={category} size={28} />
+          )}
+          <span className="inline-flex items-baseline gap-1">
+            {merchant}
+            <span className="font-display italic text-base leading-none text-[var(--color-terracotta)]">→</span>
+          </span>
         </button>
       ) : (
-        <h1 className={cn('mt-4', merchantClass)}>{merchant}</h1>
+        <h1 className={cn('mt-4 inline-flex items-center gap-2', merchantClass)}>
+          {showIcon && (
+            <MerchantIcon brandId={merchantBrandId} category={category} size={28} />
+          )}
+          <span>{merchant}</span>
+        </h1>
       )}
       <p className="mt-1 text-[13px] text-[var(--color-ink-muted)]">
         {formatDateLong(occurredOn)}

--- a/src/components/Transactions.tsx
+++ b/src/components/Transactions.tsx
@@ -15,6 +15,7 @@ import { cn } from '../lib/utils';
 import type { Transaction } from '../types';
 import { isProcessing as txIsProcessing, statusBadge } from '../lib/transactionStatus';
 import { CategoryIcon } from './CategoryIcon';
+import { MerchantIcon } from './MerchantIcon';
 import { PlaceThumbnail } from './PlaceThumbnail';
 import TransactionRowMenu from './TransactionRowMenu';
 import ConfirmActionDialog from './ConfirmActionDialog';
@@ -483,8 +484,12 @@ function LedgerRow({
         'rounded-[16px] border border-[var(--color-rule)] bg-[var(--color-surface)] p-3 pr-2',
       )}
     >
-      {/* Place thumbnail when geocoded; category icon otherwise (#96).
-          Optional has-receipt ✦ badge sits on top of either. */}
+      {/* Row icon cascade (FE#48): place map (geo-specific, #96) →
+          MerchantIcon (brand-recognition via #101 Phase 2) →
+          CategoryIcon (color tile + glyph fallback). PlaceThumbnail
+          stays the primary because it answers "where did this
+          happen?" instantly; MerchantIcon takes over when the place
+          isn't geocoded so the row still reads as a known brand. */}
       <div className="relative h-12 w-12 flex-shrink-0">
         {tx.placeMapUrl ? (
           <PlaceThumbnail
@@ -492,7 +497,8 @@ function LedgerRow({
             alt={tx.description}
             size={48}
             fallback={
-              <CategoryIcon
+              <MerchantIcon
+                brandId={tx.merchantBrandId}
                 category={tx.category}
                 transactionType={tx.transactionType}
                 size={48}
@@ -500,7 +506,8 @@ function LedgerRow({
             }
           />
         ) : (
-          <CategoryIcon
+          <MerchantIcon
+            brandId={tx.merchantBrandId}
             category={tx.category}
             transactionType={tx.transactionType}
             size={48}


### PR DESCRIPTION
## Summary

Closes #48. Now unblocked — backend `TINKPA/receipt-assistant#101` Phase 2 (PR #111) is merged, so brands populated by the ingest agent expose `icon_url: /v1/brands/<brand_id>/icon` that streams the agent-picked candidate's bytes.

Wires the brand icon into the merchant/entity row icon slots per the #48 spec, with `CategoryIcon` as the single fallback (no inter-candidate cascade — the agent already picked the winner server-side at ingest per #101).

## Changes

- New `components/MerchantIcon.tsx` — drop-in wrapper. Accepts `brandId`, `category`, `transactionType`, `size`, `className`. Renders `<img src="/api/v1/brands/:id/icon">` on a white tile when `brandId` is set, with `onError` falling straight to `CategoryIcon`. Null `brandId` skips the `<img>` entirely (no wasted 404 request for non-spending rows).
- `Dashboard.tsx` `RecentList` (size 44) — swap CategoryIcon → MerchantIcon (both as `PlaceThumbnail.fallback` and as the no-map row icon). Place map thumbnail still wins as primary; MerchantIcon takes over when no geocode exists.
- `Transactions.tsx` `LedgerRow` (size 48) — same swap. The ✦ has-receipt overlay sits on top unchanged.
- `ReceiptDetail.tsx` `AmountHero` — **add** a small (28px) MerchantIcon next to the merchant name. Previously had no icon at all.

Untouched per spec — category-only call sites:
- Dashboard category grid, Ledger filter chips (`TransactionsFilters`), Monthly / Yearly Review category breakdowns, `ReceiptDetail` Category field card, `MerchantDetail` hero category overlay, `MerchantTxnRow` (every row is the same merchant — an icon adds nothing there).

## Acceptance criteria

- [x] MerchantIcon renders the backend-provided icon when present.
- [x] Missing / null icon falls back to CategoryIcon with no visual regression.
- [x] Icon tiles match CategoryIcon sizing at every migrated call site (44 / 48 / 28 used; component supports the full 20-120 range).
- [x] Only merchant/entity call sites migrated; category call sites untouched.
- [x] AmountHero gains a merchant icon; MerchantDetail hero and MerchantTxnRow untouched.
- [x] `<img>` `onError` falls to `CategoryIcon` (not a broken-image glyph, not the next entity's icon) — covers both null `icon_url` AND runtime 404 (e.g. asset row stale but file missing on disk).

## Verification

Production build + typecheck clean. Live end-to-end smoke test against the #101 backend running locally: Starbucks (preferred=logo_dev/starbucks.com, score 92) and Apple Store (preferred=iTunes Apple-Store retail mark, score 90) icons both load and render at every migrated call site. Brands without a preferred icon (the 73 backfilled stubs at the time of #101 merge) gracefully render CategoryIcon.

## Relation

- Backend dependency: `TINKPA/receipt-assistant#101` Phase 2, PR #111 (merged 2026-05-16).
- Epic: `TINKPA/receipt-assistant#85` (closed 2026-05-16).
- Later phase 2 (line-item / inventory icons) is covered separately under `TINKPA/receipt-assistant#84`'s frontend follow-up — MerchantIcon's API is ready to extend to product icons via the same cascade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)