### PR TITLE
fix(dashboard): show globally-recent uploads in "recent", not month-scoped

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -43,7 +43,11 @@ export default function Dashboard({ onSelectReceipt, onSelectMerchant, onViewAll
 
   useEffect(() => {
     Promise.all([
-      fetchTransactions({ limit: 4, from: monthRange.from, to: monthRange.to }),
+      // Recent = freshly-uploaded / re-processed, not "this month's
+      // activity". Ride the `created_at desc` default with no month
+      // filter so a receipt with `occurred_on` years ago still bubbles
+      // to the top right after upload.
+      fetchTransactions({ limit: 4 }),
       fetchSummary({ from: monthRange.from, to: monthRange.to }),
     ])
       .then(([txs, sum]) => {
@@ -307,7 +311,7 @@ function RecentList({
     return (
       <div className="rounded-[18px] border border-[var(--color-rule)] bg-[var(--color-surface)] px-5 py-6 text-center">
         <p className="font-display italic text-[var(--color-ink-muted)]">
-          No entries this month yet.
+          Nothing here yet.
         </p>
       </div>
     );


### PR DESCRIPTION
Closes #71

## Summary

The Dashboard "recent" section was filtering by `occurred_on` within the current calendar month, so a receipt with a years-old `occurred_on` but freshly uploaded today never appeared — even though it's exactly the workflow tail the user is looking at right after capture.

Drop the month filter; ride the default `created_at desc`. Analytics surfaces ("Your May", "where it went", category grid) stay month-scoped — only the "recent" section is now global.

## Steps to reproduce

1. Upload a receipt with `occurred_on` outside the current month (e.g. a 2023 Costco receipt today).
2. Open Dashboard → "recent".
3. **Before:** the new receipt is missing; only this-month entries show.
4. **After:** the new receipt is at row 2 of recent (since it was the 2nd-most-recently created in DB).

## Root cause

`code/receipt-assistant-frontend/src/components/Dashboard.tsx:46` passed `from: monthRange.from, to: monthRange.to` to `fetchTransactions`. Those map to `occurred_from` / `occurred_to` on the backend, filtering by transaction date rather than upload time. The default sort is already `created_at desc`, so removing the filter is enough — no API or sort change needed.

## Acceptance criteria

- [x] Dashboard "recent" no longer applies the current-month `occurred_on` filter.
- [x] A receipt with `occurred_on` years ago but `created_at` today appears in recent if it's in the top 4 by upload time.
- [x] Empty-state copy reads "Nothing here yet." (not "No entries this month yet.").
- [x] Other Dashboard sections (Your May hero, where-it-went grid) remain month-scoped.

## Evidence

Verified on vite dev (`https://localhost:5175/`) against live backend. "Recent" rendered as: T-Mobile $214.85 (2026-05-16) · **Costco $931.31 (2023-08-14)** · Starbucks $4.95 · Starbucks $7.25 — exactly matching `GET /v1/transactions?limit=4&sort=created_at&order=desc`.

Screenshot: `notes/dashboard-recent-fix-dev.png` (in the outer project notebook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)