### PR TITLE
feat(ledger): month-first browsing — month switcher, range-aware grouping, infinite scroll

### DIFF
--- a/src/components/Transactions.tsx
+++ b/src/components/Transactions.tsx
@@ -234,8 +234,13 @@ export default function Transactions({
     .filter((tx) => tx.amount < 0)
     .reduce((sum, tx) => sum + tx.amount, 0);
 
-  // Group by ISO week (Mon-anchored) for the fig.02 week banners.
-  const weeks = useMemo(() => groupByWeek(filteredTransactions), [filteredTransactions]);
+  // Group by period: ISO weeks for the recent stretch (this/last week),
+  // calendar months for everything older — keeps history calm instead of
+  // one "week of … · 1 entry" banner per sparse receipt.
+  const groups = useMemo(
+    () => groupByPeriod(filteredTransactions),
+    [filteredTransactions],
+  );
 
   const handleHardDeleteRequest = async (txnId: string) => {
     setRowError(null);
@@ -340,10 +345,10 @@ export default function Transactions({
         </EmptyState>
       ) : activeSort.sort === 'occurred_on' ? (
         <div className="space-y-7">
-          {weeks.map((wk) => (
-            <WeekGroup
-              key={wk.startIso}
-              week={wk}
+          {groups.map((g) => (
+            <PeriodGroup
+              key={g.startIso}
+              group={g}
               onSelect={(tx) => onSelectReceipt?.(tx.id)}
               onHardDelete={handleHardDeleteRequest}
               onUnreconcile={(id) => setUnreconcileTarget(id)}
@@ -487,22 +492,22 @@ function SearchSoft({
   );
 }
 
-/* ── Week group ───────────────────────────────────────────────── */
+/* ── Period group (recent weeks + older months) ───────────────── */
 
-interface WeekBucket {
+interface PeriodBucket {
   startIso: string;
   label: string;
   total: number;
   txs: Transaction[];
 }
 
-function WeekGroup({
-  week,
+function PeriodGroup({
+  group,
   onSelect,
   onHardDelete,
   onUnreconcile,
 }: {
-  week: WeekBucket;
+  group: PeriodBucket;
   onSelect: (tx: Transaction) => void;
   onHardDelete: (id: string) => void;
   onUnreconcile: (id: string) => void;
@@ -511,17 +516,17 @@ function WeekGroup({
     <section>
       <div className="flex items-baseline gap-3 mb-3">
         <span className="font-hand text-xl text-[var(--color-terracotta)] leading-none">
-          {week.label}
+          {group.label}
         </span>
         <span className="text-[11px] tracking-[0.12em] uppercase text-[var(--color-ink-muted)]">
-          {week.txs.length} {week.txs.length === 1 ? 'entry' : 'entries'}
+          {group.txs.length} {group.txs.length === 1 ? 'entry' : 'entries'}
         </span>
         <span className="ml-auto font-display italic text-base font-medium tnum">
-          ${Math.round(Math.abs(week.total)).toLocaleString()}
+          ${Math.round(Math.abs(group.total)).toLocaleString()}
         </span>
       </div>
       <ul className="space-y-2">
-        {week.txs.map((tx) => (
+        {group.txs.map((tx) => (
           <li key={tx.id}>
             <LedgerRow
               tx={tx}
@@ -758,15 +763,50 @@ function EmptyState({ children }: { children: React.ReactNode }) {
 
 /* ── Helpers ──────────────────────────────────────────────────── */
 
-function groupByWeek(txs: Transaction[]): WeekBucket[] {
-  const buckets = new Map<string, WeekBucket>();
+/**
+ * Group transactions for the date-sorted ledger. The current and previous
+ * ISO weeks keep their granular "this week" / "last week" banners; everything
+ * older collapses into calendar-month buckets ("April 2026", "December 2025").
+ * This avoids the old failure mode where each sparse historical receipt got
+ * its own "week of … · 1 entry" header, and the month labels always carry the
+ * year so multi-year history reads in order. All bucket keys are sortable
+ * YYYY-MM-DD strings, so the single descending sort below stays monotonic
+ * across the week→month boundary.
+ */
+function groupByPeriod(txs: Transaction[]): PeriodBucket[] {
+  const today = new Date();
+  const thisWeek = isoWeekStart(toIso(today));
+  const lastWeek = (() => {
+    const d = new Date(today);
+    d.setDate(d.getDate() - 7);
+    return isoWeekStart(toIso(d));
+  })();
+
+  const buckets = new Map<string, PeriodBucket>();
   for (const tx of txs) {
-    const start = isoWeekStart(tx.date);
-    if (!start) continue;
-    let bucket = buckets.get(start);
+    const week = isoWeekStart(tx.date);
+    if (!week) continue;
+
+    let key: string;
+    let label: string;
+    if (week === thisWeek) {
+      key = week;
+      label = 'this week';
+    } else if (week === lastWeek) {
+      key = week;
+      label = 'last week';
+    } else {
+      // First of the transaction's own month (not the week's Monday, which
+      // could land in the prior month).
+      const [y, m] = tx.date.split('-');
+      key = `${y}-${m}-01`;
+      label = monthLabel(key);
+    }
+
+    let bucket = buckets.get(key);
     if (!bucket) {
-      bucket = { startIso: start, label: weekLabel(start), total: 0, txs: [] };
-      buckets.set(start, bucket);
+      bucket = { startIso: key, label, total: 0, txs: [] };
+      buckets.set(key, bucket);
     }
     bucket.txs.push(tx);
     bucket.total += tx.amount;
@@ -790,23 +830,11 @@ function isoWeekStart(isoDate: string): string | null {
   return `${yy}-${mm}-${dd}`;
 }
 
-function weekLabel(startIso: string): string {
-  const today = new Date();
-  const thisWeek = isoWeekStart(toIso(today));
-  if (thisWeek === startIso) return 'this week';
-
-  const lastWeek = (() => {
-    const d = new Date(today);
-    d.setDate(d.getDate() - 7);
-    return isoWeekStart(toIso(d));
-  })();
-  if (lastWeek === startIso) return 'last week';
-
-  // "Week of May 5" — pulled from the Monday date.
-  const [y, m, d] = startIso.split('-').map(Number);
-  const dt = new Date(y, m - 1, d);
-  const monthShort = dt.toLocaleString('en-US', { month: 'short' });
-  return `week of ${monthShort} ${dt.getDate()}`;
+/** "April 2026" — full month + year, from a YYYY-MM-01 key. */
+function monthLabel(startIso: string): string {
+  const [y, m] = startIso.split('-').map(Number);
+  const dt = new Date(y, m - 1, 1);
+  return dt.toLocaleString('en-US', { month: 'long', year: 'numeric' });
 }
 
 function toIso(d: Date): string {

--- a/src/components/Transactions.tsx
+++ b/src/components/Transactions.tsx
@@ -1,8 +1,8 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Link } from '@tanstack/react-router';
 import { receiptLink } from '../lib/navLinks';
 import {
-  fetchTransactions,
+  fetchTransactionsPage,
   extractProblemMessage,
   getDocument,
   getTransaction,
@@ -76,8 +76,15 @@ export default function Transactions({
 }: TransactionsProps) {
   const [transactions, setTransactions] = useState<Transaction[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [refreshKey, setRefreshKey] = useState(0);
+  // Guards loadMore against double-firing while a page request is in flight
+  // (the IntersectionObserver can fire repeatedly as the sentinel stays in
+  // view). A ref, not state, so it's synchronous.
+  const loadingMoreRef = useRef(false);
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
 
   const [hardDeleteTarget, setHardDeleteTarget] = useState<{ id: string; etag: string } | null>(null);
   const [unreconcileTarget, setUnreconcileTarget] = useState<string | null>(null);
@@ -140,8 +147,12 @@ export default function Transactions({
   const dateRange = useMemo(() => effectiveDateRange(filters), [filters]);
   const hasActiveFilter = isFilterActive(filters, searchQuery);
 
-  useEffect(() => {
-    setLoading(true);
+  // The base query (everything except the cursor), shared by the first-page
+  // fetch and loadMore so both page the same result set. Week-grouped
+  // rendering only applies to the occurred_on sort; other sorts fall back to
+  // a flat list (handled in the render path).
+  const PAGE_SIZE = 50;
+  const queryArgs = useMemo(() => {
     const dollarsToMinor = (s: string): number | undefined => {
       const trimmed = s.trim();
       if (!trimmed) return undefined;
@@ -149,8 +160,8 @@ export default function Transactions({
       if (!Number.isFinite(n)) return undefined;
       return Math.round(n * 100);
     };
-    fetchTransactions({
-      limit: 50,
+    return {
+      limit: PAGE_SIZE,
       has_document: true,
       q: debouncedSearch.trim() || undefined,
       status: filters.status,
@@ -159,20 +170,10 @@ export default function Transactions({
       amount_max_minor: dollarsToMinor(debouncedAmountMax),
       from: dateRange.occurred_from,
       to: dateRange.occurred_to,
-      // Week-grouped rendering below only makes sense when rows are
-      // sorted by `occurred_on`; for amount / created_at sorts the
-      // render path drops the banners and shows a flat list.
       sort: activeSort.sort,
       order: activeSort.order,
-    })
-      .then((rows) => {
-        setTransactions(rows);
-        setError(null);
-      })
-      .catch((e: unknown) => setError(extractProblemMessage(e)))
-      .finally(() => setLoading(false));
+    };
   }, [
-    refreshKey,
     debouncedSearch,
     debouncedPayee,
     debouncedAmountMin,
@@ -183,6 +184,62 @@ export default function Transactions({
     activeSort.sort,
     activeSort.order,
   ]);
+
+  // First page: reset the list whenever the query changes. `cancelled`
+  // guards against a slow page-1 request resolving after the filters moved on.
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    loadingMoreRef.current = false;
+    fetchTransactionsPage(queryArgs)
+      .then(({ items, nextCursor: nc }) => {
+        if (cancelled) return;
+        setTransactions(items);
+        setNextCursor(nc);
+        setError(null);
+      })
+      .catch((e: unknown) => {
+        if (!cancelled) setError(extractProblemMessage(e));
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [queryArgs, refreshKey]);
+
+  // Load the next page and append. No-ops when there's nothing more or a
+  // request is already in flight.
+  const loadMore = useCallback(() => {
+    if (loadingMoreRef.current || !nextCursor) return;
+    loadingMoreRef.current = true;
+    setLoadingMore(true);
+    fetchTransactionsPage({ ...queryArgs, cursor: nextCursor })
+      .then(({ items, nextCursor: nc }) => {
+        setTransactions((prev) => [...prev, ...items]);
+        setNextCursor(nc);
+      })
+      .catch((e: unknown) => setError(extractProblemMessage(e)))
+      .finally(() => {
+        loadingMoreRef.current = false;
+        setLoadingMore(false);
+      });
+  }, [queryArgs, nextCursor]);
+
+  // Auto-load the next page when the bottom sentinel scrolls into view.
+  useEffect(() => {
+    const el = sentinelRef.current;
+    if (!el || !nextCursor) return;
+    const io = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting) loadMore();
+      },
+      { rootMargin: '300px' },
+    );
+    io.observe(el);
+    return () => io.disconnect();
+  }, [loadMore, nextCursor]);
 
   useEffect(() => {
     if (!showDeleted) {
@@ -380,6 +437,18 @@ export default function Transactions({
             </li>
           ))}
         </ul>
+      )}
+
+      {/* Infinite-scroll sentinel: when it scrolls into view (or near it,
+          per rootMargin) the next page loads and appends. Only present while
+          a next page exists. */}
+      {!loading && nextCursor && (
+        <div ref={sentinelRef} aria-hidden="true" className="h-1" />
+      )}
+      {loadingMore && (
+        <p className="py-3 text-center font-hand text-lg text-[var(--color-ink-muted)]">
+          loading more…
+        </p>
       )}
 
       <ConfirmActionDialog

--- a/src/components/Transactions.tsx
+++ b/src/components/Transactions.tsx
@@ -26,7 +26,9 @@ import ProcessingCardList from './ProcessingCard';
 import type { ProcessingItem } from './useProcessingJobs';
 import TransactionsFilters from './TransactionsFilters';
 import {
+  DATE_PRESET_LABEL,
   DEFAULT_FILTERS,
+  currentMonthYM,
   effectiveDateRange,
   filterStateToSearch,
   isFilterActive,
@@ -35,6 +37,7 @@ import {
   type FilterState,
   type TransactionsSearch,
 } from '../lib/transactionsFilterState';
+import { addMonths, monthLabelLong } from '../lib/month';
 
 interface TransactionsProps {
   onSelectReceipt?: (receiptId: string) => void;
@@ -238,7 +241,7 @@ export default function Transactions({
   // calendar months for everything older — keeps history calm instead of
   // one "week of … · 1 entry" banner per sparse receipt.
   const groups = useMemo(
-    () => groupByPeriod(filteredTransactions),
+    () => groupTransactions(filteredTransactions),
     [filteredTransactions],
   );
 
@@ -277,7 +280,14 @@ export default function Transactions({
 
   return (
     <div className="space-y-6">
-      <Header total={Math.abs(totalExpenses)} count={filteredTransactions.length} />
+      <Header
+        total={Math.abs(totalExpenses)}
+        count={filteredTransactions.length}
+        filters={filters}
+        onMonthChange={(ym) =>
+          setFilters({ ...filters, datePreset: 'month', month: ym })
+        }
+      />
 
       <SearchSoft
         value={searchInput}
@@ -338,9 +348,11 @@ export default function Transactions({
       ) : filteredTransactions.length === 0 ? (
         <EmptyState>
           <p className="font-display italic text-[var(--color-ink-muted)] text-lg">
-            {hasActiveFilter
-              ? 'No entries match the current filters.'
-              : 'No entries yet — capture your first receipt.'}
+            {filters.datePreset === 'month'
+              ? `Nothing in ${monthLabelLong(filters.month || currentMonthYM())}.`
+              : hasActiveFilter
+                ? 'No entries match the current filters.'
+                : 'No entries yet — capture your first receipt.'}
           </p>
         </EmptyState>
       ) : activeSort.sort === 'occurred_on' ? (
@@ -406,26 +418,37 @@ export default function Transactions({
 
 /* ── Header ───────────────────────────────────────────────────── */
 
-function Header({ total, count }: { total: number; count: number }) {
-  const now = new Date();
-  const monthShort = now.toLocaleString('en-US', { month: 'long' });
-  const weekIn = Math.max(1, Math.ceil(now.getDate() / 7));
-  const weekIn_text =
-    weekIn === 1 ? 'first week in' :
-    weekIn === 2 ? 'two weeks in' :
-    weekIn === 3 ? 'three weeks in' :
-    'a full month';
+function Header({
+  total,
+  count,
+  filters,
+  onMonthChange,
+}: {
+  total: number;
+  count: number;
+  filters: FilterState;
+  onMonthChange: (ym: string) => void;
+}) {
   return (
     <div className="flex items-start justify-between gap-4">
-      <div>
+      <div className="min-w-0">
         <h1 className="font-display italic font-medium text-4xl leading-none tracking-tight">
           Ledger
         </h1>
-        <p className="mt-2 font-hand text-2xl text-[var(--color-terracotta)] leading-none">
-          {monthShort}, {weekIn_text}
-        </p>
+        {filters.datePreset === 'month' ? (
+          <MonthSwitcher
+            ym={filters.month || currentMonthYM()}
+            onChange={onMonthChange}
+          />
+        ) : (
+          <p className="mt-2 font-hand text-2xl text-[var(--color-terracotta)] leading-none">
+            {filters.datePreset === 'custom'
+              ? 'custom range'
+              : DATE_PRESET_LABEL[filters.datePreset].toLowerCase()}
+          </p>
+        )}
       </div>
-      <div className="text-right">
+      <div className="text-right flex-shrink-0">
         <p className="text-[11px] font-medium tracking-[0.18em] uppercase text-[var(--color-ink-muted)]">
           TOTAL
         </p>
@@ -436,6 +459,49 @@ function Header({ total, count }: { total: number; count: number }) {
           {count} {count === 1 ? 'entry' : 'entries'}
         </p>
       </div>
+    </div>
+  );
+}
+
+/**
+ * ‹ May 2026 › month stepper — the Ledger's primary navigation. "Next" is
+ * capped at the current month (no browsing into empty future months). The
+ * month name keeps the handwritten flourish so the header still feels warm.
+ */
+function MonthSwitcher({
+  ym,
+  onChange,
+}: {
+  ym: string;
+  onChange: (ym: string) => void;
+}) {
+  const atCurrent = ym >= currentMonthYM();
+  const arrow =
+    'flex h-7 w-7 items-center justify-center rounded-full text-[var(--color-ink-muted)] ' +
+    'hover:bg-[var(--color-paper-deep)] hover:text-[var(--color-ink)] transition-colors ' +
+    'disabled:opacity-30 disabled:hover:bg-transparent disabled:hover:text-[var(--color-ink-muted)]';
+  return (
+    <div className="mt-1.5 flex items-center gap-1.5">
+      <button
+        type="button"
+        aria-label="Previous month"
+        className={arrow}
+        onClick={() => onChange(addMonths(ym, -1))}
+      >
+        ‹
+      </button>
+      <span className="font-hand text-2xl text-[var(--color-terracotta)] leading-none min-w-[7.5rem] text-center">
+        {monthLabelLong(ym)}
+      </span>
+      <button
+        type="button"
+        aria-label="Next month"
+        className={arrow}
+        disabled={atCurrent}
+        onClick={() => onChange(addMonths(ym, 1))}
+      >
+        ›
+      </button>
     </div>
   );
 }
@@ -514,7 +580,10 @@ function PeriodGroup({
 }) {
   return (
     <section>
-      <div className="flex items-baseline gap-3 mb-3">
+      {/* Sticky band: while a group is in view its label + running total
+          pin to the top so a long month never loses context. The paper
+          background lets rows scroll cleanly underneath. */}
+      <div className="sticky top-0 z-10 flex items-baseline gap-3 mb-3 bg-[var(--color-paper)] pt-2 pb-2">
         <span className="font-hand text-xl text-[var(--color-terracotta)] leading-none">
           {group.label}
         </span>
@@ -764,16 +833,60 @@ function EmptyState({ children }: { children: React.ReactNode }) {
 /* ── Helpers ──────────────────────────────────────────────────── */
 
 /**
- * Group transactions for the date-sorted ledger. The current and previous
- * ISO weeks keep their granular "this week" / "last week" banners; everything
- * older collapses into calendar-month buckets ("April 2026", "December 2025").
- * This avoids the old failure mode where each sparse historical receipt got
- * its own "week of … · 1 entry" header, and the month labels always carry the
- * year so multi-year history reads in order. All bucket keys are sortable
- * YYYY-MM-DD strings, so the single descending sort below stays monotonic
- * across the week→month boundary.
+ * Pick the grouping that fits the visible range. A single calendar month
+ * (the default month-scoped browse, or any one-month filter) groups by ISO
+ * week — there are at most ~5 banners, so weekly granularity reads well.
+ * Anything spanning multiple months (all-time, a wide custom range) groups
+ * by month instead, so sparse history stays calm instead of emitting one
+ * "week of … · 1 entry" banner per receipt.
  */
-function groupByPeriod(txs: Transaction[]): PeriodBucket[] {
+function groupTransactions(txs: Transaction[]): PeriodBucket[] {
+  const months = new Set(txs.map((tx) => tx.date.slice(0, 7)));
+  return months.size <= 1 ? groupByWeek(txs) : groupByMonth(txs);
+}
+
+/** Week buckets with relative labels ("this week" / "last week" / "week of
+ *  May 5"). Used when the view is a single month. */
+function groupByWeek(txs: Transaction[]): PeriodBucket[] {
+  const buckets = new Map<string, PeriodBucket>();
+  for (const tx of txs) {
+    const start = isoWeekStart(tx.date);
+    if (!start) continue;
+    let bucket = buckets.get(start);
+    if (!bucket) {
+      bucket = { startIso: start, label: weekLabel(start), total: 0, txs: [] };
+      buckets.set(start, bucket);
+    }
+    bucket.txs.push(tx);
+    bucket.total += tx.amount;
+  }
+  return [...buckets.values()].sort((a, b) => (a.startIso < b.startIso ? 1 : -1));
+}
+
+/** Relative week label from a Monday ISO date. Falls back to "week of May 5"
+ *  for weeks that aren't the current or previous one. */
+function weekLabel(startIso: string): string {
+  const today = new Date();
+  if (isoWeekStart(toIso(today)) === startIso) return 'this week';
+  const lastWeek = new Date(today);
+  lastWeek.setDate(lastWeek.getDate() - 7);
+  if (isoWeekStart(toIso(lastWeek)) === startIso) return 'last week';
+  const [y, m, d] = startIso.split('-').map(Number);
+  const dt = new Date(y, m - 1, d);
+  return `week of ${dt.toLocaleString('en-US', { month: 'short' })} ${dt.getDate()}`;
+}
+
+/**
+ * Month buckets for multi-month views (all-time, wide custom ranges). The
+ * current and previous ISO weeks keep their granular "this week" / "last
+ * week" banners; everything older collapses into calendar-month buckets
+ * ("April 2026", "December 2025"). This avoids the old failure mode where
+ * each sparse historical receipt got its own "week of … · 1 entry" header,
+ * and the month labels always carry the year so multi-year history reads in
+ * order. All bucket keys are sortable YYYY-MM-DD strings, so the single
+ * descending sort below stays monotonic across the week→month boundary.
+ */
+function groupByMonth(txs: Transaction[]): PeriodBucket[] {
   const today = new Date();
   const thisWeek = isoWeekStart(toIso(today));
   const lastWeek = (() => {

--- a/src/components/TransactionsFilters.tsx
+++ b/src/components/TransactionsFilters.tsx
@@ -5,10 +5,12 @@ import {
   DEFAULT_SORT_ID,
   SORT_OPTIONS,
   STATUS_OPTIONS,
+  currentMonthYM,
   resolveSort,
   type DatePreset,
   type FilterState,
 } from '../lib/transactionsFilterState';
+import { monthLabelLong } from '../lib/month';
 import {
   CATEGORIES,
   TRANSACTION_TYPES,
@@ -72,11 +74,13 @@ export default function TransactionsFilters({
   const activeSort = resolveSort(sortId);
 
   const dateLabel =
-    filters.datePreset === 'custom'
-      ? filters.customFrom || filters.customTo
-        ? `${filters.customFrom || '…'} → ${filters.customTo || '…'}`
-        : 'Custom range'
-      : DATE_PRESET_LABEL[filters.datePreset];
+    filters.datePreset === 'month'
+      ? monthLabelLong(filters.month || currentMonthYM())
+      : filters.datePreset === 'custom'
+        ? filters.customFrom || filters.customTo
+          ? `${filters.customFrom || '…'} → ${filters.customTo || '…'}`
+          : 'Custom range'
+        : DATE_PRESET_LABEL[filters.datePreset];
 
   const categoryLabel =
     filters.categories.length === 0
@@ -122,7 +126,7 @@ export default function TransactionsFilters({
         <div ref={dateRef} className="relative">
           <Chip
             data-testid="filter-date"
-            active={filters.datePreset !== 'all'}
+            active={filters.datePreset !== 'month'}
             onClick={() => setOpenPopover((p) => (p === 'date' ? null : 'date'))}
           >
             <span className="text-[var(--color-ink-muted)] mr-1">Date:</span>
@@ -136,7 +140,14 @@ export default function TransactionsFilters({
                   key={preset}
                   data-testid={`filter-date-${preset}`}
                   onClick={() => {
-                    onChange({ ...filters, datePreset: preset });
+                    // Picking "This month" always returns to the current
+                    // month (month: ''), regardless of where the switcher
+                    // had stepped to.
+                    onChange(
+                      preset === 'month'
+                        ? { ...filters, datePreset: 'month', month: '' }
+                        : { ...filters, datePreset: preset },
+                    );
                     if (preset !== 'custom') setOpenPopover(null);
                   }}
                   className={cn(

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -620,10 +620,21 @@ export interface FetchTransactionsOpts {
   amount_max_minor?: number;
   sort?: 'occurred_on' | 'amount' | 'created_at';
   order?: 'asc' | 'desc';
+  // Opaque cursor from a previous page's nextCursor — for infinite scroll.
+  cursor?: string;
 }
 
 export async function fetchTransactions(opts?: FetchTransactionsOpts): Promise<Transaction[]> {
-  const { items } = await listTransactions({
+  const { items } = await fetchTransactionsPage(opts);
+  return items;
+}
+
+/** Like `fetchTransactions` but also returns the pagination cursor, so
+ *  callers can keep loading the next page (infinite scroll). */
+export async function fetchTransactionsPage(
+  opts?: FetchTransactionsOpts,
+): Promise<{ items: Transaction[]; nextCursor: string | null }> {
+  const { items, nextCursor } = await listTransactions({
     occurred_from: opts?.from,
     occurred_to: opts?.to,
     limit: opts?.limit,
@@ -633,10 +644,11 @@ export async function fetchTransactions(opts?: FetchTransactionsOpts): Promise<T
     payee_contains: opts?.payee_contains,
     amount_min_minor: opts?.amount_min_minor,
     amount_max_minor: opts?.amount_max_minor,
+    cursor: opts?.cursor,
     sort: opts?.sort ?? 'created_at',
     order: opts?.order ?? 'desc',
   });
-  return items.map(mapTransaction);
+  return { items: items.map(mapTransaction), nextCursor };
 }
 
 export async function getTransaction(id: string): Promise<WithETag<BackendTransaction>> {

--- a/src/lib/month.ts
+++ b/src/lib/month.ts
@@ -1,0 +1,21 @@
+/**
+ * Calendar-month helpers shared by the Ledger's month switcher, the date
+ * filter chip, and the period grouping. A "ym" is a `YYYY-MM` string; an
+ * empty ym is treated by callers as "the current month".
+ */
+
+/** "May 2026" from a YYYY-MM string. */
+export function monthLabelLong(ym: string): string {
+  const [y, m] = ym.split('-').map(Number);
+  return new Date(y, m - 1, 1).toLocaleString('en-US', {
+    month: 'long',
+    year: 'numeric',
+  });
+}
+
+/** Step a YYYY-MM by `delta` months (negative = earlier), returning YYYY-MM. */
+export function addMonths(ym: string, delta: number): string {
+  const [y, m] = ym.split('-').map(Number);
+  const d = new Date(y, m - 1 + delta, 1);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
+}

--- a/src/lib/transactionsFilterState.ts
+++ b/src/lib/transactionsFilterState.ts
@@ -7,10 +7,14 @@ import {
   type TransactionType,
 } from '../types';
 
-export type DatePreset = 'all' | 'last_30d' | 'last_90d' | 'this_year' | 'custom';
+export type DatePreset = 'month' | 'all' | 'last_30d' | 'last_90d' | 'this_year' | 'custom';
 
 export interface FilterState {
   datePreset: DatePreset;
+  // Only consulted when datePreset === 'month'. YYYY-MM; '' means the
+  // current calendar month (resolved against `now` in effectiveDateRange).
+  // This is the Ledger's default browse mode — see the month switcher.
+  month: string;
   // Only consulted when datePreset === 'custom'.
   customFrom: string;
   customTo: string;
@@ -27,7 +31,8 @@ export interface FilterState {
 }
 
 export const DEFAULT_FILTERS: FilterState = {
-  datePreset: 'all',
+  datePreset: 'month',
+  month: '',
   customFrom: '',
   customTo: '',
   categories: [],
@@ -39,6 +44,7 @@ export const DEFAULT_FILTERS: FilterState = {
 };
 
 export const DATE_PRESET_LABEL: Record<DatePreset, string> = {
+  month: 'This month',
   all: 'All time',
   last_30d: 'Last 30 days',
   last_90d: 'Last 90 days',
@@ -88,6 +94,11 @@ export function resolveSort(id: string): SortOption {
   return SORT_OPTIONS.find((o) => o.id === id) ?? SORT_OPTIONS[0];
 }
 
+/** Current calendar month as YYYY-MM, against a reference date. */
+export function currentMonthYM(now: Date = new Date()): string {
+  return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
+}
+
 /** Compute the ISO date range that should be sent to the backend
  *  for a given filter state. Returns undefined values for "no bound". */
 export function effectiveDateRange(
@@ -96,6 +107,16 @@ export function effectiveDateRange(
 ): { occurred_from?: string; occurred_to?: string } {
   const ymd = (d: Date) => d.toISOString().slice(0, 10);
   switch (filters.datePreset) {
+    case 'month': {
+      // Default browse mode: a single calendar month. '' = current month.
+      const ym = filters.month || currentMonthYM(now);
+      const [y, m] = ym.split('-').map(Number);
+      const lastDay = new Date(y, m, 0).getDate(); // day 0 of next month
+      return {
+        occurred_from: `${ym}-01`,
+        occurred_to: `${ym}-${String(lastDay).padStart(2, '0')}`,
+      };
+    }
     case 'all':
       return {};
     case 'last_30d': {
@@ -121,7 +142,8 @@ export function effectiveDateRange(
 
 export function isFilterActive(filters: FilterState, q: string): boolean {
   return (
-    filters.datePreset !== 'all' ||
+    // Month mode (any month) is the default browse mode, not a "filter".
+    filters.datePreset !== 'month' ||
     filters.categories.length > 0 ||
     filters.transactionTypes.length > 0 ||
     filters.status !== undefined ||
@@ -145,7 +167,7 @@ export function isFilterActive(filters: FilterState, q: string): boolean {
 // whose value differs from its default — TanStack drops `undefined`
 // keys from the querystring entirely.
 
-const datePresetSchema = z.enum(['all', 'last_30d', 'last_90d', 'this_year', 'custom']);
+const datePresetSchema = z.enum(['month', 'all', 'last_30d', 'last_90d', 'this_year', 'custom']);
 const statusSchema = z.enum(['draft', 'posted', 'voided', 'reconciled', 'error']);
 const sortIdSchema = z.enum(SORT_OPTIONS.map((o) => o.id) as [string, ...string[]]);
 
@@ -154,8 +176,9 @@ const sortIdSchema = z.enum(SORT_OPTIONS.map((o) => o.id) as [string, ...string[
 // hand-mangled URL) resolves to the default instead of throwing. This
 // is what lets `validateSearch` never reject a URL.
 export const transactionsSearchSchema = z.object({
-  // Date preset + (custom-only) bounds.
+  // Date preset + (month-only) month + (custom-only) bounds.
   datePreset: datePresetSchema.optional().catch(DEFAULT_FILTERS.datePreset),
+  month: z.string().optional().catch(''),
   from: z.string().optional().catch(''),
   to: z.string().optional().catch(''),
   // Multi-selects. A malformed value (or unknown member) falls to [].
@@ -184,6 +207,7 @@ export function searchToFilterState(search: TransactionsSearch): {
 } {
   const filters: FilterState = {
     datePreset: search.datePreset ?? DEFAULT_FILTERS.datePreset,
+    month: search.month ?? DEFAULT_FILTERS.month,
     customFrom: search.from ?? DEFAULT_FILTERS.customFrom,
     customTo: search.to ?? DEFAULT_FILTERS.customTo,
     categories: search.categories ?? DEFAULT_FILTERS.categories,
@@ -212,6 +236,9 @@ export function filterStateToSearch(args: {
   const { filters, sortId, q, showDeleted } = args;
   const out: TransactionsSearch = {};
   if (filters.datePreset !== DEFAULT_FILTERS.datePreset) out.datePreset = filters.datePreset;
+  // A non-current month is the only month worth putting in the URL — the
+  // default ('' = current month) stays implicit so the bare URL is clean.
+  if (filters.datePreset === 'month' && filters.month) out.month = filters.month;
   // Custom bounds are only meaningful for the 'custom' preset.
   if (filters.datePreset === 'custom') {
     if (filters.customFrom) out.from = filters.customFrom;


### PR DESCRIPTION
Reworks how the Ledger is browsed, in response to live review: the old all-time list looked "怪怪的" (broke down on sparse history) and, more fundamentally, **all-time isn't a real browse target — nobody scrolls years of receipts; you browse by month.**

Three commits, each verified live in-browser before the next:

### 1. `fix(ledger)` — collapse sparse history into month groups
The date-sorted list grouped every txn by ISO week with no age floor, so sparse history became one `week of … · 1 entry` banner per receipt, and labels dropped the year (read as scrambled). Now: recent weeks keep `this week`/`last week`; older entries collapse into month buckets (`April 2026`) that always carry the year.

### 2. `feat(ledger)` — month-scoped default + month switcher
- Ledger opens on the **current month** (matches the "May, a full month" header intent); a ‹ prev / next › switcher steps months (next capped at current).
- New `'month'` date preset + `month` (YYYY-MM, `''` = current) in `FilterState`; it's the default and the `isFilterActive` baseline. URL carries a non-current month as `?month=YYYY-MM`.
- All time / last-90d / this-year / custom move into the Date chip ("This month" returns to default).
- Grouping is **range-aware**: a single month groups by ISO week; multi-month views (all-time, wide custom) use the month-bucket grouping from #1. Shared helpers in `lib/month.ts`.
- Empty month reads `Nothing in <Month Year>.`

### 3. `feat(ledger)` — infinite scroll via cursor pagination
Wires the backend's existing `next_cursor` into the list so a long (usually filtered) month loads progressively. `fetchTransactionsPage()` returns `{ items, nextCursor }`; an IntersectionObserver sentinel appends pages (guarded against double-fire; page-1 effect is cancellable). Sticky section headers keep the month/week label + running total pinned while scrolling a long month.

## Acceptance criteria
- [x] Default view is the current month with a working ‹ prev / next › switcher (next disabled at current month).
- [x] TOTAL / count and grouping are scoped to the selected month.
- [x] Single month → week grouping; all-time / wide range → month-bucket grouping, descending, year shown.
- [x] Date chip mirrors the month and isn't flagged "active" in month mode; "This month" resets to current.
- [x] Empty month shows `Nothing in <Month Year>.`
- [x] Infinite scroll pages + concatenates + terminates (verified at PAGE_SIZE=3 over 11 rows / 4 pages; restored to 50).
- [x] `tsc --noEmit` clean.

## Verification
Driven live in Chrome at `/transactions`: May default ($67·5) → ‹ April ($8·2) → next arrow steps back to May (then disabled) → empty March shows new copy → all-time pages through every entry to the oldest with month grouping intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)