### PR TITLE
Make spending category/period surfaces drill into the Ledger

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -9,7 +9,7 @@ import {
 import type { Transaction, Category } from '../types';
 import { isProcessing as txIsProcessing } from '../lib/transactionStatus';
 import { cn } from '../lib/utils';
-import { receiptLink } from '../lib/navLinks';
+import { receiptLink, categoryLedgerLink } from '../lib/navLinks';
 import { CategoryIcon } from './CategoryIcon';
 import { MerchantIcon } from './MerchantIcon';
 import ProcessingCardList from './ProcessingCard';
@@ -104,7 +104,11 @@ export default function Dashboard({
       <SpentCard amount={totalSpent} count={totalCount} loading={loading} />
 
       <SectionTitle title="where it went" />
-      <CategoryGrid items={spendingByCategory} loading={loading} />
+      <CategoryGrid
+        items={spendingByCategory}
+        loading={loading}
+        range={{ from: monthRange.from, to: monthRange.to }}
+      />
 
       <SectionTitle
         title="recent"
@@ -248,7 +252,15 @@ function SectionTitle({
 
 /* ── Category grid (up to 7 spending categories) ─────────────── */
 
-function CategoryGrid({ items, loading }: { items: SpendingCategorySlice[]; loading: boolean }) {
+function CategoryGrid({
+  items,
+  loading,
+  range,
+}: {
+  items: SpendingCategorySlice[];
+  loading: boolean;
+  range: { from: string; to: string };
+}) {
   if (loading) {
     return (
       <div className="grid grid-cols-2 gap-3">
@@ -272,12 +284,16 @@ function CategoryGrid({ items, loading }: { items: SpendingCategorySlice[]; load
   return (
     <div className="grid grid-cols-2 gap-3">
       {items.map((c) => (
-        <div
+        <Link
           key={c.category}
+          {...categoryLedgerLink(c.category, range)}
           className={cn(
             'rounded-[18px] p-4 min-h-[100px]',
             'border border-[var(--color-rule)] bg-[var(--color-surface)]',
             'flex flex-col justify-between',
+            'cursor-pointer transition-shadow',
+            'hover:shadow-[0_4px_16px_-8px_rgba(45,37,32,0.12)]',
+            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-terracotta)]',
           )}
         >
           <CategoryIcon category={c.category} size={28} />
@@ -289,7 +305,7 @@ function CategoryGrid({ items, loading }: { items: SpendingCategorySlice[]; load
               ${Math.round(c.total).toLocaleString()}
             </p>
           </div>
-        </div>
+        </Link>
       ))}
     </div>
   );

--- a/src/components/MonthlyReview.tsx
+++ b/src/components/MonthlyReview.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { useNavigate } from '@tanstack/react-router';
+import { Link, useNavigate } from '@tanstack/react-router';
 import { ChevronLeft, ChevronRight, TrendingDown, TrendingUp, Loader2, PieChart as PieIcon, Receipt } from 'lucide-react';
 import {
   Bar,
@@ -24,6 +24,7 @@ import type { Category, Transaction } from '../types';
 import { cn } from '../lib/utils';
 import { CategoryIcon } from './CategoryIcon';
 import { MerchantIcon } from './MerchantIcon';
+import { categoryLedgerLink, receiptLink } from '../lib/navLinks';
 
 function formatMoney(minor: number, currency = 'USD'): string {
   return (minor / 100).toLocaleString(undefined, {
@@ -366,7 +367,11 @@ export default function MonthlyReview({ month }: { month?: string }) {
                     : null;
                 const isOver = deltaPct != null && deltaPct > 0;
                 return (
-                  <div key={cat.category} className="space-y-3">
+                  <Link
+                    key={cat.category}
+                    {...categoryLedgerLink(cat.category, { from: startOfMonth(now), to: endOfMonth(now) })}
+                    className="block space-y-3 rounded-lg -m-2 p-2 transition-colors hover:bg-surface-container-high/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+                  >
                     <div className="flex justify-between items-center mb-1">
                       <span className="text-sm font-bold text-white flex items-center gap-2">
                         <CategoryIcon category={cat.category} size={20} />
@@ -398,7 +403,7 @@ export default function MonthlyReview({ month }: { month?: string }) {
                         </span>
                       </div>
                     )}
-                  </div>
+                  </Link>
                 );
               })}
             </div>
@@ -477,32 +482,34 @@ function NotableTransactions({
       ) : (
         <ol className="space-y-3">
           {top.map((r, idx) => (
-            <li
-              key={r.id}
-              className="flex items-center gap-4 p-3 rounded-lg bg-surface-container-high/40 border border-outline-variant/10"
-            >
-              <span className="text-on-surface-variant font-bold w-6 text-center">
-                {idx + 1}
-              </span>
-              <MerchantIcon
-                brandId={r.merchantBrandId}
-                category={r.category}
-                transactionType={r.transactionType}
-                size={40}
-              />
-              <div className="flex-1 min-w-0">
-                <p className="text-sm font-medium text-white truncate">
-                  {r.description}
-                </p>
-                {r.placeCity && (
-                  <p className="text-xs text-on-surface-variant truncate">
-                    {r.placeCity}
+            <li key={r.id}>
+              <Link
+                {...receiptLink(r.id)}
+                className="flex items-center gap-4 p-3 rounded-lg bg-surface-container-high/40 border border-outline-variant/10 transition-colors hover:bg-surface-container-high/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+              >
+                <span className="text-on-surface-variant font-bold w-6 text-center">
+                  {idx + 1}
+                </span>
+                <MerchantIcon
+                  brandId={r.merchantBrandId}
+                  category={r.category}
+                  transactionType={r.transactionType}
+                  size={40}
+                />
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-medium text-white truncate">
+                    {r.description}
                   </p>
-                )}
-              </div>
-              <span className="text-base font-bold font-headline text-white tnum">
-                {formatMoney(Math.round(r._abs * 100), currency)}
-              </span>
+                  {r.placeCity && (
+                    <p className="text-xs text-on-surface-variant truncate">
+                      {r.placeCity}
+                    </p>
+                  )}
+                </div>
+                <span className="text-base font-bold font-headline text-white tnum">
+                  {formatMoney(Math.round(r._abs * 100), currency)}
+                </span>
+              </Link>
             </li>
           ))}
         </ol>

--- a/src/components/YearlyReview.tsx
+++ b/src/components/YearlyReview.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { useNavigate } from '@tanstack/react-router';
+import { Link, useNavigate } from '@tanstack/react-router';
 import { ChevronLeft, ChevronRight, TrendingUp, TrendingDown, Loader2, Landmark, PiggyBank, Wallet } from 'lucide-react';
 import {
   Bar,
@@ -25,6 +25,7 @@ import {
 import type { Category } from '../types';
 import { cn } from '../lib/utils';
 import { CategoryIcon } from './CategoryIcon';
+import { categoryLedgerLink, dateRangeLedgerLink } from '../lib/navLinks';
 
 function formatMoney(minor: number, currency = 'USD'): string {
   return (minor / 100).toLocaleString(undefined, {
@@ -179,6 +180,16 @@ export default function YearlyReview({ year }: { year?: number }) {
     {},
   );
 
+  // Per-quarter date ranges for the displayed year, used to drill the
+  // Quarterly Summary rows into a date-scoped Ledger.
+  const qy = now.getFullYear();
+  const quarterRange = {
+    Q1: { from: `${qy}-01-01`, to: `${qy}-03-31` },
+    Q2: { from: `${qy}-04-01`, to: `${qy}-06-30` },
+    Q3: { from: `${qy}-07-01`, to: `${qy}-09-30` },
+    Q4: { from: `${qy}-10-01`, to: `${qy}-12-31` },
+  } as const;
+
   return (
     <div className="space-y-12 animate-in fade-in duration-700">
       <section className="flex flex-col md:flex-row justify-between items-end gap-6 pb-4">
@@ -321,7 +332,11 @@ export default function YearlyReview({ year }: { year?: number }) {
           ) : (
             <div className="space-y-5 flex-1">
               {spendingCategoryRows.slice(0, 7).map((it) => (
-                <div key={it.category} className="space-y-2">
+                <Link
+                  key={it.category}
+                  {...categoryLedgerLink(it.category, { from: startOfYear(now), to: endOfYear(now) })}
+                  className="block space-y-2 rounded-lg -m-2 p-2 transition-colors hover:bg-surface-container-high/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+                >
                   <div className="flex justify-between text-sm">
                     <span className="text-on-surface font-medium flex items-center gap-2">
                       <CategoryIcon category={it.category} size={20} />
@@ -335,7 +350,7 @@ export default function YearlyReview({ year }: { year?: number }) {
                       style={{ width: `${(it.total_minor / maxCategoryMinor) * 100}%` }}
                     />
                   </div>
-                </div>
+                </Link>
               ))}
             </div>
           )}
@@ -362,7 +377,11 @@ export default function YearlyReview({ year }: { year?: number }) {
                 const data = quarterAgg[q] ?? { inflow: 0, outflow: 0, net: 0 };
                 const surplus = data.net >= 0;
                 return (
-                  <tr key={q} className="hover:bg-surface-container-high/20 transition-colors">
+                  <tr
+                    key={q}
+                    onClick={() => navigate(dateRangeLedgerLink(quarterRange[q]))}
+                    className="hover:bg-surface-container-high/20 transition-colors cursor-pointer"
+                  >
                     <td className="px-8 py-5 text-sm font-bold text-white">{q} {now.getFullYear()}</td>
                     <td className="px-8 py-5 text-sm text-right text-primary font-medium">
                       {formatMoney(data.inflow, currency)}

--- a/src/lib/navLinks.ts
+++ b/src/lib/navLinks.ts
@@ -8,9 +8,34 @@
  *
  * Spreading one of these onto <Link> gives it the correct `to` + `params`
  * (and TanStack type-checks the pair against the generated route tree).
+ *
+ * The Ledger builders below are the exception: `/transactions` keys its
+ * filter state off the URL *search* object (see transactionsFilterState.ts),
+ * not route params, so they carry `search` instead of `params`.
  */
+import type { Category } from '../types';
+
+type Range = { from: string; to: string };
+
 export const receiptLink = (receiptId: string) =>
   ({ to: '/receipt/$receiptId', params: { receiptId } }) as const;
+
+/** Ledger filtered to one category, optionally scoped to a date range so the
+ *  drilled-in list matches the period of the figure that was clicked. */
+export const categoryLedgerLink = (category: Category, range?: Range) =>
+  ({
+    to: '/transactions',
+    search: range
+      ? { datePreset: 'custom' as const, from: range.from, to: range.to, categories: [category] }
+      : { categories: [category] },
+  }) as const;
+
+/** Ledger scoped to a date range (no category filter). */
+export const dateRangeLedgerLink = (range: Range) =>
+  ({
+    to: '/transactions',
+    search: { datePreset: 'custom' as const, from: range.from, to: range.to },
+  }) as const;
 
 export const merchantLink = (merchantId: string) =>
   ({ to: '/merchant/$merchantId', params: { merchantId } }) as const;


### PR DESCRIPTION
## Summary
The Dashboard **where it went** category cards looked tappable but were inert `<div>`s. This makes them — and the same "looks clickable, isn't" pattern across the Monthly and Yearly reviews — drill into the Ledger, **pre-filtered by category and scoped to the period the figure represents**, so the drilled-in list reconciles with the number that was clicked.

Five surfaces, all routed through the Ledger's existing URL search contract (`datePreset=custom` + `from`/`to` + `categories[]`) — **no backend or routing change**:

| Surface | Was | Now → destination |
|---|---|---|
| Dashboard `CategoryGrid` cards | dead `<div>` | `<Link>` → Ledger, category + **current month** |
| MonthlyReview category rows | dead `<div>` | `<Link>` → Ledger, category + **selected month** |
| MonthlyReview "Notable this month" rows | dead `<li>` | `<Link {...receiptLink}>` → receipt detail (fixes inconsistency with the identical, already-linked Dashboard "recent" rows) |
| YearlyReview category rows | dead `<div>` | `<Link>` → Ledger, category + **displayed year** |
| YearlyReview quarterly table rows | dead `<tr>` (had `hover:` styling) | `onClick` navigate → Ledger, **that quarter's date range** (a `<tr>` can't be an `<a>`) |

New typed builders in `src/lib/navLinks.ts`: `categoryLedgerLink(category, range?)` and `dateRangeLedgerLink(range)`. Real `<Link>`/`<a href>` preserves Cmd-click / open-in-new-tab / hover preview.

## Acceptance criteria
- [x] Dashboard category card → Ledger filtered to that category **and** the current month; chips show `Date: 2026-05-01 → 2026-05-31`, `Category: Food & Drinks`.
- [x] MonthlyReview category row range follows the month picker (stepped to April → link became `from=2026-04-01&to=2026-04-30`).
- [x] MonthlyReview "Notable" row → `/receipt/:id`.
- [x] YearlyReview category row → Ledger filtered to category + full displayed year.
- [x] YearlyReview Q2 row → Ledger scoped to `2026-04-01 → 2026-06-30`, `Category: All`.
- [x] `tsc --noEmit` clean; zero console errors.

## Verification (browser evidence, per project rule)
Driven live in Chrome via `frontend-test-runner` against the local dev server with real data. All five surfaces confirmed to render real `<a href>` (or pointer-cursor `<tr>`) and land on the correct filtered Ledger / receipt. Screenshots captured: dashboard, food-filtered ledger, monthly review, yearly review, Q2-filtered ledger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
