### PR TITLE
feat(capture): accept PDFs and all image formats in gallery picker

### DIFF
--- a/src/components/Capture.tsx
+++ b/src/components/Capture.tsx
@@ -183,7 +183,7 @@ export default function Capture({ onCancel, onComplete }: CaptureProps) {
       <input
         ref={galleryInputRef}
         type="file"
-        accept="image/jpeg,.jpg,.jpeg"
+        accept="image/*,application/pdf"
         className="hidden"
         onChange={handlePicked}
       />


### PR DESCRIPTION
## Summary
The gallery file picker in `Capture.tsx` was restricted to `image/jpeg,.jpg,.jpeg`, while the backend already accepts the full range it advertises (`image/*` + HEIC/HEIF/WEBP via extension, plus `application/pdf`) in `receipt-assistant/src/routes/ingest.service.ts::guessDocumentKind`. Users who wanted to upload a bank-statement PDF, an emailed-receipt PDF, or a HEIC straight from iOS Photos hit a dead end at the OS file picker — they could `curl` it but not pick it.

This widens the gallery `<input accept>` to `image/*,application/pdf`, matching what the API supports end-to-end. The camera input keeps `image/*` (OS camera pickers never yield PDF).

## Proposed fix / scope
One-line change in `src/components/Capture.tsx`:

```diff
-        accept="image/jpeg,.jpg,.jpeg"
+        accept="image/*,application/pdf"
```

`handlePicked` → `sendFile` → `ingestBatch([file])` is format-agnostic — whatever the user picks is POST-ed as-is. No client-side transcoding to broaden.

## Acceptance criteria
- [x] Gallery picker on the Capture screen exposes PDFs alongside images.
- [x] Backend continues to classify the upload correctly (`receipt_pdf` for PDF, `receipt_image` for image/*).
- [x] `tsc --noEmit` clean.

## Impact / Relation
- Unblocks any user with PDF-only receipts (bank statements, e-receipts from Uber/email).
- No backend or schema change — purely an `accept` widening on the existing ingest path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)