### PR TITLE
feat(#101): "Upload your own" button on Brand picker

### DIFF
--- a/src/components/Brands.tsx
+++ b/src/components/Brands.tsx
@@ -1,10 +1,11 @@
-import React, { useEffect, useState } from 'react';
-import { ChevronRight, ArrowLeft, Lock, Globe } from 'lucide-react';
+import React, { useEffect, useRef, useState } from 'react';
+import { ChevronRight, ArrowLeft, Lock, Globe, Upload } from 'lucide-react';
 import {
   listBrands,
   getBrand,
   patchBrand,
   listBrandAssets,
+  uploadBrandAsset,
   extractProblemMessage,
   type BackendBrand,
   type BackendBrandAsset,
@@ -171,6 +172,8 @@ function BrandDetail({
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState<string | null>(null);
   const [banner, setBanner] = useState<{ tone: 'ok' | 'err'; text: string } | null>(null);
+  const [uploading, setUploading] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
 
   const loadAll = () => {
     Promise.all([getBrand(brandId), listBrandAssets(brandId)])
@@ -182,6 +185,29 @@ function BrandDetail({
   };
 
   useEffect(loadAll, [brandId]);
+
+  const handleUpload = async (file: File) => {
+    if (!brand) return;
+    setUploading(true);
+    setBanner(null);
+    try {
+      await uploadBrandAsset(brand.brand_id, file);
+      // Re-fetch both brand (preferred_asset_id + user_chose_at) and assets.
+      const [b, a] = await Promise.all([getBrand(brand.brand_id), listBrandAssets(brand.brand_id)]);
+      setBrand(b);
+      setAssets(a);
+      onPatched(b);
+      setBanner({
+        tone: 'ok',
+        text: `Uploaded "${file.name}" — set as preferred and locked from re-extract overrides.`,
+      });
+    } catch (e: unknown) {
+      setBanner({ tone: 'err', text: extractProblemMessage(e) });
+    } finally {
+      setUploading(false);
+      if (fileInputRef.current) fileInputRef.current.value = '';
+    }
+  };
 
   const setPreferred = async (assetId: string | null) => {
     if (!brand) return;
@@ -274,9 +300,34 @@ function BrandDetail({
       )}
 
       <Section title={`Candidate assets (${assets?.length ?? 0})`}>
-        <p className="text-[12px] text-[var(--color-ink-muted)] mb-3">
-          Pick one to set <code className="tnum">preferred_asset_id</code> — re-extract will respect your choice.
-        </p>
+        <div className="flex items-start justify-between gap-3 mb-3">
+          <p className="text-[12px] text-[var(--color-ink-muted)]">
+            Pick one to set <code className="tnum">preferred_asset_id</code> — re-extract will respect your choice.
+          </p>
+          <button
+            type="button"
+            onClick={() => fileInputRef.current?.click()}
+            disabled={uploading}
+            className={cn(
+              'shrink-0 inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-[12px] font-medium transition-colors disabled:opacity-40',
+              'border border-[var(--color-rule)] text-[var(--color-ink-muted)] hover:text-[var(--color-ink)] hover:border-[var(--color-ink)]',
+            )}
+            title="Upload your own icon for this brand — auto-sets as preferred and locks against re-extract"
+          >
+            <Upload size={12} />
+            {uploading ? 'Uploading…' : 'Upload your own'}
+          </button>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/png,image/jpeg,image/svg+xml,image/webp,image/gif"
+            className="hidden"
+            onChange={(e) => {
+              const f = e.target.files?.[0];
+              if (f) void handleUpload(f);
+            }}
+          />
+        </div>
 
         {assets === null && (
           <p className="text-sm text-[var(--color-ink-muted)]">Loading…</p>

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -1677,7 +1677,63 @@ export interface paths {
             };
         };
         put?: never;
-        post?: never;
+        /**
+         * Upload a user-provided brand icon
+         * @description Multipart upload (field name `file`) — saves bytes to the brand-assets bind-mount, inserts a brand_assets row with tier=user_upload, and stamps user_chose_at + preferred_asset_id to the new asset (the upload IS the user's choice; Layer-3 lock per #101). Re-uploading identical bytes returns the existing row 200 OK (UNIQUE on (brand_id, content_hash)); new bytes return 201.
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    brandId: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "multipart/form-data": components["schemas"]["UploadBrandAssetForm"];
+                };
+            };
+            responses: {
+                /** @description Dedup hit — existing asset returned */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["BrandAsset"];
+                    };
+                };
+                /** @description New asset created */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["BrandAsset"];
+                    };
+                };
+                /** @description Brand not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+                /** @description Validation failed */
+                422: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+            };
+        };
         delete?: never;
         options?: never;
         head?: never;
@@ -4290,6 +4346,10 @@ export interface components {
             preferred_asset_id?: string | null;
             name?: string;
             domain?: string | null;
+        };
+        UploadBrandAssetForm: {
+            /** Format: binary */
+            file?: string;
         };
         Document: {
             /**

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1440,3 +1440,24 @@ export async function patchBrand(
   });
   return unwrap('patchBrand', data, error, response.status);
 }
+
+/**
+ * Upload a user-provided icon for a brand. The backend stamps
+ * `user_chose_at` and points `preferred_asset_id` at the new asset —
+ * the upload IS the user's choice, so re-extract (`Phase 4c`) will
+ * never overwrite it. Same-bytes re-upload returns the existing row
+ * 200 OK (UNIQUE on `(brand_id, content_hash)`); new bytes return 201.
+ */
+export async function uploadBrandAsset(
+  brandId: string,
+  file: File,
+): Promise<BackendBrandAsset> {
+  const form = new FormData();
+  form.append('file', file);
+  const { data, error, response } = await client.POST('/v1/brands/{brandId}/assets', {
+    params: { path: { brandId } },
+    body: form as unknown as Record<string, never>,
+    bodySerializer: (b) => b as unknown as FormData,
+  });
+  return unwrap('uploadBrandAsset', data, error, response.status);
+}


### PR DESCRIPTION
## Summary
Pairs with TINKPA/receipt-assistant#119. Adds a small file-upload button in the Brand-detail "Candidate assets" section. On file pick, POSTs multipart to \`/v1/brands/:bid/assets\`, then refetches both the brand row + asset list — the new user_upload candidate appears with the amber badge and the brand's row icon flips to it (backend auto-stamps \`user_chose_at\`).

Closes the long-tail UX gap where small / IG-only brands with no agent-discoverable icons had no way to render anything but \`CategoryIcon\`.

## Test plan
- [x] tsc + api-types regen clean.
- [x] Backend smoke-tested upload + dedup + un-retire paths (see #119 test plan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)