### PR TITLE
fix(receipt): render PDF originals via iframe + fallback link

### DIFF
--- a/src/components/ReceiptDetail.tsx
+++ b/src/components/ReceiptDetail.tsx
@@ -781,6 +781,7 @@ function OriginalReceiptCollapsible({
 }) {
   const [open, setOpen] = useState(false);
   const isEmail = kind === 'receipt_email';
+  const isPdf = kind === 'receipt_pdf' || kind === 'statement_pdf';
   const sender = (sourceMeta?.sender as string | undefined) ?? null;
   const subject = (sourceMeta?.subject as string | undefined) ?? null;
   const receivedAt = (sourceMeta?.received_at as string | undefined) ?? null;
@@ -826,6 +827,30 @@ function OriginalReceiptCollapsible({
                 className="block w-full rounded-[10px] border border-[var(--color-rule)] bg-white"
                 style={{ height: 520 }}
               />
+            </div>
+          ) : isPdf ? (
+            <div className="space-y-3">
+              {/* PDFs can't render in an <img> tag — embed the browser's
+                  built-in PDF viewer via an iframe pointing at the raw
+                  /content stream (served as application/pdf). No sandbox:
+                  this is our own same-origin file, and a strict sandbox
+                  blocks the viewer. The link below is the fallback for
+                  mobile browsers (iOS Safari) that won't render PDFs
+                  inline. */}
+              <iframe
+                src={documentContentUrl(documentId)}
+                title="Original PDF"
+                className="block w-full rounded-[10px] border border-[var(--color-rule)] bg-white"
+                style={{ height: 520 }}
+              />
+              <a
+                href={documentContentUrl(documentId)}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-block text-sm font-medium text-[var(--color-terracotta)] hover:underline"
+              >
+                Open PDF in new tab
+              </a>
             </div>
           ) : (
             <img


### PR DESCRIPTION
## What
PDF receipts (`receipt_pdf` / `statement_pdf`) rendered as a **blank** "Original receipt" panel. `OriginalReceiptCollapsible` only branched email vs image, so PDFs fell into the `<img>` path — browsers can't render `application/pdf` in an `<img>`, the load failed, and the `onError` handler hid the element.

## Change
Add a PDF branch to `OriginalReceiptCollapsible` (`src/components/ReceiptDetail.tsx`):
- `receipt_pdf` / `statement_pdf` → embed the browser's built-in PDF viewer via an `<iframe>` pointing at the `/content` stream (served as `application/pdf`). No `sandbox` — it's our own same-origin file, and a strict sandbox blocks the viewer.
- Always-visible **"Open PDF in new tab"** fallback link for mobile browsers (iOS Safari) that won't render PDFs inline.
- Images and emails are unchanged.

Backend already serves PDF bytes correctly (`GET /v1/documents/:id/content` → `Content-Type: application/pdf`); the document `kind` was already passed into the component, so no plumbing or backend changes were needed.

## Scope
Frontend only, single file, +25 lines (additive). `tsc --noEmit` passes.

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)