### PR TITLE
Render email-sourced receipts (Original Email fold) + source affordances (#76)

### DIFF
--- a/src/components/ReceiptDetail.tsx
+++ b/src/components/ReceiptDetail.tsx
@@ -4,6 +4,7 @@ import {
   classifyBackendCategory,
   fetchReceiptDetail,
   documentContentUrl,
+  documentRenderedUrl,
   extractProblemMessage,
   getTransaction,
   postReExtractDocument,
@@ -283,7 +284,11 @@ export default function ReceiptDetail({ receiptId, onBack, onSelectMerchant, onS
         }
       />
 
-      <StatusRow badge={badge} paymentMethod={receipt.paymentMethod ?? null} />
+      <StatusRow
+        badge={badge}
+        paymentMethod={receipt.paymentMethod ?? null}
+        source={primaryDoc?.kind ?? null}
+      />
 
       {isProcessing && <ProcessingNote />}
 
@@ -320,7 +325,14 @@ export default function ReceiptDetail({ receiptId, onBack, onSelectMerchant, onS
        *  Hidden when there are no matches (no skeleton, no placeholder). */}
 
       {!isProcessing && receipt.documentId && (
-        <OriginalReceiptCollapsible documentId={receipt.documentId} />
+        <OriginalReceiptCollapsible
+          documentId={receipt.documentId}
+          kind={primaryDoc?.kind ?? null}
+          sourceMeta={
+            (primaryDoc as { source_meta?: Record<string, unknown> | null } | undefined)
+              ?.source_meta ?? null
+          }
+        />
       )}
 
       {/* Re-extract affordance. Only on active (non-voided) receipts
@@ -665,16 +677,40 @@ function AmountHero({
   );
 }
 
+function sourceLabel(
+  kind: string | null | undefined,
+): { glyph: string; label: string } | null {
+  if (kind === 'receipt_email') return { glyph: '✉︎', label: 'via email' };
+  if (kind === 'receipt_pdf' || kind === 'statement_pdf')
+    return { glyph: '⌗', label: 'via pdf' };
+  return null;
+}
+
 function StatusRow({
   badge,
   paymentMethod,
+  source,
 }: {
   badge: ReturnType<typeof statusBadge>;
   paymentMethod: string | null;
+  source?: string | null;
 }) {
-  if (!badge && !paymentMethod) return null;
+  const src = sourceLabel(source);
+  if (!badge && !paymentMethod && !src) return null;
   return (
     <div className="flex items-center justify-center gap-2 text-[12px] text-[var(--color-ink-muted)]">
+      {src && (
+        <span
+          className={cn(
+            'inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium',
+            'bg-[var(--color-terracotta-soft)] text-[var(--color-terracotta-deep)]',
+          )}
+        >
+          <span aria-hidden="true">{src.glyph}</span>
+          {src.label}
+        </span>
+      )}
+      {src && (badge || paymentMethod) && <span aria-hidden="true">·</span>}
       {badge && (
         <span
           className={cn(
@@ -697,8 +733,57 @@ function StatusRow({
   );
 }
 
-function OriginalReceiptCollapsible({ documentId }: { documentId: string }) {
+function formatReceived(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+/** Email message-header strip shown above the rendered email body, so the
+ *  fold reads as "the original email" rather than a raw HTML blob (#76). */
+function EmailHeaderStrip({
+  sender,
+  subject,
+  receivedAt,
+}: {
+  sender: string | null;
+  subject: string | null;
+  receivedAt: string | null;
+}) {
+  return (
+    <div className="rounded-[10px] border border-[var(--color-rule)] bg-[var(--color-surface)] px-4 py-3">
+      {subject && (
+        <p className="font-display italic font-medium text-[15px] leading-snug text-[var(--color-ink)]">
+          {subject}
+        </p>
+      )}
+      <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-[12px] text-[var(--color-ink-muted)]">
+        {sender && <span className="min-w-0 truncate">{sender}</span>}
+        {sender && receivedAt && <span aria-hidden="true">·</span>}
+        {receivedAt && <span className="tnum">{formatReceived(receivedAt)}</span>}
+      </div>
+    </div>
+  );
+}
+
+function OriginalReceiptCollapsible({
+  documentId,
+  kind,
+  sourceMeta,
+}: {
+  documentId: string;
+  kind?: string | null;
+  sourceMeta?: Record<string, unknown> | null;
+}) {
   const [open, setOpen] = useState(false);
+  const isEmail = kind === 'receipt_email';
+  const sender = (sourceMeta?.sender as string | undefined) ?? null;
+  const subject = (sourceMeta?.subject as string | undefined) ?? null;
+  const receivedAt = (sourceMeta?.received_at as string | undefined) ?? null;
   return (
     <div className="rounded-[18px] border border-[var(--color-rule)] bg-[var(--color-surface)] overflow-hidden">
       <button
@@ -707,7 +792,7 @@ function OriginalReceiptCollapsible({ documentId }: { documentId: string }) {
         className="w-full px-5 py-4 flex items-center justify-between text-left hover:bg-[var(--color-paper-deep)]/30 transition-colors"
       >
         <span className="font-display italic font-medium text-lg leading-none">
-          Original receipt
+          {isEmail ? 'Original email' : 'Original receipt'}
         </span>
         {open ? <ChevronDown size={18} className="text-[var(--color-ink-muted)]" /> : <ChevronRight size={18} className="text-[var(--color-ink-muted)]" />}
       </button>
@@ -719,14 +804,39 @@ function OriginalReceiptCollapsible({ documentId }: { documentId: string }) {
               'linear-gradient(180deg, rgba(245, 230, 195, 0.4) 0%, rgba(201, 123, 92, 0.06) 100%), var(--color-surface)',
           }}
         >
-          <img
-            src={documentContentUrl(documentId)}
-            alt="Receipt"
-            className="block max-w-full max-h-[500px] object-contain mx-auto rounded-[10px]"
-            onError={(e) => {
-              (e.target as HTMLImageElement).style.display = 'none';
-            }}
-          />
+          {isEmail ? (
+            <div className="space-y-3">
+              {(sender || subject || receivedAt) && (
+                <EmailHeaderStrip
+                  sender={sender}
+                  subject={subject}
+                  receivedAt={receivedAt}
+                />
+              )}
+              {/* Faithful render of the sender's HTML, isolated in a
+                  sandboxed iframe (no scripts / no same-origin). The
+                  backend serves it with a strict CSP; this is the second
+                  containment layer. Fixed height + internal scroll since
+                  email heights vary wildly. */}
+              <iframe
+                src={documentRenderedUrl(documentId)}
+                title="Original email"
+                sandbox=""
+                referrerPolicy="no-referrer"
+                className="block w-full rounded-[10px] border border-[var(--color-rule)] bg-white"
+                style={{ height: 520 }}
+              />
+            </div>
+          ) : (
+            <img
+              src={documentContentUrl(documentId)}
+              alt="Receipt"
+              className="block max-w-full max-h-[500px] object-contain mx-auto rounded-[10px]"
+              onError={(e) => {
+                (e.target as HTMLImageElement).style.display = 'none';
+              }}
+            />
+          )}
         </div>
       )}
     </div>

--- a/src/components/Transactions.tsx
+++ b/src/components/Transactions.tsx
@@ -475,6 +475,21 @@ function WeekGroup({
   );
 }
 
+/**
+ * Quiet source marker for the ledger row. Only NON-photo sources are
+ * marked (email / PDF); a camera/photo receipt is the default and stays
+ * unmarked, keeping the list calm (#76). Glyphs are forced to text
+ * rendering (no emoji color) to sit in the muted meta line.
+ */
+function sourceTag(
+  kind: string | null | undefined,
+): { glyph: string; label: string } | null {
+  if (kind === 'receipt_email') return { glyph: '✉︎', label: 'email' };
+  if (kind === 'receipt_pdf' || kind === 'statement_pdf')
+    return { glyph: '⌗', label: 'pdf' };
+  return null;
+}
+
 function LedgerRow({
   tx,
   onSelect,
@@ -548,6 +563,14 @@ function LedgerRow({
               · {badge.label}
             </span>
           )}
+          {(() => {
+            const src = sourceTag(tx.documentKind);
+            return src ? (
+              <span className="ml-1" title={`From ${src.label}`}>
+                · <span className="not-italic">{src.glyph}</span> {src.label}
+              </span>
+            ) : null;
+          })()}
         </p>
       </button>
 

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -1837,6 +1837,56 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/brands/{brandId}/rollup": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Brand-level rollup — locations, recent transactions, sibling brands
+         * @description Aggregates across every merchant row sharing this brand_id within the workspace. Powers the BrandPage UI (#XXX). Voided transactions excluded from money sums. Sibling brands (same parent_id) included for the Costco-style grouped-brand callout.
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    brandId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["BrandRollup"];
+                    };
+                };
+                /** @description Brand not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/postings": {
         parameters: {
             query?: never;
@@ -2121,6 +2171,62 @@ export interface paths {
                 };
                 /** @description Not found */
                 404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/documents/{id}/rendered": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Decoded + sanitized HTML body of a receipt_email document, for the frontend 'Original email' fold. Served with a strict CSP; render inside a sandboxed iframe. */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Sanitized email HTML */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "text/html": string;
+                    };
+                };
+                /** @description Not found / no file */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+                /** @description Document is not an email (kind != receipt_email) */
+                422: {
                     headers: {
                         [name: string]: unknown;
                     };
@@ -3924,6 +4030,9 @@ export interface components {
              */
             id: string;
             kind: string;
+            source_meta?: {
+                [key: string]: unknown;
+            } | null;
         };
         Place: {
             /**
@@ -4338,6 +4447,94 @@ export interface components {
                 [key: string]: unknown;
             };
         };
+        BrandRollupStats: {
+            location_count: number;
+            transaction_count: number;
+            lifetime_spend_minor: number;
+            current_month_spend_minor: number;
+            last_transaction_date: string | null;
+            currency: string;
+        };
+        Merchant: {
+            /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            id: string;
+            /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            workspace_id: string;
+            brand_id: string;
+            canonical_name: string;
+            category: string | null;
+            place_id: string | null;
+            photo_url: string | null;
+            photo_attribution: string | null;
+            address: string | null;
+            lat: number | null;
+            lng: number | null;
+            /** @enum {string} */
+            enrichment_status: "pending" | "success" | "not_found" | "failed";
+            /** Format: date-time */
+            enrichment_attempted_at: string | null;
+            custom_name: string | null;
+            /** Format: date-time */
+            created_at: string;
+            /** Format: date-time */
+            updated_at: string;
+        };
+        MerchantStats: {
+            transaction_count: number;
+            lifetime_spend_minor: number;
+            current_month_spend_minor: number;
+            last_transaction_date: string | null;
+            currency: string;
+        };
+        BrandRollupLocation: {
+            merchant: components["schemas"]["Merchant"];
+            stats: components["schemas"]["MerchantStats"];
+        };
+        BrandRollupRecentRow: {
+            /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            id: string;
+            occurred_on: string;
+            payee: string | null;
+            /** @enum {string} */
+            status: "draft" | "posted" | "voided" | "reconciled" | "error";
+            total_minor: number;
+            currency: string;
+            /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            document_id: string | null;
+            /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            merchant_id: string;
+            merchant_canonical_name: string;
+            merchant_custom_name: string | null;
+        };
+        BrandRollupSibling: {
+            brand_id: string;
+            name: string;
+            domain: string | null;
+            icon_url: string | null;
+            location_count: number;
+        };
+        BrandRollup: {
+            brand: components["schemas"]["Brand"];
+            stats: components["schemas"]["BrandRollupStats"];
+            locations: components["schemas"]["BrandRollupLocation"][];
+            recent_transactions: components["schemas"]["BrandRollupRecentRow"][];
+            sibling_brands: components["schemas"]["BrandRollupSibling"][];
+        };
         UpdateBrandRequest: {
             /**
              * Format: uuid
@@ -4371,6 +4568,12 @@ export interface components {
             /** @description Model identifier under which ocr_text was produced. NULL on legacy rows. */
             ocr_model_version: string | null;
             extraction_meta: {
+                [key: string]: unknown;
+            } | null;
+            /** @description RFC822 Message-ID for email-sourced documents (kind=receipt_email); NULL otherwise. */
+            message_id: string | null;
+            /** @description Channel provenance for non-image sources. For email: {channel,sender,subject,received_at,message_id}. */
+            source_meta: {
                 [key: string]: unknown;
             } | null;
             /**
@@ -4781,43 +4984,6 @@ export interface components {
              */
             net_minor: number;
             buckets: components["schemas"]["CashflowBucket"][];
-        };
-        Merchant: {
-            /**
-             * Format: uuid
-             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
-             */
-            id: string;
-            /**
-             * Format: uuid
-             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
-             */
-            workspace_id: string;
-            brand_id: string;
-            canonical_name: string;
-            category: string | null;
-            place_id: string | null;
-            photo_url: string | null;
-            photo_attribution: string | null;
-            address: string | null;
-            lat: number | null;
-            lng: number | null;
-            /** @enum {string} */
-            enrichment_status: "pending" | "success" | "not_found" | "failed";
-            /** Format: date-time */
-            enrichment_attempted_at: string | null;
-            custom_name: string | null;
-            /** Format: date-time */
-            created_at: string;
-            /** Format: date-time */
-            updated_at: string;
-        };
-        MerchantStats: {
-            transaction_count: number;
-            lifetime_spend_minor: number;
-            current_month_spend_minor: number;
-            last_transaction_date: string | null;
-            currency: string;
         };
         MerchantDetail: {
             merchant: components["schemas"]["Merchant"];

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -450,6 +450,7 @@ export function mapTransaction(t: BackendTransaction): Transaction {
     amount: classification.transactionType === 'income' ? rv.total : -rv.total,
     rawStatus: t.status,
     documentId: rv.documentId,
+    documentKind: rv.documentKind,
     merchantBrandId: m?.brand_id ?? null,
     merchantId: m?.id ?? null,
   };
@@ -880,6 +881,13 @@ export async function restoreDocument(id: string): Promise<BackendDocument> {
  *  /api and the static bundle. */
 export function documentContentUrl(docId: string): string {
   return `/api/v1/documents/${docId}/content`;
+}
+
+/** URL for the decoded + sanitized HTML body of a receipt_email
+ *  document (#122). Intended as the `src` of a sandboxed `<iframe>` in
+ *  the "Original email" fold. Served with a strict CSP by the backend. */
+export function documentRenderedUrl(docId: string): string {
+  return `/api/v1/documents/${docId}/rendered`;
 }
 
 export async function linkDocument(docId: string, transactionId: string): Promise<void> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,6 +49,10 @@ export interface Transaction {
   /** Primary linked document id, if any — needed for tombstone toggle and
    *  delete-receipt cascade flows from the list. */
   documentId?: string | null;
+  /** Kind of the primary document (`receipt_image` | `receipt_email` |
+   *  `receipt_pdf` | …). Drives the list source glyph — only non-photo
+   *  sources are marked (#76). */
+  documentKind?: string | null;
   /** Canonical merchant brand id (kebab-case, e.g. "costco"). Populated
    *  from the joined `merchant.brand_id`. Drives navigation from a
    *  receipt → BrandPage (one brand across all its physical stores). */


### PR DESCRIPTION
## Summary
Frontend for email-receipt display (Closes #76). **Depends on TINKPA/receipt-assistant#122** (backend schema + `source_meta` + `/rendered`) — `api-types.ts` here is regenerated against that branch's spec.

- **Ledger list** (`Transactions.tsx`): a quiet source glyph on **non-photo rows only** — `✉︎ email` / `⌗ pdf` in the muted meta line under the merchant name. Camera/photo receipts stay unmarked (keeps the list calm). Threaded `documentKind` through the compact `Transaction` view (`types.ts`, `api.ts`).
- **ReceiptDetail**:
  - `✉︎ via email` terracotta pill in the centered status row (below the amount hero).
  - bottom fold retitles **"Original receipt" → "Original email"** for `receipt_email`.
  - fold renders an **email-header strip** (sender / subject / received date from `documents.source_meta`) above a **`sandbox=""` `<iframe>`** loading `GET /api/v1/documents/:id/rendered`. `sandbox=""` + the backend's strict CSP isolate the untrusted email HTML. Image/PDF receipts unchanged.
- `documentRenderedUrl()` helper; `api-types.ts` regenerated for `source_meta` + the `/rendered` path.

## Design
Matches the locked warm/editorial system (Lora italic display, terracotta single-accent, barely-visible rules) per `frontend-design`. Provenance is treated as secondary metadata — quiet glyph in the list, small pill on detail, faithful (not restyled) email render in the demoted fold.

## Verification (real Chrome, frontend-test-runner) — 4/4 AC PASS
- **AC1 list glyph:** `✉︎ EMAIL` present on 10/10 email rows' subtitles. <details><summary>screenshot</summary>`/tmp/ac1_ledger_list.png`</details>
- **AC2 via-email pill:** centered `✉︎ via email` pill on ReceiptDetail (Apple $0.99). `/tmp/ac2_detail_pill.png`
- **AC3 Original email fold:** title = "Original email"; header strip (`Your receipt from Apple.` / `Apple <no_reply@email.apple.com>` / `Apr 30, 2026`); iframe renders the real Apple receipt HTML. `GET /api/v1/documents/<id>/rendered → 200 text/html, 19,734 bytes`, served with scoped CSP; `sandbox=""`. `/tmp/ac3_rendered_email.png`
- **AC4:** zero console errors / zero CSP violations across list, detail, and iframe re-render.

## Test plan
- [ ] Merge #122 first (backend contract), then this.
- [ ] Re-run `npm run api:types` from `main` after #122 merges (should be a no-op diff).

## Note (non-blocking)
SPA isn't URL-addressable — ReceiptDetail state is in-memory, so receipts can't be deep-linked/reloaded. Separate issue if shareable receipt URLs are wanted.