### PR TITLE
feat(#72): re-add Amount sort options on Ledger

### DIFF
--- a/src/lib/transactionsFilterState.ts
+++ b/src/lib/transactionsFilterState.ts
@@ -64,14 +64,15 @@ export interface SortOption {
   order: SortOrder;
 }
 
-// Amount sort is intentionally absent: backend `GET /v1/transactions`
-// currently only supports `sort=occurred_on | created_at` and returns
-// 501 for `sort=amount` (it requires a subquery over postings). Tracked
-// in the receipt-assistant backend; surface here once that lands.
+// Amount sort key on the backend is MAX(ABS(amount_base_minor)) per
+// transaction — the largest leg. Same axis as the amount_min/max
+// filters, so filtering and sorting agree on what "amount" means.
 export const SORT_OPTIONS: SortOption[] = [
-  { id: 'date-desc',    label: 'Date (newest first)', chipLabel: 'Date ↓',         sort: 'occurred_on', order: 'desc' },
-  { id: 'date-asc',     label: 'Date (oldest first)', chipLabel: 'Date ↑',         sort: 'occurred_on', order: 'asc'  },
-  { id: 'created-desc', label: 'Recently added',      chipLabel: 'Recently added', sort: 'created_at',  order: 'desc' },
+  { id: 'date-desc',    label: 'Date (newest first)',     chipLabel: 'Date ↓',         sort: 'occurred_on', order: 'desc' },
+  { id: 'date-asc',     label: 'Date (oldest first)',     chipLabel: 'Date ↑',         sort: 'occurred_on', order: 'asc'  },
+  { id: 'amount-desc',  label: 'Amount (largest first)',  chipLabel: 'Amount ↓',       sort: 'amount',      order: 'desc' },
+  { id: 'amount-asc',   label: 'Amount (smallest first)', chipLabel: 'Amount ↑',       sort: 'amount',      order: 'asc'  },
+  { id: 'created-desc', label: 'Recently added',          chipLabel: 'Recently added', sort: 'created_at',  order: 'desc' },
 ];
 
 export const DEFAULT_SORT_ID = 'date-desc';


### PR DESCRIPTION
Follow-up to #73. Backend [TINKPA/receipt-assistant#121](https://github.com/TINKPA/receipt-assistant/pull/121) landed \`sort=amount\` support on \`GET /v1/transactions\`, so the two Amount entries originally specified in #72 can ship.

## Summary

One-file change: re-add \`amount-desc\` and \`amount-asc\` to \`SORT_OPTIONS\` in \`src/lib/transactionsFilterState.ts\`, between the Date and Recently-added entries. Final popover order (matching #72 spec):

1. Date (newest first)
2. Date (oldest first)
3. **Amount (largest first)** ← restored
4. **Amount (smallest first)** ← restored
5. Recently added

Comment updated to explain the backend semantic (\`MAX(ABS(amount_base_minor))\` — same axis as the amount filters, so filter + sort agree on what "amount" means).

## Evidence

Verified on vite dev against the rebuilt backend (6500dcf):

| Sort | Top of result |
|---|---|
| Amount ↓ | \$3487.20, \$1531.80 (Vanilla Gift), \$931.31 (Costco), \$620.96 (Target) |
| Amount ↑ | \$0.00 (AMC voided), \$0.00 (USPS), \$4.95 (Starbucks) |

5/5 popover options present, week banners hide on non-date sort (existing behavior), no 501s, no console errors.

Screenshots: \`notes/120-amount-desc.png\`, \`notes/120-amount-popover.png\` in the outer project notebook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)