### PR TITLE
feat(#78): "Already in your ledger" — distinct dedup upload state

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -244,6 +244,7 @@ export default function App() {
         jobs={jobs}
         onJobDone={removeJob}
         onRefresh={() => setRefreshKey((k) => k + 1)}
+        onSelectTransaction={handleSelectReceipt}
       />
     </>
   );

--- a/src/components/BatchDetail.tsx
+++ b/src/components/BatchDetail.tsx
@@ -6,6 +6,7 @@ import {
   Clock,
   Cog,
   FileText,
+  Layers,
   Zap,
 } from 'lucide-react';
 import {
@@ -31,6 +32,7 @@ const INGEST_STATUS_META: Record<
   queued: { label: 'Queued', badge: 'bg-surface-container-highest text-on-surface-variant', icon: Clock },
   processing: { label: 'Processing', badge: 'bg-tertiary/10 text-tertiary', icon: Cog },
   done: { label: 'Done', badge: 'bg-primary/10 text-primary', icon: CheckCircle2 },
+  dedup: { label: 'Duplicate', badge: 'bg-sky-400/10 text-sky-300', icon: Layers },
   error: { label: 'Error', badge: 'bg-error/10 text-error', icon: AlertCircle },
   unsupported: { label: 'Unsupported', badge: 'bg-error/10 text-error', icon: AlertCircle },
 };
@@ -111,7 +113,9 @@ export default function BatchDetail({ batchId, onBack, onSelectTransaction }: Ba
   }
 
   const { counts } = batch;
-  const pct = counts.total > 0 ? Math.round(((counts.done + counts.error) / counts.total) * 100) : 0;
+  // dedup + unsupported are terminal too, so they count toward completion.
+  const terminalDone = counts.done + counts.dedup + counts.error + counts.unsupported;
+  const pct = counts.total > 0 ? Math.round((terminalDone / counts.total) * 100) : 0;
 
   return (
     <div className="space-y-8 animate-in fade-in slide-in-from-bottom-4 duration-700 max-w-5xl">
@@ -140,11 +144,12 @@ export default function BatchDetail({ batchId, onBack, onSelectTransaction }: Ba
           </div>
         </div>
 
-        <div className="grid grid-cols-2 md:grid-cols-5 gap-4 mt-6 pt-6 border-t border-outline-variant/10">
+        <div className="grid grid-cols-3 md:grid-cols-6 gap-4 mt-6 pt-6 border-t border-outline-variant/10">
           <StatCard label="Total" value={counts.total} />
           <StatCard label="Queued" value={counts.queued} tone="muted" />
           <StatCard label="Processing" value={counts.processing} tone="tertiary" />
           <StatCard label="Done" value={counts.done} tone="primary" />
+          <StatCard label="Duplicate" value={counts.dedup} tone="info" />
           <StatCard label="Error" value={counts.error + counts.unsupported} tone="error" />
         </div>
 
@@ -228,18 +233,20 @@ function StatCard({
 }: {
   label: string;
   value: number;
-  tone?: 'default' | 'muted' | 'primary' | 'tertiary' | 'error';
+  tone?: 'default' | 'muted' | 'primary' | 'tertiary' | 'info' | 'error';
 }) {
   const valueClass =
     tone === 'primary'
       ? 'text-primary'
       : tone === 'tertiary'
         ? 'text-tertiary'
-        : tone === 'error'
-          ? 'text-error'
-          : tone === 'muted'
-            ? 'text-on-surface-variant'
-            : 'text-white';
+        : tone === 'info'
+          ? 'text-sky-300'
+          : tone === 'error'
+            ? 'text-error'
+            : tone === 'muted'
+              ? 'text-on-surface-variant'
+              : 'text-white';
   return (
     <div>
       <p className="text-xs text-on-surface-variant uppercase tracking-widest">{label}</p>

--- a/src/components/Batches.tsx
+++ b/src/components/Batches.tsx
@@ -84,8 +84,9 @@ export default function Batches({ onSelectBatch }: BatchesProps) {
               {items.map((b) => {
                 const meta = STATUS_META[b.status];
                 const Icon = meta.icon;
-                const { done, error: errored, total } = b.counts;
-                const pct = total > 0 ? Math.round(((done + errored) / total) * 100) : 0;
+                const { done, error: errored, dedup, total } = b.counts;
+                const pct =
+                  total > 0 ? Math.round(((done + dedup + errored) / total) * 100) : 0;
                 return (
                   <tr
                     key={b.id}
@@ -116,8 +117,11 @@ export default function Batches({ onSelectBatch }: BatchesProps) {
                             style={{ width: `${pct}%` }}
                           />
                         </div>
-                        <span className="text-[11px] text-on-surface-variant font-mono w-16 text-right">
+                        <span className="text-[11px] text-on-surface-variant font-mono w-28 text-right">
                           {done}/{total}
+                          {dedup > 0 && (
+                            <span className="text-sky-300"> · {dedup} deduped</span>
+                          )}
                           {errored > 0 && <span className="text-error"> · {errored} err</span>}
                         </span>
                       </div>

--- a/src/components/ProcessingToast.tsx
+++ b/src/components/ProcessingToast.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
-import { Loader2, CheckCircle, XCircle, X } from 'lucide-react';
+import { Loader2, CheckCircle, XCircle, Layers, X } from 'lucide-react';
 import { motion, AnimatePresence } from 'motion/react';
 import { getBatch, extractProblemMessage } from '../lib/api';
 
@@ -26,7 +26,7 @@ interface ToastState {
   batchId: string;
   ingestId: string;
   filename: string;
-  status: 'processing' | 'done' | 'error';
+  status: 'processing' | 'done' | 'duplicate' | 'error';
   transactionId?: string;
   error?: string;
 }
@@ -35,6 +35,9 @@ interface ProcessingToastProps {
   jobs: ProcessingJob[];
   onJobDone: (batchId: string) => void;
   onRefresh: () => void;
+  /** Tap a terminal toast to jump to the produced transaction. For a
+   *  dedup hit this is the *pre-existing* transaction the upload matched. */
+  onSelectTransaction?: (transactionId: string) => void;
 }
 
 // `useProcessingJobs` hook lives in ./useProcessingJobs.ts (separate
@@ -48,9 +51,18 @@ const TERMINAL_ERROR = new Set(['failed', 'reconcile_error']);
  *  terminal state + error text. Toasts are then *derived* from
  *  (jobs, statusMap, dismissed), which sidesteps the
  *  react-hooks/set-state-in-effect lint. */
-type StatusOverride = { status: 'done' | 'error'; transactionId?: string; error?: string };
+type StatusOverride = {
+  status: 'done' | 'duplicate' | 'error';
+  transactionId?: string;
+  error?: string;
+};
 
-export default function ProcessingToast({ jobs, onJobDone, onRefresh }: ProcessingToastProps) {
+export default function ProcessingToast({
+  jobs,
+  onJobDone,
+  onRefresh,
+  onSelectTransaction,
+}: ProcessingToastProps) {
   const [statusMap, setStatusMap] = useState<Record<string, StatusOverride>>({});
   const [dismissed, setDismissed] = useState<Set<string>>(new Set());
   // Keep the latest callbacks in a ref so the polling interval can use
@@ -90,17 +102,35 @@ export default function ProcessingToast({ jobs, onJobDone, onRefresh }: Processi
         try {
           const batch = await getBatch(job.batchId);
           if (TERMINAL_DONE.has(batch.status)) {
-            const produced = batch.items.find((i) => i.id === job.ingestId)?.produced;
-            const transactionId = produced?.transaction_ids?.[0];
-            setStatusMap((prev) => ({
-              ...prev,
-              [job.batchId]: { status: 'done', transactionId },
-            }));
-            callbacksRef.current.onRefresh();
-            setTimeout(() => {
-              setDismissed((prev) => new Set(prev).add(job.batchId));
-              callbacksRef.current.onJobDone(job.batchId);
-            }, 3000);
+            // Per-file outcome: dedup is decided by the *ingest item's*
+            // own status, not the batch's. A byte-identical re-upload is
+            // born terminal with `status='dedup'` and points at the
+            // pre-existing transaction — no new row was written, so we
+            // surface a neutral "already in your ledger" state and skip
+            // onRefresh (there's nothing new to fetch).
+            const item = batch.items.find((i) => i.id === job.ingestId);
+            const transactionId = item?.produced?.transaction_ids?.[0];
+            if (item?.status === 'dedup') {
+              setStatusMap((prev) => ({
+                ...prev,
+                [job.batchId]: { status: 'duplicate', transactionId },
+              }));
+              // Intentionally no onRefresh() — dedup adds no new data.
+              setTimeout(() => {
+                setDismissed((prev) => new Set(prev).add(job.batchId));
+                callbacksRef.current.onJobDone(job.batchId);
+              }, 5000);
+            } else {
+              setStatusMap((prev) => ({
+                ...prev,
+                [job.batchId]: { status: 'done', transactionId },
+              }));
+              callbacksRef.current.onRefresh();
+              setTimeout(() => {
+                setDismissed((prev) => new Set(prev).add(job.batchId));
+                callbacksRef.current.onJobDone(job.batchId);
+              }, 3000);
+            }
           } else if (TERMINAL_ERROR.has(batch.status)) {
             const ingestErr = batch.items.find((i) => i.id === job.ingestId)?.error ?? null;
             setStatusMap((prev) => ({
@@ -138,19 +168,53 @@ export default function ProcessingToast({ jobs, onJobDone, onRefresh }: Processi
   return (
     <div className="fixed bottom-6 right-6 z-50 flex flex-col gap-3">
       <AnimatePresence>
-        {toasts.map((toast) => (
+        {toasts.map((toast) => {
+          // A terminal toast that produced a transaction is tappable —
+          // jump to that transaction. For dedup this is the pre-existing
+          // row the upload matched, so the user can confirm it's already
+          // tracked rather than wondering where their upload went.
+          const tappable =
+            (toast.status === 'done' || toast.status === 'duplicate') &&
+            !!toast.transactionId &&
+            !!onSelectTransaction;
+          const goToTransaction = () => {
+            if (tappable && toast.transactionId) {
+              onSelectTransaction!(toast.transactionId);
+              dismiss(toast.batchId);
+            }
+          };
+          return (
           <motion.div
             key={toast.batchId}
             initial={{ opacity: 0, y: 20, scale: 0.95 }}
             animate={{ opacity: 1, y: 0, scale: 1 }}
             exit={{ opacity: 0, y: 10, scale: 0.95 }}
-            className="glass-panel border border-outline-variant/20 rounded-xl px-5 py-4 shadow-2xl flex items-center gap-3 min-w-[280px]"
+            onClick={tappable ? goToTransaction : undefined}
+            role={tappable ? 'button' : undefined}
+            tabIndex={tappable ? 0 : undefined}
+            onKeyDown={
+              tappable
+                ? (e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault();
+                      goToTransaction();
+                    }
+                  }
+                : undefined
+            }
+            className={
+              'glass-panel border border-outline-variant/20 rounded-xl px-5 py-4 shadow-2xl flex items-center gap-3 min-w-[280px]' +
+              (tappable ? ' cursor-pointer hover:border-outline-variant/40 transition-colors' : '')
+            }
           >
             {toast.status === 'processing' && (
               <Loader2 className="animate-spin text-tertiary shrink-0" size={20} />
             )}
             {toast.status === 'done' && (
               <CheckCircle className="text-primary shrink-0" size={20} />
+            )}
+            {toast.status === 'duplicate' && (
+              <Layers className="text-sky-400 shrink-0" size={20} />
             )}
             {toast.status === 'error' && (
               <XCircle className="text-error shrink-0" size={20} />
@@ -159,9 +223,15 @@ export default function ProcessingToast({ jobs, onJobDone, onRefresh }: Processi
             <div className="flex-1 min-w-0">
               <p className="text-sm font-bold text-white">
                 {toast.status === 'processing' && 'Processing receipt...'}
-                {toast.status === 'done' && 'Receipt ready'}
+                {toast.status === 'done' && 'Receipt added'}
+                {toast.status === 'duplicate' && 'Already in your ledger'}
                 {toast.status === 'error' && 'Processing failed'}
               </p>
+              {toast.status === 'duplicate' && (
+                <p className="text-xs text-sky-300/80 mt-0.5 truncate">
+                  This receipt was added before
+                </p>
+              )}
               {toast.status === 'error' && toast.error && (
                 <p className="text-xs text-error mt-0.5 truncate">{toast.error}</p>
               )}
@@ -171,13 +241,17 @@ export default function ProcessingToast({ jobs, onJobDone, onRefresh }: Processi
             </div>
 
             <button
-              onClick={() => dismiss(toast.batchId)}
+              onClick={(e) => {
+                e.stopPropagation();
+                dismiss(toast.batchId);
+              }}
               className="text-on-surface-variant hover:text-white transition-colors shrink-0"
             >
               <X size={16} />
             </button>
           </motion.div>
-        ))}
+          );
+        })}
       </AnimatePresence>
     </div>
   );

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -4612,9 +4612,10 @@ export interface components {
             done: number;
             error: number;
             unsupported: number;
+            dedup: number;
         };
         /** @enum {string} */
-        IngestStatus: "queued" | "processing" | "done" | "error" | "unsupported";
+        IngestStatus: "queued" | "processing" | "done" | "error" | "unsupported" | "dedup";
         /** @enum {string|null} */
         IngestClassification: "receipt_image" | "receipt_email" | "receipt_pdf" | "statement_pdf" | "unsupported" | null;
         IngestProduced: {


### PR DESCRIPTION
## Summary

Backend L1 dedup ([receipt-assistant#124](https://github.com/TINKPA/receipt-assistant/issues/124) / PR #127, **now merged to `main`**): a re-upload that matches an already-ingested document no longer creates a duplicate transaction — the ingest row is terminal with `status='dedup'` and `produced.transaction_ids=[<existing tx>]`, and `batch.counts` gains a `dedup` tally.

The frontend previously collapsed every terminal outcome into **done / error**, so a dedup hit was silently mis-reported as the green **"Receipt ready"** state — the user thought they'd added a new receipt, tapped in, and landed on the *previous* transaction with no signal it was a duplicate. This PR adds a neutral, honest **third upload state** across the surfaces.

`Fixes #78`. Backend #127 is already merged, so `npm run api:types` against `main` is clean (no local type widening needed).

## What changed (per file)

- **`src/components/ProcessingToast.tsx`** — added a `'duplicate'` variant to the status-override union. In the poll loop, when the batch reaches a terminal-done state we branch on the **ingest item's own** status: `item.status === 'dedup'` → neutral "Already in your ledger" toast (info-blue `Layers` icon, copy _"This receipt was added before"_, taps to the **pre-existing** `produced.transaction_ids[0]`, **5s** auto-dismiss, **skips `onRefresh`**); otherwise the existing green "Receipt added" path (3s, calls `onRefresh`). Terminal done/duplicate toasts are now tappable (click + Enter/Space → their transaction).
- **`src/App.tsx`** — wired `onSelectTransaction={handleSelectReceipt}` into `<ProcessingToast>`.
- **`src/components/BatchDetail.tsx`** — added a `dedup` per-item row state (`Duplicate` badge, neutral sky/`Layers`) distinct from done/error; added a **Duplicate** stat card; dedup counts toward the batch completion %.
- **`src/components/Batches.tsx`** — surfaces `counts.dedup` as a neutral "N deduped" chip alongside done/error; dedup counts toward progress %.
- **`src/lib/api-types.ts`** — regenerated via `npm run api:types` against merged `main`; `IngestStatus` and `BatchCounts` now carry `dedup` (no local widening).

Design: dedup is **informational, not an error** — a distinct neutral sky-blue (not green, not red), per the issue's product decision. Per-file, not per-batch (no batch-level summary toast). Matches the existing glass-panel dark system / semantic tokens / `lucide-react` / `motion/react` per the `frontend-design` skill.

## Verification status — please read before merging

I want to be precise about what is and isn't proven, rather than overclaim.

**Proven:**
- `tsc --noEmit` is clean against the regenerated types; the code compiles with `IngestStatus`/`BatchCounts` carrying `dedup` from the **merged-main** spec (not a local hack).
- `eslint` is clean for all five touched files. (The repo has 6 pre-existing lint errors in untouched components — `Dashboard`/`MonthlyReview`/`Products`/`Transactions`/`BrandPage`/`MerchantDetail` — that also reproduce on `main`.)
- The live backend's `ingest_status` enum includes `dedup`, and `GET /v1/batches/:id` returns the `counts.dedup` field — i.e. the data contract the UI keys off exists end-to-end.

**NOT yet proven (why this stays a draft):**
- **The `dedup` ingest status was not reproduced live in this session.** L1 dedup requires the *first* upload's document + transaction to be fully committed before the identical re-upload is processed, because the dedup decision is made by the `claude -p` extraction agent via a sha/document pre-check (see backend `src/ingest/prompt.ts`). In this environment extraction is slow and my repeated re-upload attempts raced that commit — each upload was extracted independently and produced its own transaction (`counts.dedup=0`), and a strictly-sequential attempt could not get the first extraction to finish inside the poll window. So I have **not** captured a real `status='dedup'` response to screenshot the new toast against.
- **Browser click-through was not performed.** This issue is `area/ui` and project policy is to close it with a live `frontend-test-runner` browser run (screenshots / HTML report). That harness depends on `chrome-devtools-mcp`, which was **not registered in this session**; loading newly-registered MCP tools needs a Claude Code restart this background agent can't do, and no `Task`/agent-spawn tool was available to launch the subagent. Per the skill's own rule ("if frontend-test-runner genuinely can't run, say so explicitly — do not substitute code analysis"), I'm flagging this rather than passing code-reading off as a browser test.

**Outstanding AC for a maintainer / follow-up session (with `chrome-devtools-mcp` loaded, and a reliably-committing first upload):**
- [ ] fresh upload → green "Receipt added" toast, taps to the new tx
- [ ] re-upload matching an already-committed receipt → neutral "Already in your ledger" toast (not green/red), taps to the **pre-existing** tx, list does **not** refresh
- [ ] mixed batch (1 new + 1 dup) → two toasts, one of each
- [ ] `BatchDetail` shows the dedup item as `Duplicate`; `Batches` shows the "N deduped" chip

Dev server runs over HTTPS at `https://localhost:5174` (basic-ssl self-signed; bypass the cert interstitial), backend at `http://localhost:3000` via the app's `/api` proxy.

## Cleanup

Every test upload created during verification (transactions, postings, documents, ingests, batches) was hard-deleted; `SELECT count(*) FROM transactions` is back to the pre-test baseline of **11**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
