### PR TITLE
fix(#79): consume joined merchant ref so brand rename propagates to ledger

### DIFF
--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -3863,6 +3863,16 @@ export interface components {
                 ocr_extracted?: unknown;
             }[] | null;
         } | null;
+        TransactionMerchantRef: {
+            /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            id: string;
+            brand_id: string;
+            canonical_name: string;
+            custom_name: string | null;
+        } | null;
         TransactionItem: {
             line_no: number;
             raw_name: string;
@@ -3949,6 +3959,7 @@ export interface components {
             postings: components["schemas"]["Posting"][];
             documents: components["schemas"]["TransactionDocumentRef"][];
             place: components["schemas"]["Place"];
+            merchant: components["schemas"]["TransactionMerchantRef"];
             items: components["schemas"]["TransactionItem"][];
         };
         BulkResultItem: {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -157,9 +157,29 @@ function categoryFromTxn(t: BackendTransaction): string | null {
   return null;
 }
 
-/** Pull the merchant block written by the extractor (Phase 2.5) from
- *  transaction metadata. Returns null if absent (legacy rows pre-#64). */
-function merchantFromTxn(t: BackendTransaction): { brand_id: string; canonical_name: string } | null {
+/** Pull the merchant block for a transaction. Prefers the top-level
+ *  `merchant` field (#79 Phase C — joined from `merchants` so the row
+ *  carries `custom_name`, the brand-level Layer-3 override). Falls back
+ *  to the extractor's `metadata.merchant` block (Phase 2.5) for legacy
+ *  rows whose `merchant_id` FK isn't populated yet. Returns null when
+ *  neither source exposes a brand_id. */
+function merchantFromTxn(
+  t: BackendTransaction,
+): { brand_id: string; canonical_name: string; custom_name: string | null } | null {
+  const joined = (t as Record<string, unknown>).merchant;
+  if (joined && typeof joined === 'object') {
+    const rec = joined as Record<string, unknown>;
+    const brandId = typeof rec.brand_id === 'string' ? rec.brand_id : null;
+    if (brandId) {
+      const canonical = typeof rec.canonical_name === 'string' ? rec.canonical_name : null;
+      const custom = typeof rec.custom_name === 'string' ? rec.custom_name : null;
+      return {
+        brand_id: brandId,
+        canonical_name: canonical ?? brandId,
+        custom_name: custom,
+      };
+    }
+  }
   const md = t.metadata ?? {};
   const m = (md as Record<string, unknown>).merchant;
   if (!m || typeof m !== 'object') return null;
@@ -167,7 +187,11 @@ function merchantFromTxn(t: BackendTransaction): { brand_id: string; canonical_n
   const brandId = typeof rec.brand_id === 'string' ? rec.brand_id : null;
   const canonical = typeof rec.canonical_name === 'string' ? rec.canonical_name : null;
   if (!brandId) return null;
-  return { brand_id: brandId, canonical_name: canonical ?? brandId };
+  return {
+    brand_id: brandId,
+    canonical_name: canonical ?? brandId,
+    custom_name: null,
+  };
 }
 
 // Match any CJK Unified Ideograph block, including extensions and


### PR DESCRIPTION
## Summary
- Pairs with TINKPA/receipt-assistant#115 — the backend now exposes \`merchant.custom_name\` on the \`Transaction\` response.
- \`merchantFromTxn()\` prefers the new top-level \`merchant\` block and falls back to the extractor's \`metadata.merchant\` for legacy rows.
- \`custom_name\` flows into the existing \`displayName()\` cascade (place.custom_name → merchant.custom_name → derived), so a brand rename on MerchantDetail now propagates to every Ledger row under that \`brand_id\` without an N+1 fetch.

## Test plan
- [x] \`npx tsc --noEmit\` clean.
- [x] \`api-types.ts\` regenerated.
- [x] Live verify: rename Apple Store → 苹果商店 via MerchantDetail, then search "Apple" on /transactions — both rows render as \"苹果商店 Shopping · SUN · May 10\".

Closes the original FE#79 Phase C AC item: "A brand-level rename in MerchantDetail propagates to all place rows under that brand_id."

🤖 Generated with [Claude Code](https://claude.com/claude-code)