### PR TITLE
feat(data-layer): mount QueryClientProvider (TanStack Query infra) [1/5]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@google/genai": "^1.29.0",
         "@tailwindcss/vite": "^4.1.14",
+        "@tanstack/react-query": "^5.100.14",
         "@tanstack/react-router": "^1.170.10",
         "@vis.gl/react-google-maps": "^1.8.3",
         "@vitejs/plugin-react": "^5.0.4",
@@ -28,6 +29,7 @@
         "zod": "^4.4.3"
       },
       "devDependencies": {
+        "@tanstack/react-query-devtools": "^5.100.14",
         "@tanstack/router-plugin": "^1.168.13",
         "@types/express": "^4.17.21",
         "@types/node": "^22.14.0",
@@ -1859,6 +1861,61 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.100.14",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.100.14.tgz",
+      "integrity": "sha512-5X41dGpxgeaHISCRW2oYwcSycZeULZzAunaudXT9ov1KOTj9xwt0CH6hbwqP1/z74ZWF7rYFnDpyYH07XFcZew==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-devtools": {
+      "version": "5.100.14",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.100.14.tgz",
+      "integrity": "sha512-g96SmSSQecYTYcyuAMRXr895GplJv01UGt7qttQWPOUyZ5EGz5tbRc589bMc2m5BsPFD6O0PCEAHdbDYNP6UBw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.100.14",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.100.14.tgz",
+      "integrity": "sha512-oOr6aRdSFEwWhzxEkD/9ZcItM3+LjBSkeVmadWKwUssAHTsqd/7bOjWrX4AbvEkoEhgAxzN0Xk6H/aYzXiYBAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.100.14"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "5.100.14",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.100.14.tgz",
+      "integrity": "sha512-JkP5VDgKOw3t/QSA1OABRHEqx8BuNs5MfvZRooNqdvN57SzTuGq3fKR1a2IH5rqa5HDLUm+FOXUEnB9ueHiLzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-devtools": "5.100.14"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.100.14",
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@tanstack/react-router": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@google/genai": "^1.29.0",
     "@tailwindcss/vite": "^4.1.14",
+    "@tanstack/react-query": "^5.100.14",
     "@tanstack/react-router": "^1.170.10",
     "@vis.gl/react-google-maps": "^1.8.3",
     "@vitejs/plugin-react": "^5.0.4",
@@ -33,6 +34,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@tanstack/react-query-devtools": "^5.100.14",
     "@tanstack/router-plugin": "^1.168.13",
     "@types/express": "^4.17.21",
     "@types/node": "^22.14.0",

--- a/src/lib/queryClient.ts
+++ b/src/lib/queryClient.ts
@@ -1,0 +1,32 @@
+import { QueryClient } from '@tanstack/react-query';
+
+/**
+ * Single app-wide QueryClient.
+ *
+ * Why a module singleton (not `new QueryClient()` inline in main.tsx): the
+ * cache must outlive any component, and several non-render call sites need to
+ * invalidate it — the `appContext` refresh bridge, mutation handlers in
+ * ReceiptDetail / add / useProcessingJobs. Components reach it via
+ * `useQueryClient()`; this export is the same instance the provider holds.
+ *
+ * Defaults chosen to preserve the app's pre-Query behavior:
+ * - `staleTime: 30s` — list/detail data is considered fresh for half a minute,
+ *   so drilling into a receipt and coming straight back doesn't refetch. This
+ *   is the property that lets the Ledger keep its loaded pages on Back (#89).
+ * - `gcTime: 5min` — cached pages survive a brief unmount (drill-in → Back)
+ *   but don't accumulate forever.
+ * - `refetchOnWindowFocus: false` — the legacy useEffect screens never
+ *   refetched on focus; keep that to avoid surprise reloads.
+ * - `retry: 1` — one retry on transient failure, matching the single-shot
+ *   feel of the old fetches without hammering the backend.
+ */
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 30_000,
+      gcTime: 5 * 60_000,
+      refetchOnWindowFocus: false,
+      retry: 1,
+    },
+  },
+});

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,10 @@
 import {StrictMode} from 'react';
 import {createRoot} from 'react-dom/client';
 import {createRouter, RouterProvider} from '@tanstack/react-router';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {ReactQueryDevtools} from '@tanstack/react-query-devtools';
 import {routeTree} from './routeTree.gen';
+import {queryClient} from './lib/queryClient';
 import './index.css';
 
 // The router-plugin generates the `Register` module augmentation (which wires
@@ -9,8 +12,14 @@ import './index.css';
 // must NOT declare it again here — doing so triggers TS2300 duplicate identifier.
 const router = createRouter({routeTree});
 
+// QueryClientProvider wraps the router so every route/component can use
+// TanStack Query hooks. Devtools render only in dev (tree-shaken from prod
+// builds via the import.meta.env.DEV guard).
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <RouterProvider router={router} />
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router} />
+      {import.meta.env.DEV && <ReactQueryDevtools initialIsOpen={false} />}
+    </QueryClientProvider>
   </StrictMode>,
 );


### PR DESCRIPTION
PR 1 of 5 in the data-layer migration — tracking #90.

## Summary
Adds `@tanstack/react-query` (+ dev-only devtools) and wraps `<RouterProvider>` with `<QueryClientProvider>` in `src/main.tsx`, backed by a `queryClient` singleton (`src/lib/queryClient.ts`) so non-render call sites can invalidate the same cache later.

**Behavior-neutral** — no screen consumes Query yet. Defaults (`staleTime 30s`, `gcTime 5m`, no refetch-on-focus, `retry 1`) preserve pre-Query behavior; the 30s staleTime is what later lets the Ledger keep loaded pages on Back (#89).

## Verification (browser, not code analysis)
`frontend-test-runner` against the live dev server + real backend — **4/4 PASS**:
- App boots clean, no new console errors (only pre-existing PWA meta deprecation warning).
- React Query devtools mounted and **inert** — 0 queries registered, proving nothing uses Query yet.
- Navigation round-trip (ledger → receipt → back) works.
- Upload pipeline accepted: `POST /v1/ingest/batch → 202`, batch polling → `processing` (backend ground-truth confirmed).

Build (`tsc && vite build`) passes. Pre-existing lint debt on `main` (9 errors / 17 warnings, all in untouched files) is unchanged — my files are lint-clean.

## Part of #90