### PR TITLE
refactor(data-layer): Dashboard+Batches → useQuery, delete refreshKey [5/5]

### DIFF
--- a/src/components/Batches.tsx
+++ b/src/components/Batches.tsx
@@ -1,9 +1,9 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { Loader2, FileStack, CheckCircle2, AlertCircle, Clock, Cog } from 'lucide-react';
 import {
   listBatches,
   extractProblemMessage,
-  type BackendBatchSummary,
   type BatchStatus,
 } from '../lib/api';
 import { cn } from '../lib/utils';
@@ -36,16 +36,12 @@ function formatDate(iso: string): string {
 }
 
 export default function Batches({ onSelectBatch }: BatchesProps) {
-  const [items, setItems] = useState<BackendBatchSummary[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    listBatches({ limit: 50 })
-      .then((r) => setItems(r.items))
-      .catch((e) => setError(extractProblemMessage(e)))
-      .finally(() => setLoading(false));
-  }, []);
+  const { data, isLoading: loading, error: queryError } = useQuery({
+    queryKey: ['batches', { limit: 50 }],
+    queryFn: () => listBatches({ limit: 50 }),
+  });
+  const items = data?.items ?? [];
+  const error = queryError ? extractProblemMessage(queryError) : null;
 
   return (
     <div className="space-y-10 animate-in fade-in slide-in-from-bottom-4 duration-700">

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,10 +1,10 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { Link } from '@tanstack/react-router';
 import {
   fetchTransactions,
   fetchSummary,
   classifyBackendCategory,
-  type SpendingSummary,
 } from '../lib/api';
 import type { Transaction, Category } from '../types';
 import { isProcessing as txIsProcessing } from '../lib/transactionStatus';
@@ -46,28 +46,22 @@ export default function Dashboard({
   processingItems = [],
   onDismissProcessing,
 }: DashboardProps) {
-  const [transactions, setTransactions] = useState<Transaction[]>([]);
-  const [summary, setSummary] = useState<SpendingSummary[]>([]);
-  const [loading, setLoading] = useState(true);
-
   const monthRange = useMemo(() => currentMonthRange(new Date()), []);
 
-  useEffect(() => {
-    Promise.all([
-      // Recent = freshly-uploaded / re-processed, not "this month's
-      // activity". Ride the `created_at desc` default with no month
-      // filter so a receipt with `occurred_on` years ago still bubbles
-      // to the top right after upload.
-      fetchTransactions({ limit: 4 }),
-      fetchSummary({ from: monthRange.from, to: monthRange.to }),
-    ])
-      .then(([txs, sum]) => {
-        setTransactions(txs);
-        setSummary(sum);
-      })
-      .catch(console.error)
-      .finally(() => setLoading(false));
-  }, [monthRange.from, monthRange.to]);
+  // Recent = freshly-uploaded / re-processed, not "this month's activity".
+  // Ride the `created_at desc` default with no month filter so a receipt with
+  // `occurred_on` years ago still bubbles to the top right after upload. Keyed
+  // under ['transactions','recent'] so it shares the namespace the Ledger and
+  // mutation invalidators target.
+  const { data: transactions = [], isLoading: txLoading } = useQuery({
+    queryKey: ['transactions', 'recent', { limit: 4 }],
+    queryFn: () => fetchTransactions({ limit: 4 }),
+  });
+  const { data: summary = [], isLoading: sumLoading } = useQuery({
+    queryKey: ['summary', { from: monthRange.from, to: monthRange.to }],
+    queryFn: () => fetchSummary({ from: monthRange.from, to: monthRange.to }),
+  });
+  const loading = txLoading || sumLoading;
 
   const spendingByCategory = useMemo<SpendingCategorySlice[]>(() => {
     const buckets = new Map<Category, { total: number; count: number }>();

--- a/src/components/Transactions.tsx
+++ b/src/components/Transactions.tsx
@@ -181,8 +181,8 @@ export default function Transactions({
   // keyed by queryArgs, so drilling into a receipt and coming back rehydrates
   // every page synchronously instead of refetching only page 1 — the
   // precondition for scroll restoration (#89). Refetch-on-mutation is driven
-  // by cache invalidation (the bumpRefresh bridge + the row handlers below),
-  // replacing the old refreshKey-as-effect-dep remount.
+  // by cache invalidation (invalidateLedgerSurfaces on upload-complete, plus
+  // the row handlers below), replacing the old refreshKey-as-effect-dep remount.
   const {
     data,
     isLoading: loading,

--- a/src/lib/appContext.tsx
+++ b/src/lib/appContext.tsx
@@ -1,29 +1,20 @@
 import React from 'react';
 import { useProcessingJobs } from '../components/useProcessingJobs';
-import { queryClient } from './queryClient';
+import { invalidateLedgerSurfaces } from './queryClient';
 
 /**
- * Cross-route application context.
- *
- * Before TanStack Router, the upload→extraction job list (ProcessingToast)
- * and the post-mutation `refreshKey` lived in App.tsx component state. With
- * routing, the toast must persist across navigation and any route must be
- * able to push a job or bump the refresh counter — so both move into a
- * context provided once at the root route, above the <Outlet/>.
+ * Cross-route application context — now scoped to just the upload-job
+ * machinery (the post-mutation refresh moved entirely to TanStack Query cache
+ * invalidation in #90, so the old `refreshKey`/`bumpRefresh` counter is gone).
  *
  * - `jobs/addJob/removeJob` come from useProcessingJobs (localStorage-backed,
  *   so outstanding uploads survive a full page reload). The root-level
  *   floating `ProcessingToast` consumes these.
  * - `items/dismiss` are the same jobs projected to polled, render-ready state.
  *   The inline `ProcessingCardList` (top of the ledger / dashboard) consumes
- *   these. Polling lives in the hook, so a completed upload bumps `refreshKey`
- *   via the `onRefresh` wiring below and the list refetches in place.
- * - `refreshKey/bumpRefresh` drive the `key={refreshKey}` remount pattern the
- *   list screens use to refetch after a mutation. During the TanStack Query
- *   migration (#90), `bumpRefresh` is a *bridge*: it bumps the counter AND
- *   invalidates the Query cache, so screens still on the remount pattern and
- *   screens already moved to Query both refresh from the one signal. Both the
- *   counter and this bridge are deleted once every screen is migrated (PR5).
+ *   these. Polling lives in the hook; when an upload completes the hook's
+ *   `onRefresh` fires `invalidateLedgerSurfaces()` and every list query
+ *   (ledger / month summary / batches) refetches in place.
  */
 interface AppCtxValue {
   jobs: ReturnType<typeof useProcessingJobs>['jobs'];
@@ -31,36 +22,21 @@ interface AppCtxValue {
   removeJob: ReturnType<typeof useProcessingJobs>['removeJob'];
   items: ReturnType<typeof useProcessingJobs>['items'];
   dismiss: ReturnType<typeof useProcessingJobs>['dismiss'];
-  refreshKey: number;
-  bumpRefresh: () => void;
 }
 
 const AppCtx = React.createContext<AppCtxValue | null>(null);
 
 /** Provider — mounted once in __root.tsx. */
 export function AppProvider({ children }: { children: React.ReactNode }) {
-  const [refreshKey, setRefreshKey] = React.useState(0);
-  // Bridge (migration #90): one refresh signal must reach both worlds while
-  // screens move to TanStack Query one at a time. The counter bump still
-  // remounts any screen on the legacy `key={refreshKey}` pattern; the
-  // unfiltered `invalidateQueries()` marks every cached query stale so any
-  // already-migrated screen refetches too. With zero queries registered today
-  // the invalidate is a harmless no-op — each migrated screen starts honoring
-  // it the moment it lands. Counter + bridge are removed in PR5.
-  const bumpRefresh = React.useCallback(() => {
-    setRefreshKey((k) => k + 1);
-    queryClient.invalidateQueries();
-  }, []);
-  // A completed upload (non-dedup) calls onRefresh; route the same single
-  // refresh signal the rest of the app uses so the inline card's real row
-  // appears in place without a manual reload.
+  // A completed upload (non-dedup) calls onRefresh; invalidate every list
+  // surface so the inline card's real row appears in place without a reload.
   const { jobs, addJob, removeJob, items, dismiss } = useProcessingJobs({
-    onRefresh: bumpRefresh,
+    onRefresh: invalidateLedgerSurfaces,
   });
 
   const value = React.useMemo<AppCtxValue>(
-    () => ({ jobs, addJob, removeJob, items, dismiss, refreshKey, bumpRefresh }),
-    [jobs, addJob, removeJob, items, dismiss, refreshKey, bumpRefresh],
+    () => ({ jobs, addJob, removeJob, items, dismiss }),
+    [jobs, addJob, removeJob, items, dismiss],
   );
 
   return <AppCtx.Provider value={value}>{children}</AppCtx.Provider>;

--- a/src/lib/queryClient.ts
+++ b/src/lib/queryClient.ts
@@ -30,3 +30,20 @@ export const queryClient = new QueryClient({
     },
   },
 });
+
+/**
+ * Refresh every list/summary surface that a receipt mutation or a completed
+ * upload can affect — the Ledger (`['transactions']`), the Dashboard month
+ * summary (`['summary']`), and the Batches list (`['batches']`).
+ *
+ * This is the exact replacement for the old `bumpRefresh()` fan-out: that
+ * counter remounted all three list screens at once; this invalidates the same
+ * three query namespaces (by prefix, so arg-tails don't have to match). One
+ * place to maintain so the call sites (upload-complete, add, receipt mutation,
+ * the processing toast) can't drift apart. Replaces the migration bridge.
+ */
+export function invalidateLedgerSurfaces() {
+  queryClient.invalidateQueries({ queryKey: ['transactions'] });
+  queryClient.invalidateQueries({ queryKey: ['summary'] });
+  queryClient.invalidateQueries({ queryKey: ['batches'] });
+}

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -1,5 +1,6 @@
 import { createRootRoute, Outlet, useNavigate } from '@tanstack/react-router';
 import { AppProvider, useAppCtx } from '../lib/appContext';
+import { invalidateLedgerSurfaces } from '../lib/queryClient';
 import ProcessingToast from '../components/ProcessingToast';
 
 export const Route = createRootRoute({
@@ -21,13 +22,13 @@ function RootComponent() {
  * list from AppCtx and jumps to the produced transaction on tap.
  */
 function ToastHost() {
-  const { jobs, removeJob, bumpRefresh } = useAppCtx();
+  const { jobs, removeJob } = useAppCtx();
   const navigate = useNavigate();
   return (
     <ProcessingToast
       jobs={jobs}
       onJobDone={removeJob}
-      onRefresh={bumpRefresh}
+      onRefresh={invalidateLedgerSurfaces}
       onSelectTransaction={(id) =>
         navigate({ to: '/receipt/$receiptId', params: { receiptId: id } })
       }

--- a/src/routes/_shell/batches/index.tsx
+++ b/src/routes/_shell/batches/index.tsx
@@ -1,6 +1,5 @@
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import Batches from '../../../components/Batches';
-import { useAppCtx } from '../../../lib/appContext';
 
 export const Route = createFileRoute('/_shell/batches/')({
   component: BatchesRoute,
@@ -8,10 +7,10 @@ export const Route = createFileRoute('/_shell/batches/')({
 
 function BatchesRoute() {
   const navigate = useNavigate();
-  const { refreshKey } = useAppCtx();
+  // Batches reads via useQuery and refetches on cache invalidation, so it
+  // stays mounted — no refreshKey remount needed.
   return (
     <Batches
-      key={refreshKey}
       onSelectBatch={(id) => navigate({ to: '/batches/$batchId', params: { batchId: id } })}
     />
   );

--- a/src/routes/_shell/index.tsx
+++ b/src/routes/_shell/index.tsx
@@ -8,15 +8,17 @@ export const Route = createFileRoute('/_shell/')({
 
 function DashboardRoute() {
   const navigate = useNavigate();
-  const { refreshKey, items: processingItems, dismiss: dismissProcessing } = useAppCtx();
+  const { items: processingItems, dismiss: dismissProcessing } = useAppCtx();
   return (
+    // No key={refreshKey}: Dashboard now reads via useQuery and refetches on
+    // cache invalidation (upload-complete / mutation → invalidateLedgerSurfaces),
+    // so it stays mounted instead of remounting.
     <Dashboard
-      key={refreshKey}
       onSelectReceipt={(id) => navigate({ to: '/receipt/$receiptId', params: { receiptId: id } })}
       onViewAllTransactions={() => navigate({ to: '/transactions' })}
       // Inline upload status (#85), mirrored on the home view: the in-flight
       // receipt shows as a card above "recent" and resolves in place once the
-      // hook bumps refreshKey.
+      // completed upload invalidates the recent-list query.
       processingItems={processingItems}
       onDismissProcessing={dismissProcessing}
     />

--- a/src/routes/_shell/receipt/$receiptId.tsx
+++ b/src/routes/_shell/receipt/$receiptId.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute } from '@tanstack/react-router';
 import ReceiptDetail from '../../../components/ReceiptDetail';
 import { useBack } from '../../../lib/useBack';
-import { useAppCtx } from '../../../lib/appContext';
+import { invalidateLedgerSurfaces } from '../../../lib/queryClient';
 
 export const Route = createFileRoute('/_shell/receipt/$receiptId')({
   component: ReceiptRoute,
@@ -10,15 +10,16 @@ export const Route = createFileRoute('/_shell/receipt/$receiptId')({
 function ReceiptRoute() {
   const { receiptId } = Route.useParams();
   const back = useBack('/transactions');
-  const { bumpRefresh } = useAppCtx();
   // Merchant/brand navigation is now handled inside ReceiptDetail via real
   // <Link>s (AmountHero merchant name → brand, LocationCard → merchant), so
   // the route no longer threads onSelectMerchant/onSelectBrand callbacks.
+  // A mutation (void/delete/restore/re-extract) invalidates the ledger, month
+  // summary, and batches so every list surface reflects the change.
   return (
     <ReceiptDetail
       receiptId={receiptId}
       onBack={back}
-      onAfterMutation={bumpRefresh}
+      onAfterMutation={invalidateLedgerSurfaces}
     />
   );
 }

--- a/src/routes/_shell/transactions.tsx
+++ b/src/routes/_shell/transactions.tsx
@@ -25,11 +25,11 @@ function TransactionsRoute() {
   const navigate = useNavigate({ from: '/transactions' });
   const { items: processingItems, dismiss: dismissProcessing } = useAppCtx();
   return (
-    // No `key={refreshKey}` remount: the Ledger now refetches via TanStack
-    // Query cache invalidation (the bumpRefresh bridge invalidates
-    // ['transactions']), so it stays MOUNTED across mutations and uploads.
-    // Keeping it mounted is what lets the router's scrollRestoration preserve
-    // the scroll offset on Back (#89) instead of the list snapping to the top.
+    // No remount key: the Ledger refetches via TanStack Query cache
+    // invalidation (invalidateLedgerSurfaces on upload-complete / mutation),
+    // so it stays MOUNTED across mutations and uploads. Keeping it mounted is
+    // what lets the router's scrollRestoration preserve the scroll offset on
+    // Back (#89) instead of the list snapping to the top.
     <Transactions
       search={search}
       onSearchChange={(next: TransactionsSearch) =>
@@ -42,7 +42,7 @@ function TransactionsRoute() {
         navigate({ to: '/receipt/$receiptId', params: { receiptId: id } })
       }
       // Inline upload status (#85). The in-flight receipt renders as a card
-      // at the top of the ledger; on completion the bumpRefresh bridge
+      // at the top of the ledger; on completion invalidateLedgerSurfaces
       // invalidates the ['transactions'] query and the real row arrives in
       // place. Tapping a terminal card navigates via onSelectReceipt above.
       processingItems={processingItems}

--- a/src/routes/add.tsx
+++ b/src/routes/add.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import Capture from '../components/Capture';
 import { useAppCtx } from '../lib/appContext';
+import { invalidateLedgerSurfaces } from '../lib/queryClient';
 
 /**
  * `/add` is a full-screen capture surface. It is intentionally a child of the
@@ -13,13 +14,13 @@ export const Route = createFileRoute('/add')({
 
 function AddRoute() {
   const navigate = useNavigate();
-  const { addJob, bumpRefresh } = useAppCtx();
+  const { addJob } = useAppCtx();
   return (
     <Capture
       onCancel={() => navigate({ to: '/' })}
       onComplete={(job) => {
         addJob(job);
-        bumpRefresh();
+        invalidateLedgerSurfaces();
         // Drop back to Books so the user sees their entry processing.
         navigate({ to: '/' });
       }}


### PR DESCRIPTION
PR 5 of 5 — tracking #90. **Final slice; completes the migration.**

## Summary
Removes the legacy `refreshKey`/`bumpRefresh` remount mechanism entirely:
- `Dashboard.tsx` → two `useQuery` (`['transactions','recent']` + `['summary']`); `Batches.tsx` → `useQuery(['batches'])`.
- Route wrappers drop `key={refreshKey}`.
- `appContext` loses `refreshKey`/`bumpRefresh` (now only the upload-job machinery).
- New `queryClient.invalidateLedgerSurfaces()` (invalidates `['transactions']`+`['summary']`+`['batches']`) is the exact replacement for the old fan-out, called from `/add`, the receipt mutation wrapper, the root ProcessingToast, and the upload-complete `onRefresh`.

`grep -rn 'refreshKey|bumpRefresh' src` → 0 live references (comments only).

## Verification (browser) — 5/5 PASS
`frontend-test-runner`: Dashboard + Batches render via Query (devtools confirm `['transactions','recent']`, `['summary']`, `['batches']` with data); receipt mutation refreshes dashboard recent + ledger via invalidation **with no remount**; upload fires `invalidateLedgerSurfaces` in-place; ledger pagination + #89 scroll-restoration **unregressed** (Y1=Y2=1100). Test edit reverted, data clean.

Build + tsc pass; lint problem count unchanged from `main` (no new issues).

## Closes the migration #90