### PR TITLE
feat(receipt): clickable Location card → Google Maps merchant

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
     <!-- Type -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@300;400;500;600;700&family=Lora:ital,wght@0,400..700;1,400..700&family=Caveat:wght@400;500;600&display=swap" />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@300;400;500;600;700&family=Lora:ital,wght@0,400..700;1,400..700&family=Caveat:wght@400;500;600&family=Quicksand:wght@400;500;700&display=swap" />
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/ReceiptDetail.tsx
+++ b/src/components/ReceiptDetail.tsx
@@ -302,8 +302,8 @@ export default function ReceiptDetail({ receiptId, onBack, onSelectMerchant, onS
       {!isProcessing && (
         <LocationCard
           place={receipt.place}
-          placeId={receipt.place?.id ?? null}
           merchantId={receipt.merchantId}
+          payee={receipt.payee ?? null}
           onSelectMerchant={onSelectMerchant}
         />
       )}
@@ -753,30 +753,26 @@ function NoteCard({ text }: { text: string }) {
   );
 }
 
-// FE#15: a persistent Location card so users can tell the difference
-// between "no location data for this receipt" (e.g. geocoding skipped
-// or denied at extract time) and "the section is broken / missing".
-// Before this fix, the only diagnostic was buried in backend container
-// logs ("Geocoding denied — skip geocoding") and the user saw nothing.
+// FE#15 + design #35 (pastel-pillow): persistent Location card. Whole card
+// click opens Google Maps for the actual merchant (uses google_place_id
+// + payee), not just the address. "View all visits" remains the in-app
+// path to MerchantDetail.
 function LocationCard({
   place,
-  placeId,
   merchantId,
+  payee,
   onSelectMerchant,
 }: {
   place: ReceiptView['place'];
-  placeId: string | null;
   merchantId: string | null;
+  payee: string | null;
   onSelectMerchant?: (merchantId: string) => void;
 }) {
-  // Compose what we have. `formatted_address` from Google is the
-  // typical human-friendly line ("1635 S San Gabriel Blvd, …").
   const addr = place?.formatted_address?.trim() || null;
   const cityState = (() => {
     if (!addr) return null;
     const parts = addr.split(',').map((s) => s.trim()).filter(Boolean);
     if (parts.length < 2) return null;
-    // US format trims trailing ", USA"; non-US use second-to-last.
     if (place?.country_code === 'US' && parts.length >= 4) {
       const city = parts[parts.length - 3];
       const stateZip = parts[parts.length - 2];
@@ -785,71 +781,186 @@ function LocationCard({
     }
     return parts[parts.length - 2] ?? null;
   })();
-  const mapUrl =
-    placeId && place && place.lat != null && place.lng != null
-      ? `/api/v1/places/${placeId}/map`
-      : null;
 
-  return (
-    <div className="rounded-[14px] border border-[var(--color-rule)] bg-[var(--color-surface)] px-4 py-3">
-      <p className="text-[11px] font-medium tracking-[0.14em] uppercase text-[var(--color-ink-muted)]">
-        Location
-      </p>
-      {place ? (
-        <div className="mt-2 flex items-start gap-3">
-          {mapUrl ? (
-            <img
-              src={mapUrl}
-              alt="Static map of merchant location"
-              loading="lazy"
-              decoding="async"
-              width={72}
-              height={72}
-              className="h-[72px] w-[72px] rounded-[10px] object-cover bg-[var(--color-paper-deep)]/40 shrink-0"
-            />
-          ) : null}
-          <div className="min-w-0 flex-1">
-            {cityState && (
-              <p className="text-[15px] font-medium">{cityState}</p>
-            )}
-            {addr && (
-              <p
-                className={cn(
-                  'text-[13px] text-[var(--color-ink-muted)]',
-                  cityState ? 'mt-0.5' : 'mt-1',
-                )}
-              >
-                {addr}
-              </p>
-            )}
-            {!cityState && !addr && (
-              <p className="text-[13px] text-[var(--color-ink-muted)]">
-                Geocoded, but no street address returned.
-              </p>
-            )}
-          </div>
-        </div>
-      ) : (
+  // Build a Maps URL that resolves to the merchant's place card, not just
+  // the address. We only pass `query_place_id` when we believe the
+  // place_id points to a real business — when the backend's geocoder
+  // matched a premise / street / postal code instead, the place_id
+  // resolves to a bare address and Google faithfully shows that. In
+  // those cases we drop the place_id and rely on Google's text search,
+  // which finds the actual merchant at that address (e.g. "Tokyo
+  // Central 1740 Artesia Blvd, Gardena, CA").
+  const GEOCODING_FALLBACK_TYPES = new Set([
+    'premise',
+    'subpremise',
+    'street_address',
+    'route',
+    'intersection',
+    'postal_code',
+    'plus_code',
+    'locality',
+    'sublocality',
+    'neighborhood',
+    'administrative_area_level_1',
+    'administrative_area_level_2',
+    'administrative_area_level_3',
+    'country',
+  ]);
+  const trustPlaceId =
+    !!place?.google_place_id &&
+    !!place?.primary_type &&
+    !GEOCODING_FALLBACK_TYPES.has(place.primary_type);
+
+  const mapsUrl = (() => {
+    if (!place) return null;
+    const name = payee?.trim() || place.display_name_en || '';
+    const q = encodeURIComponent(`${name} ${addr ?? ''}`.trim());
+    if (!q) return null;
+    const base = `https://www.google.com/maps/search/?api=1&query=${q}`;
+    return trustPlaceId
+      ? `${base}&query_place_id=${encodeURIComponent(place.google_place_id)}`
+      : base;
+  })();
+  const openMaps = () => {
+    if (mapsUrl) window.open(mapsUrl, '_blank', 'noopener,noreferrer');
+  };
+
+  if (!place) {
+    return (
+      <div className="rounded-[14px] border border-[var(--color-rule)] bg-[var(--color-surface)] px-4 py-3">
+        <p className="text-[11px] font-medium tracking-[0.14em] uppercase text-[var(--color-ink-muted)]">
+          Location
+        </p>
         <p className="mt-2 text-[13px] text-[var(--color-ink-muted)]">
           Location unavailable —{' '}
           <span className="italic">geocoding may be disabled or failed.</span>
         </p>
-      )}
-      {merchantId && onSelectMerchant && (
+      </div>
+    );
+  }
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={openMaps}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          openMaps();
+        }
+      }}
+      className="relative cursor-pointer overflow-hidden rounded-[28px] px-5 py-5 transition-transform duration-150 ease-out hover:-translate-y-[1px] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-terracotta)]"
+      style={{
+        background: 'linear-gradient(135deg,#FDE2E4 0%,#E2F0CB 50%,#CDE7F7 100%)',
+        boxShadow:
+          'inset 0 4px 0 rgba(255,255,255,0.6), 0 14px 30px -10px rgba(180,140,180,0.32), 0 1px 2px rgba(60,40,20,0.04)',
+        fontFamily: 'Quicksand, ui-sans-serif, system-ui, sans-serif',
+        color: '#3A3550',
+      }}
+    >
+      <span
+        aria-hidden="true"
+        className="pointer-events-none absolute -top-[70px] -right-[60px] h-[180px] w-[180px] rounded-full"
+        style={{ background: 'rgba(255,255,255,0.55)', filter: 'blur(14px)' }}
+      />
+      <span
+        aria-hidden="true"
+        className="pointer-events-none absolute -bottom-[30px] left-[30%] h-[100px] w-[100px] rounded-full"
+        style={{ background: 'rgba(255,180,200,0.35)', filter: 'blur(20px)' }}
+      />
+
+      <p
+        className="relative text-[11px] font-medium tracking-[0.18em] uppercase"
+        style={{
+          color: '#7A6F92',
+          fontFamily: 'Plus Jakarta Sans, ui-sans-serif, system-ui, sans-serif',
+        }}
+      >
+        Location
+      </p>
+
+      <div className="relative mt-3 flex items-center gap-4">
+        <div
+          aria-hidden="true"
+          className="shrink-0 inline-flex items-center justify-center"
+          style={{
+            width: 60,
+            height: 60,
+            fontSize: 28,
+            background: 'linear-gradient(135deg,#FFB5C2,#FFE2A8)',
+            borderRadius: '42% 58% 65% 35% / 38% 50% 50% 62%',
+            boxShadow:
+              '0 6px 16px -6px rgba(255,140,160,0.45), inset 0 2px 0 rgba(255,255,255,0.5)',
+            animation: 'pastel-blob 8s ease-in-out infinite',
+          }}
+        >
+          📍
+        </div>
+        <div className="min-w-0 flex-1">
+          {cityState && (
+            <p
+              className="text-[20px] font-bold leading-tight"
+              style={{ color: '#3A3550', letterSpacing: '-0.01em' }}
+            >
+              {cityState}
+            </p>
+          )}
+          {addr && (
+            <p
+              className="mt-0.5 text-[13px] font-medium leading-snug"
+              style={{ color: '#7A7090' }}
+            >
+              {addr}
+            </p>
+          )}
+          {!cityState && !addr && (
+            <p className="text-[13px] font-medium" style={{ color: '#7A7090' }}>
+              Geocoded, but no street address returned.
+            </p>
+          )}
+        </div>
+      </div>
+
+      <div className="relative mt-4 flex flex-wrap items-center justify-between gap-3">
         <button
           type="button"
-          onClick={() => onSelectMerchant(merchantId)}
-          data-testid="receipt-view-all-at-location"
-          className={cn(
-            'mt-3 inline-flex items-center gap-1 text-[12px] font-medium',
-            'text-[var(--color-terracotta)] hover:text-[var(--color-terracotta-deep)]',
-            'transition-colors',
-          )}
+          onClick={(e) => {
+            e.stopPropagation();
+            openMaps();
+          }}
+          disabled={!mapsUrl}
+          className="inline-flex items-center gap-2 rounded-full px-4 py-2.5 text-[13px] font-bold transition-colors disabled:opacity-50"
+          style={{
+            background: 'rgba(255,255,255,0.72)',
+            color: '#5A5070',
+            backdropFilter: 'blur(10px)',
+            WebkitBackdropFilter: 'blur(10px)',
+            fontFamily: 'Quicksand, ui-sans-serif, system-ui, sans-serif',
+          }}
         >
-          View all visits to this location
-          <span className="font-display italic text-base leading-none">→</span>
+          Open in Maps
+          <span aria-hidden="true">↗</span>
         </button>
-      )}
+        {merchantId && onSelectMerchant && (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              onSelectMerchant(merchantId);
+            }}
+            data-testid="receipt-view-all-at-location"
+            className="inline-flex items-center gap-1 text-[13px] font-semibold"
+            style={{
+              color: '#7A6F92',
+              fontFamily: 'Quicksand, ui-sans-serif, system-ui, sans-serif',
+            }}
+          >
+            View all visits
+            <span aria-hidden="true">→</span>
+          </button>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -116,3 +116,10 @@
 
 .no-scrollbar::-webkit-scrollbar { display: none; }
 .no-scrollbar { -ms-overflow-style: none; scrollbar-width: none; }
+
+/* LocationCard pastel-pillow blob morph (design #35). Used by ReceiptDetail.tsx::LocationCard. */
+@keyframes pastel-blob {
+  0%, 100% { border-radius: 42% 58% 65% 35% / 38% 50% 50% 62%; }
+  33%      { border-radius: 60% 40% 35% 65% / 55% 35% 65% 45%; }
+  66%      { border-radius: 35% 65% 50% 50% / 45% 60% 40% 55%; }
+}


### PR DESCRIPTION
## Summary
- Replace the static-map Location card on ReceiptDetail with a clickable pastel-pillow card. Whole-card click + an explicit **Open in Maps** pill open Google Maps in a new tab; **View all visits** still routes to MerchantDetail.
- Build the Maps URL with `payee` + `formatted_address`. Pass `query_place_id` **only** when `place.primary_type` is a real business type. `premise` / `street_address` / `postal_code` / `locality` / `neighborhood` / etc. fall back to a text-search query so Google resolves the actual store at that address — fixes Tokyo Central et al. where the geocoder matched the building, not the business.

## Why
- The Location card was decorative — clicking did nothing. Users who wanted to navigate had to copy the address by hand.
- Naive use of `query_place_id` doesn't fix it: ~7% of the corpus has `primary_type = premise` because the ingest-time geocoder matched a street address rather than the storefront. With `query_place_id` set, Google Maps then faithfully shows the premise. The fix is to filter `primary_type` and prefer text search when the place_id isn't a business.

## What's new in the LocationCard
- Design #35 from a quick 37-variant exploration (separate HTML mockup, not committed) — pastel sherbet gradient, animated CSS border-radius "blob" with the pin emoji, frosted-glass "Open in Maps" pill.
- New font: Quicksand (added to the existing Google Fonts `<link>`).
- New `@keyframes pastel-blob` in `index.css` (scoped to one usage).
- `LocationCard` now takes `payee` (added to the call site); the now-unused `placeId` prop is dropped.

## Test plan
- [ ] **Tokyo Central** (2026-05-14, `primary_type = premise`) → Open in Maps lands on the Tokyo Central business, not on bare 1740 Artesia Blvd.
- [ ] **Starbucks** (`primary_type = coffee_shop`) → Open in Maps opens the place card directly (the `query_place_id` path still works for real businesses).
- [ ] Receipt with no place → fallback "Location unavailable" card still renders.
- [ ] Keyboard: Enter / Space on the focused card opens Maps.
- [ ] **View all visits** still routes to MerchantDetail unchanged.
- [ ] Other rows flagged by the audit (Torihei Yakitori, Xiao Ling Crispy Potato Bites, Trader Joe's @ 11755 Olympic, Grovemade) all land on the right business now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)