### PR TITLE
feat(data-layer): bridge bumpRefresh → invalidateQueries [2/5]

### DIFF
--- a/src/lib/appContext.tsx
+++ b/src/lib/appContext.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useProcessingJobs } from '../components/useProcessingJobs';
+import { queryClient } from './queryClient';
 
 /**
  * Cross-route application context.
@@ -18,7 +19,11 @@ import { useProcessingJobs } from '../components/useProcessingJobs';
  *   these. Polling lives in the hook, so a completed upload bumps `refreshKey`
  *   via the `onRefresh` wiring below and the list refetches in place.
  * - `refreshKey/bumpRefresh` drive the `key={refreshKey}` remount pattern the
- *   list screens use to refetch after a mutation.
+ *   list screens use to refetch after a mutation. During the TanStack Query
+ *   migration (#90), `bumpRefresh` is a *bridge*: it bumps the counter AND
+ *   invalidates the Query cache, so screens still on the remount pattern and
+ *   screens already moved to Query both refresh from the one signal. Both the
+ *   counter and this bridge are deleted once every screen is migrated (PR5).
  */
 interface AppCtxValue {
   jobs: ReturnType<typeof useProcessingJobs>['jobs'];
@@ -35,7 +40,17 @@ const AppCtx = React.createContext<AppCtxValue | null>(null);
 /** Provider — mounted once in __root.tsx. */
 export function AppProvider({ children }: { children: React.ReactNode }) {
   const [refreshKey, setRefreshKey] = React.useState(0);
-  const bumpRefresh = React.useCallback(() => setRefreshKey((k) => k + 1), []);
+  // Bridge (migration #90): one refresh signal must reach both worlds while
+  // screens move to TanStack Query one at a time. The counter bump still
+  // remounts any screen on the legacy `key={refreshKey}` pattern; the
+  // unfiltered `invalidateQueries()` marks every cached query stale so any
+  // already-migrated screen refetches too. With zero queries registered today
+  // the invalidate is a harmless no-op — each migrated screen starts honoring
+  // it the moment it lands. Counter + bridge are removed in PR5.
+  const bumpRefresh = React.useCallback(() => {
+    setRefreshKey((k) => k + 1);
+    queryClient.invalidateQueries();
+  }, []);
   // A completed upload (non-dedup) calls onRefresh; route the same single
   // refresh signal the rest of the app uses so the inline card's real row
   // appears in place without a manual reload.


### PR DESCRIPTION
PR 2 of 5 — tracking #90.

## Summary
Makes `appContext.bumpRefresh()` a **compatibility bridge**: it bumps the legacy `refreshKey` counter AND calls `queryClient.invalidateQueries()`. One refresh signal now reaches both the legacy `key={refreshKey}` remount screens and any screen already migrated to TanStack Query — so screens can migrate one at a time without a big-bang.

**Behavior-neutral today**: zero queries registered ⇒ the unfiltered invalidate is a no-op. Counter + bridge are removed in PR5.

## Verification (browser)
`frontend-test-runner`, **4/4 PASS**: app loads clean (no new console errors); editing a receipt payee refreshes the ledger via the bridge (`PATCH 200` → fresh list `GET 200`, row updated); devtools confirm `invalidateQueries()` ran against an empty cache without error; upload accepted (`202 → processing`). Test edit reverted, data left clean.

Build passes; no new lint issues (the appContext `react-refresh` warning pre-exists on `main`).

## Part of #90