### PR TITLE
feat(#72): user-controllable sort on Ledger

### DIFF
--- a/src/components/Transactions.tsx
+++ b/src/components/Transactions.tsx
@@ -23,8 +23,10 @@ import DeletedBadge from './DeletedBadge';
 import TransactionsFilters from './TransactionsFilters';
 import {
   DEFAULT_FILTERS,
+  DEFAULT_SORT_ID,
   effectiveDateRange,
   isFilterActive,
+  resolveSort,
   type FilterState,
 } from '../lib/transactionsFilterState';
 
@@ -74,6 +76,9 @@ export default function Transactions({
   const [tombstoneLoading, setTombstoneLoading] = useState(false);
 
   const [filters, setFilters] = useState<FilterState>(DEFAULT_FILTERS);
+  // Sort is view config, not a filter — survives "clear all".
+  const [sortId, setSortId] = useState<string>(DEFAULT_SORT_ID);
+  const activeSort = useMemo(() => resolveSort(sortId), [sortId]);
   const debouncedSearch = useDebouncedValue(searchQuery, 300);
   const debouncedPayee = useDebouncedValue(filters.payeeContains, 300);
   const debouncedAmountMin = useDebouncedValue(filters.amountMinDollars, 300);
@@ -101,11 +106,11 @@ export default function Transactions({
       amount_max_minor: dollarsToMinor(debouncedAmountMax),
       from: dateRange.occurred_from,
       to: dateRange.occurred_to,
-      // Ledger groups rows by ISO-week of `occurred_on`, so the fetch
-      // axis must match — otherwise a freshly re-ingested old receipt
-      // crowds out recently-occurred ones on page 1.
-      sort: 'occurred_on',
-      order: 'desc',
+      // Week-grouped rendering below only makes sense when rows are
+      // sorted by `occurred_on`; for amount / created_at sorts the
+      // render path drops the banners and shows a flat list.
+      sort: activeSort.sort,
+      order: activeSort.order,
     })
       .then((rows) => {
         setTransactions(rows);
@@ -122,6 +127,8 @@ export default function Transactions({
     filters.status,
     dateRange.occurred_from,
     dateRange.occurred_to,
+    activeSort.sort,
+    activeSort.order,
   ]);
 
   useEffect(() => {
@@ -232,6 +239,8 @@ export default function Transactions({
         }}
         showDeleted={showDeleted}
         onToggleShowDeleted={() => setShowDeleted((s) => !s)}
+        sortId={sortId}
+        onSortChange={setSortId}
       />
 
       {rowError && (
@@ -270,7 +279,7 @@ export default function Transactions({
               : 'No entries yet — capture your first receipt.'}
           </p>
         </EmptyState>
-      ) : (
+      ) : activeSort.sort === 'occurred_on' ? (
         <div className="space-y-7">
           {weeks.map((wk) => (
             <WeekGroup
@@ -288,6 +297,25 @@ export default function Transactions({
             />
           ))}
         </div>
+      ) : (
+        <ul className="space-y-2">
+          {filteredTransactions.map((tx) => (
+            <li key={tx.id}>
+              <LedgerRow
+                tx={tx}
+                onSelect={(t) => {
+                  if (t.merchantBrandId && onSelectMerchant) {
+                    onSelectMerchant(t.merchantBrandId);
+                  } else {
+                    onSelectReceipt?.(t.id);
+                  }
+                }}
+                onHardDelete={handleHardDeleteRequest}
+                onUnreconcile={(id) => setUnreconcileTarget(id)}
+              />
+            </li>
+          ))}
+        </ul>
       )}
 
       <ConfirmActionDialog

--- a/src/components/TransactionsFilters.tsx
+++ b/src/components/TransactionsFilters.tsx
@@ -2,7 +2,10 @@ import { useEffect, useRef, useState } from 'react';
 import { cn } from '../lib/utils';
 import {
   DATE_PRESET_LABEL,
+  DEFAULT_SORT_ID,
+  SORT_OPTIONS,
   STATUS_OPTIONS,
+  resolveSort,
   type DatePreset,
   type FilterState,
 } from '../lib/transactionsFilterState';
@@ -37,6 +40,8 @@ interface TransactionsFiltersProps {
   onClear: () => void;
   showDeleted: boolean;
   onToggleShowDeleted: () => void;
+  sortId: string;
+  onSortChange: (id: string) => void;
 }
 
 /**
@@ -53,13 +58,18 @@ export default function TransactionsFilters({
   onClear,
   showDeleted,
   onToggleShowDeleted,
+  sortId,
+  onSortChange,
 }: TransactionsFiltersProps) {
-  const [openPopover, setOpenPopover] = useState<'date' | 'type' | 'category' | null>(null);
+  const [openPopover, setOpenPopover] = useState<'date' | 'type' | 'category' | 'sort' | null>(null);
   const [moreOpen, setMoreOpen] = useState(false);
 
   const dateRef = useClickAway(() => setOpenPopover((p) => (p === 'date' ? null : p)));
   const typeRef = useClickAway(() => setOpenPopover((p) => (p === 'type' ? null : p)));
   const categoryRef = useClickAway(() => setOpenPopover((p) => (p === 'category' ? null : p)));
+  const sortRef = useClickAway(() => setOpenPopover((p) => (p === 'sort' ? null : p)));
+
+  const activeSort = resolveSort(sortId);
 
   const dateLabel =
     filters.datePreset === 'custom'
@@ -277,6 +287,42 @@ export default function TransactionsFilters({
             )}
           </div>
         )}
+
+        {/* Sort chip — view config, not a filter, so it lives outside FilterState
+            and isn't reset by "clear all". */}
+        <div ref={sortRef} className="relative">
+          <Chip
+            data-testid="filter-sort"
+            active={sortId !== DEFAULT_SORT_ID}
+            onClick={() => setOpenPopover((p) => (p === 'sort' ? null : 'sort'))}
+          >
+            <span className="text-[var(--color-ink-muted)] mr-1">Sort:</span>
+            {activeSort.chipLabel}
+          </Chip>
+          {openPopover === 'sort' && (
+            <Popover testid="filter-sort-popover">
+              {SORT_OPTIONS.map((opt) => (
+                <button
+                  type="button"
+                  key={opt.id}
+                  data-testid={`filter-sort-${opt.id}`}
+                  onClick={() => {
+                    onSortChange(opt.id);
+                    setOpenPopover(null);
+                  }}
+                  className={cn(
+                    'w-full text-left px-3 py-2 rounded-[10px] text-sm transition-colors',
+                    sortId === opt.id
+                      ? 'bg-[var(--color-terracotta-soft)] text-[var(--color-terracotta-deep)] font-medium'
+                      : 'text-[var(--color-ink)] hover:bg-[var(--color-paper-deep)]',
+                  )}
+                >
+                  {opt.label}
+                </button>
+              ))}
+            </Popover>
+          )}
+        </div>
 
         <Chip
           data-testid="toggle-show-deleted"

--- a/src/lib/transactionsFilterState.ts
+++ b/src/lib/transactionsFilterState.ts
@@ -47,6 +47,39 @@ export const STATUS_OPTIONS: { value: RawTransactionStatus; label: string }[] = 
   { value: 'error', label: 'Error' },
 ];
 
+/* ── Sort ─────────────────────────────────────────────────────── */
+// Sort is view config, not a filter, so it lives outside FilterState —
+// the "clear all" button doesn't reset it.
+
+export type SortKey = 'occurred_on' | 'amount' | 'created_at';
+export type SortOrder = 'asc' | 'desc';
+
+export interface SortOption {
+  id: string;
+  // Long form used inside the popover.
+  label: string;
+  // Short form used on the chip itself.
+  chipLabel: string;
+  sort: SortKey;
+  order: SortOrder;
+}
+
+// Amount sort is intentionally absent: backend `GET /v1/transactions`
+// currently only supports `sort=occurred_on | created_at` and returns
+// 501 for `sort=amount` (it requires a subquery over postings). Tracked
+// in the receipt-assistant backend; surface here once that lands.
+export const SORT_OPTIONS: SortOption[] = [
+  { id: 'date-desc',    label: 'Date (newest first)', chipLabel: 'Date ↓',         sort: 'occurred_on', order: 'desc' },
+  { id: 'date-asc',     label: 'Date (oldest first)', chipLabel: 'Date ↑',         sort: 'occurred_on', order: 'asc'  },
+  { id: 'created-desc', label: 'Recently added',      chipLabel: 'Recently added', sort: 'created_at',  order: 'desc' },
+];
+
+export const DEFAULT_SORT_ID = 'date-desc';
+
+export function resolveSort(id: string): SortOption {
+  return SORT_OPTIONS.find((o) => o.id === id) ?? SORT_OPTIONS[0];
+}
+
 /** Compute the ISO date range that should be sent to the backend
  *  for a given filter state. Returns undefined values for "no bound". */
 export function effectiveDateRange(


### PR DESCRIPTION
Closes #72

## Summary

Adds a **Sort** chip to the Ledger filter row, between Category and Show-deleted. Opens a popover with three options:

- **Date (newest first)** — default; backend \`sort=occurred_on order=desc\`
- **Date (oldest first)** — \`sort=occurred_on order=asc\`
- **Recently added** — \`sort=created_at order=desc\` (matches Dashboard "recent" semantics from #71/#70)

Sort state lives in \`Transactions.tsx\` (not in \`FilterState\`) so **clear all** doesn't reset it — sort is view config, not a filter. The chip activates the dark style only when the user has moved off the default.

Week banners (\`WEEK OF MAR 17 – MAR 23\`) only make sense for date-sorted rows; on \`sort=created_at\` the render path falls back to a flat list of \`LedgerRow\` items.

## Scope reduction

The original issue described 5 sort options (Date ↓/↑, Amount ↓/↑, Recently added). **Amount sort intentionally not shipped** here — backend \`GET /v1/transactions\` returns 501 for \`sort=amount\` because it needs a subquery over \`postings\`. Tracked as [TINKPA/receipt-assistant#120](https://github.com/TINKPA/receipt-assistant/issues/120). Once the backend lands amount sort, a small follow-up PR re-adds the two Amount entries to \`SORT_OPTIONS\` (one-file change).

## Acceptance criteria

- [x] **Sort** chip on the Ledger filter row, between Category and Show-deleted.
- [x] Popover lists 3 options.
- [x] Selecting an option re-fetches with the right \`sort\` / \`order\`.
- [x] Week banners visible when sort is \`occurred_on\`, hidden on \`created_at\` (flat list).
- [x] \`Clear all\` does NOT reset the sort selection.
- [x] Default on fresh page load is \`Date ↓\` (\`occurred_on desc\`).

## Evidence

Verified on vite dev \`https://localhost:5173/\` against live backend:

| Sort | Backend call | Top row sanity check |
|---|---|---|
| Date (newest first) | \`sort=occurred_on&order=desc\` | May 14 entries |
| Date (oldest first) | \`sort=occurred_on&order=asc\` | Oct 20 (oldest week) |
| Recently added | \`sort=created_at&order=desc\` | Valvoline Instant Oil Change (most-recent upload) |

\`clear all\` after applying Last-30-days correctly resets Date to "All time" while keeping Sort = "Recently added". No console errors (one unrelated \`apple-mobile-web-app-capable\` deprecation warning).

Screenshots in \`notes/72-sort-*.png\` of the outer project notebook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)