### PR TITLE
feat(ledger): restore scroll position on Back — close #89 [4/5]

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -10,7 +10,14 @@ import './index.css';
 // The router-plugin generates the `Register` module augmentation (which wires
 // `typeof router` into TanStack's type system) inside routeTree.gen.ts, so we
 // must NOT declare it again here — doing so triggers TS2300 duplicate identifier.
-const router = createRouter({routeTree});
+//
+// `scrollRestoration` makes the router save/restore window scroll per location.
+// It's the second half of the #89 fix: now that the Ledger's pages live in the
+// TanStack Query cache (PR3), navigating into a receipt and back rehydrates the
+// full list synchronously, so the page is tall again and the saved scroll
+// offset actually exists to restore to. (The deprecated <ScrollRestoration/>
+// component is replaced by this router option.)
+const router = createRouter({routeTree, scrollRestoration: true});
 
 // QueryClientProvider wraps the router so every route/component can use
 // TanStack Query hooks. Devtools render only in dev (tree-shaken from prod

--- a/src/routes/_shell/transactions.tsx
+++ b/src/routes/_shell/transactions.tsx
@@ -23,10 +23,14 @@ export const Route = createFileRoute('/_shell/transactions')({
 function TransactionsRoute() {
   const search = Route.useSearch();
   const navigate = useNavigate({ from: '/transactions' });
-  const { refreshKey, items: processingItems, dismiss: dismissProcessing } = useAppCtx();
+  const { items: processingItems, dismiss: dismissProcessing } = useAppCtx();
   return (
+    // No `key={refreshKey}` remount: the Ledger now refetches via TanStack
+    // Query cache invalidation (the bumpRefresh bridge invalidates
+    // ['transactions']), so it stays MOUNTED across mutations and uploads.
+    // Keeping it mounted is what lets the router's scrollRestoration preserve
+    // the scroll offset on Back (#89) instead of the list snapping to the top.
     <Transactions
-      key={refreshKey}
       search={search}
       onSearchChange={(next: TransactionsSearch) =>
         // `replace` so view-state tweaks (typing in a filter, toggling a
@@ -38,9 +42,9 @@ function TransactionsRoute() {
         navigate({ to: '/receipt/$receiptId', params: { receiptId: id } })
       }
       // Inline upload status (#85). The in-flight receipt renders as a card
-      // at the top of the ledger; on completion the hook bumps refreshKey
-      // and the real row arrives in place. Tapping a terminal card navigates
-      // via onSelectReceipt above.
+      // at the top of the ledger; on completion the bumpRefresh bridge
+      // invalidates the ['transactions'] query and the real row arrives in
+      // place. Tapping a terminal card navigates via onSelectReceipt above.
       processingItems={processingItems}
       onDismissProcessing={dismissProcessing}
     />


### PR DESCRIPTION
PR 4 of 5 — tracking #90. **Closes #89.**

## Summary
- `src/main.tsx`: `createRouter({ scrollRestoration: true })` — router saves/restores window scroll per location.
- `src/routes/_shell/transactions.tsx`: removed `key={refreshKey}` so the Ledger stays mounted (refetches via invalidation, not remount).

Both are needed: PR3 put the ledger's pages in the Query cache, so on Back the list rehydrates to full height synchronously and the saved scroll offset exists to restore to.

## #89 close evidence (browser, not code analysis)
`frontend-test-runner`, **6/6 PASS**:
- **Scroll preserved**: scrollY **1200 → 1200** (Δ=0, stable over 1.2s, 8 samples); the "Apple · Apr 29" row returns to viewport `top:9px`; all 18 rows preserved from cache (list served **304**, no refetch-flash).
- Deep-link/refresh on `/receipt/$id` renders standalone; receipt opens from brand/merchant entry; floating dock visible in detail (HIG); mutation refresh works AND scroll survives mutate→Back; upload accepted. Zero new console errors. Data left clean.

Before/after screenshots + scrollY numbers in `notes/qa-query-provider/pr4-report.html`.

## Part of #90