### PR TITLE
refactor(lint): zero out all 26 ESLint problems

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -25,4 +25,16 @@ export default tseslint.config(
       ],
     },
   },
+  {
+    // TanStack Router file-based route modules must `export const Route =
+    // createFileRoute(...)` alongside their route component. That's a non-
+    // component export the react-refresh rule can't reconcile, so it false-
+    // positives on every route file. Fast-refresh of route modules is handled
+    // by @tanstack/router-plugin's own HMR, so this dev-only ergonomics rule
+    // adds no value here — turn it off for the routes directory specifically.
+    files: ['src/routes/**/*.{ts,tsx}'],
+    rules: {
+      'react-refresh/only-export-components': 'off',
+    },
+  },
 )

--- a/src/components/BatchDetail.tsx
+++ b/src/components/BatchDetail.tsx
@@ -24,7 +24,6 @@ import { receiptLink } from '../lib/navLinks';
 interface BatchDetailProps {
   batchId: string;
   onBack: () => void;
-  onSelectTransaction: (txnId: string) => void;
 }
 
 const INGEST_STATUS_META: Record<
@@ -46,7 +45,7 @@ interface LiveEvent {
   payload: unknown;
 }
 
-export default function BatchDetail({ batchId, onBack, onSelectTransaction }: BatchDetailProps) {
+export default function BatchDetail({ batchId, onBack }: BatchDetailProps) {
   const [batch, setBatch] = useState<BackendBatch | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -184,7 +183,7 @@ export default function BatchDetail({ batchId, onBack, onSelectTransaction }: Ba
           </thead>
           <tbody className="divide-y divide-outline-variant/5">
             {batch.items.map((ing) => (
-              <IngestRow key={ing.id} ingest={ing} onSelectTransaction={onSelectTransaction} />
+              <IngestRow key={ing.id} ingest={ing} />
             ))}
           </tbody>
         </table>
@@ -257,13 +256,7 @@ function StatCard({
   );
 }
 
-function IngestRow({
-  ingest,
-  onSelectTransaction,
-}: {
-  ingest: BackendIngest;
-  onSelectTransaction: (id: string) => void;
-}) {
+function IngestRow({ ingest }: { ingest: BackendIngest }) {
   const meta = INGEST_STATUS_META[ingest.status];
   const Icon = meta.icon;
   const txnIds = ingest.produced?.transaction_ids ?? [];

--- a/src/components/BrandPage.tsx
+++ b/src/components/BrandPage.tsx
@@ -1,9 +1,8 @@
-import { useEffect, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { Link } from '@tanstack/react-router';
 import {
   extractProblemMessage,
   fetchBrandRollup,
-  type BrandRollup,
   type BrandRollupLocation,
   type BrandRollupRecentRow,
   type BrandRollupSibling,
@@ -45,31 +44,15 @@ export default function BrandPage({
   onSelectBrand,
   onSelectReceipt,
 }: BrandPageProps) {
-  const [rollup, setRollup] = useState<BrandRollup | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    let cancelled = false;
-    setLoading(true);
-    setError(null);
-    fetchBrandRollup(brandId)
-      .then((r) => {
-        if (!cancelled) {
-          setRollup(r);
-          setLoading(false);
-        }
-      })
-      .catch((e: unknown) => {
-        if (!cancelled) {
-          setError(extractProblemMessage(e));
-          setLoading(false);
-        }
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [brandId]);
+  const {
+    data: rollup,
+    isLoading: loading,
+    error: queryError,
+  } = useQuery({
+    queryKey: ['brandRollup', brandId],
+    queryFn: () => fetchBrandRollup(brandId),
+  });
+  const error = queryError ? extractProblemMessage(queryError) : null;
 
   if (loading) {
     return (

--- a/src/components/MerchantDetail.tsx
+++ b/src/components/MerchantDetail.tsx
@@ -8,7 +8,6 @@ import {
   patchMerchant,
   patchPlace,
   pickCjk,
-  placeName,
   postRefreshPlace,
   type MerchantDetailResponse,
   type MerchantTransactionRow,

--- a/src/components/MonthlyReview.tsx
+++ b/src/components/MonthlyReview.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { Link, useNavigate } from '@tanstack/react-router';
 import { ChevronLeft, ChevronRight, TrendingDown, TrendingUp, Loader2, PieChart as PieIcon, Receipt } from 'lucide-react';
 import {
@@ -16,9 +17,6 @@ import {
   getCashflowReport,
   getSummaryReport,
   getTrendsReport,
-  type BackendCashflowReport,
-  type BackendSummaryReport,
-  type BackendTrendsReport,
 } from '../lib/api';
 import type { Category, Transaction } from '../types';
 import { cn } from '../lib/utils';
@@ -100,60 +98,51 @@ export default function MonthlyReview({ month }: { month?: string }) {
     });
   };
 
-  const [cashflow, setCashflow] = useState<BackendCashflowReport | null>(null);
-  const [trends, setTrends] = useState<BackendTrendsReport | null>(null);
-  const [thisMonth, setThisMonth] = useState<BackendSummaryReport | null>(null);
-  const [lastMonth, setLastMonth] = useState<BackendSummaryReport | null>(null);
-  // FE#23: full this-month receipt list (sorted by amount desc).
-  // Seeds both the "Notable transactions" section (top-3 spending)
-  // and the Receipts count KPI. ~200-cap on the API call covers all
-  // but the most active months.
-  const [allReceipts, setAllReceipts] = useState<Transaction[] | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    setLoading(true);
-    setError(null);
-    Promise.all([
-      getCashflowReport({ from: startOfMonth(sixMonthsAgo(now)), to: endOfMonth(now) }),
-      getTrendsReport({
-        from: startOfMonth(sixMonthsAgo(now)),
-        to: endOfMonth(now),
-        period: 'month',
-        groupBy: 'total',
-      }),
-      getSummaryReport({ from: startOfMonth(now), to: endOfMonth(now), groupBy: 'category' }),
-      getSummaryReport({
-        from: startOfMonth(prevMonth),
-        to: endOfMonth(prevMonth),
-        groupBy: 'category',
-      }),
-      fetchTransactions({
-        from: startOfMonth(now),
-        to: endOfMonth(now),
-        // Backend only supports sort=occurred_on / sort=created_at —
-        // sort=amount needs a JOIN over postings and isn't wired yet.
-        // Pull the full month and sort by amount client-side; 200-cap
-        // covers all but the most active months.
-        sort: 'occurred_on',
-        order: 'desc',
-        limit: 200,
-      }),
-    ])
-      .then(([cf, tr, thisM, lastM, top]) => {
-        setCashflow(cf);
-        setTrends(tr);
-        setThisMonth(thisM);
-        setLastMonth(lastM);
-        // Client-side sort by amount desc so Notable picks largest;
-        // KPI count is independent of sort order.
-        const byAmount = [...top].sort((a, b) => b.amount - a.amount);
-        setAllReceipts(byAmount);
-      })
-      .catch((e) => setError(extractProblemMessage(e)))
-      .finally(() => setLoading(false));
-  }, [now, prevMonth]);
+  // FE#23: the this-month receipt list (sorted by amount desc) seeds both the
+  // "Notable transactions" section (top-3 spending) and the Receipts count KPI.
+  // ~200-cap on the API call covers all but the most active months.
+  // All five reports fetch together in one query keyed by the month pair.
+  const { data, isLoading: loading, error: queryError } = useQuery({
+    queryKey: ['monthlyReview', yearMonthKey(now), yearMonthKey(prevMonth)],
+    queryFn: async () => {
+      const [cf, tr, thisM, lastM, top] = await Promise.all([
+        getCashflowReport({ from: startOfMonth(sixMonthsAgo(now)), to: endOfMonth(now) }),
+        getTrendsReport({
+          from: startOfMonth(sixMonthsAgo(now)),
+          to: endOfMonth(now),
+          period: 'month',
+          groupBy: 'total',
+        }),
+        getSummaryReport({ from: startOfMonth(now), to: endOfMonth(now), groupBy: 'category' }),
+        getSummaryReport({
+          from: startOfMonth(prevMonth),
+          to: endOfMonth(prevMonth),
+          groupBy: 'category',
+        }),
+        fetchTransactions({
+          from: startOfMonth(now),
+          to: endOfMonth(now),
+          // Backend only supports sort=occurred_on / sort=created_at —
+          // sort=amount needs a JOIN over postings and isn't wired yet.
+          // Pull the full month and sort by amount client-side; 200-cap
+          // covers all but the most active months.
+          sort: 'occurred_on',
+          order: 'desc',
+          limit: 200,
+        }),
+      ]);
+      // Client-side sort by amount desc so Notable picks largest;
+      // KPI count is independent of sort order.
+      const allReceipts = [...top].sort((a, b) => b.amount - a.amount);
+      return { cashflow: cf, trends: tr, thisMonth: thisM, lastMonth: lastM, allReceipts };
+    },
+  });
+  const error = queryError ? extractProblemMessage(queryError) : null;
+  const cashflow = data?.cashflow ?? null;
+  const trends = data?.trends ?? null;
+  const thisMonth = data?.thisMonth ?? null;
+  const lastMonth = data?.lastMonth ?? null;
+  const allReceipts = data?.allReceipts ?? null;
 
   if (loading) {
     return (

--- a/src/components/Products.tsx
+++ b/src/components/Products.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { ChevronRight, ArrowLeft, RotateCw, GitMerge } from 'lucide-react';
 import {
   listProducts,
@@ -56,21 +57,24 @@ interface ProductsProps {
 export default function Products({ onBack }: ProductsProps) {
   const [klass, setKlass] = useState<ProductClass | 'all'>('all');
   const [search, setSearch] = useState('');
-  const [products, setProducts] = useState<BackendProduct[] | null>(null);
-  const [error, setError] = useState<string | null>(null);
   const [selectedId, setSelectedId] = useState<string | null>(null);
 
-  useEffect(() => {
-    setProducts(null);
-    setError(null);
-    listProducts({
-      class: klass === 'all' ? undefined : klass,
-      search: search.trim() || undefined,
-      limit: 100,
-    })
-      .then(setProducts)
-      .catch((e: unknown) => setError(extractProblemMessage(e)));
-  }, [klass, search]);
+  // `products === null` is the loading sentinel the render relies on, so default
+  // the (undefined-while-loading) query data to null rather than [].
+  const {
+    data: products = null,
+    error: queryError,
+    refetch,
+  } = useQuery({
+    queryKey: ['products', klass, search.trim()],
+    queryFn: () =>
+      listProducts({
+        class: klass === 'all' ? undefined : klass,
+        search: search.trim() || undefined,
+        limit: 100,
+      }),
+  });
+  const error = queryError ? extractProblemMessage(queryError) : null;
 
   if (selectedId) {
     return (
@@ -79,11 +83,8 @@ export default function Products({ onBack }: ProductsProps) {
         onBack={() => setSelectedId(null)}
         onMerged={() => {
           setSelectedId(null);
-          // Trigger refetch by twiddling the filter (cheap idempotent).
-          setProducts(null);
-          listProducts({ class: klass === 'all' ? undefined : klass, limit: 100 })
-            .then(setProducts)
-            .catch((e: unknown) => setError(extractProblemMessage(e)));
+          // A merge changes the product set — refetch the list query.
+          refetch();
         }}
       />
     );

--- a/src/components/ReceiptDetail.tsx
+++ b/src/components/ReceiptDetail.tsx
@@ -888,12 +888,10 @@ function LocationCard({
   place,
   merchantId,
   payee,
-  onSelectMerchant,
 }: {
   place: ReceiptView['place'];
   merchantId: string | null;
   payee: string | null;
-  onSelectMerchant?: (merchantId: string) => void;
 }) {
   const addr = place?.formatted_address?.trim() || null;
   const cityState = (() => {

--- a/src/components/Transactions.tsx
+++ b/src/components/Transactions.tsx
@@ -17,7 +17,6 @@ import { useDebouncedValue } from '../lib/useDebouncedValue';
 import { cn } from '../lib/utils';
 import type { Transaction } from '../types';
 import { isProcessing as txIsProcessing, statusBadge } from '../lib/transactionStatus';
-import { CategoryIcon } from './CategoryIcon';
 import { MerchantIcon } from './MerchantIcon';
 import TransactionRowMenu from './TransactionRowMenu';
 import ConfirmActionDialog from './ConfirmActionDialog';
@@ -394,7 +393,6 @@ export default function Transactions({
             <PeriodGroup
               key={g.startIso}
               group={g}
-              onSelect={(tx) => onSelectReceipt?.(tx.id)}
               onHardDelete={handleHardDeleteRequest}
               onUnreconcile={(id) => setUnreconcileTarget(id)}
             />
@@ -406,7 +404,6 @@ export default function Transactions({
             <li key={tx.id}>
               <LedgerRow
                 tx={tx}
-                onSelect={(t) => onSelectReceipt?.(t.id)}
                 onHardDelete={handleHardDeleteRequest}
                 onUnreconcile={(id) => setUnreconcileTarget(id)}
               />
@@ -614,12 +611,10 @@ interface PeriodBucket {
 
 function PeriodGroup({
   group,
-  onSelect,
   onHardDelete,
   onUnreconcile,
 }: {
   group: PeriodBucket;
-  onSelect: (tx: Transaction) => void;
   onHardDelete: (id: string) => void;
   onUnreconcile: (id: string) => void;
 }) {
@@ -644,7 +639,6 @@ function PeriodGroup({
           <li key={tx.id}>
             <LedgerRow
               tx={tx}
-              onSelect={onSelect}
               onHardDelete={onHardDelete}
               onUnreconcile={onUnreconcile}
             />
@@ -672,12 +666,10 @@ function sourceTag(
 
 function LedgerRow({
   tx,
-  onSelect,
   onHardDelete,
   onUnreconcile,
 }: {
   tx: Transaction;
-  onSelect: (tx: Transaction) => void;
   onHardDelete: (id: string) => void;
   onUnreconcile: (id: string) => void;
 }) {

--- a/src/lib/appContext.tsx
+++ b/src/lib/appContext.tsx
@@ -1,11 +1,14 @@
 import React from 'react';
 import { useProcessingJobs } from '../components/useProcessingJobs';
 import { invalidateLedgerSurfaces } from './queryClient';
+import { AppCtx, type AppCtxValue } from './appCtx';
 
 /**
- * Cross-route application context — now scoped to just the upload-job
+ * Cross-route application context provider — scoped to the upload-job
  * machinery (the post-mutation refresh moved entirely to TanStack Query cache
  * invalidation in #90, so the old `refreshKey`/`bumpRefresh` counter is gone).
+ * The context object + `useAppCtx` accessor live in `./appCtx` so this module
+ * exports only the component (keeps Fast Refresh happy).
  *
  * - `jobs/addJob/removeJob` come from useProcessingJobs (localStorage-backed,
  *   so outstanding uploads survive a full page reload). The root-level
@@ -16,17 +19,6 @@ import { invalidateLedgerSurfaces } from './queryClient';
  *   `onRefresh` fires `invalidateLedgerSurfaces()` and every list query
  *   (ledger / month summary / batches) refetches in place.
  */
-interface AppCtxValue {
-  jobs: ReturnType<typeof useProcessingJobs>['jobs'];
-  addJob: ReturnType<typeof useProcessingJobs>['addJob'];
-  removeJob: ReturnType<typeof useProcessingJobs>['removeJob'];
-  items: ReturnType<typeof useProcessingJobs>['items'];
-  dismiss: ReturnType<typeof useProcessingJobs>['dismiss'];
-}
-
-const AppCtx = React.createContext<AppCtxValue | null>(null);
-
-/** Provider — mounted once in __root.tsx. */
 export function AppProvider({ children }: { children: React.ReactNode }) {
   // A completed upload (non-dedup) calls onRefresh; invalidate every list
   // surface so the inline card's real row appears in place without a reload.
@@ -40,10 +32,4 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
   );
 
   return <AppCtx.Provider value={value}>{children}</AppCtx.Provider>;
-}
-
-export function useAppCtx(): AppCtxValue {
-  const ctx = React.useContext(AppCtx);
-  if (!ctx) throw new Error('useAppCtx must be used within <AppProvider>');
-  return ctx;
 }

--- a/src/lib/appCtx.ts
+++ b/src/lib/appCtx.ts
@@ -1,0 +1,25 @@
+import { createContext, useContext } from 'react';
+import type { useProcessingJobs } from '../components/useProcessingJobs';
+
+/**
+ * Cross-route app context — the upload-job machinery shared between the root
+ * `ProcessingToast` and the inline `ProcessingCardList`. The context object,
+ * its value type, and the `useAppCtx` accessor live here (a non-component
+ * module) rather than alongside `<AppProvider>` in `appContext.tsx`, so that
+ * file can export only its component and keep React Fast Refresh working.
+ */
+export interface AppCtxValue {
+  jobs: ReturnType<typeof useProcessingJobs>['jobs'];
+  addJob: ReturnType<typeof useProcessingJobs>['addJob'];
+  removeJob: ReturnType<typeof useProcessingJobs>['removeJob'];
+  items: ReturnType<typeof useProcessingJobs>['items'];
+  dismiss: ReturnType<typeof useProcessingJobs>['dismiss'];
+}
+
+export const AppCtx = createContext<AppCtxValue | null>(null);
+
+export function useAppCtx(): AppCtxValue {
+  const ctx = useContext(AppCtx);
+  if (!ctx) throw new Error('useAppCtx must be used within <AppProvider>');
+  return ctx;
+}

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -1,5 +1,6 @@
 import { createRootRoute, Outlet, useNavigate } from '@tanstack/react-router';
-import { AppProvider, useAppCtx } from '../lib/appContext';
+import { AppProvider } from '../lib/appContext';
+import { useAppCtx } from '../lib/appCtx';
 import { invalidateLedgerSurfaces } from '../lib/queryClient';
 import ProcessingToast from '../components/ProcessingToast';
 

--- a/src/routes/_shell/batches/$batchId.tsx
+++ b/src/routes/_shell/batches/$batchId.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute, useNavigate } from '@tanstack/react-router';
+import { createFileRoute } from '@tanstack/react-router';
 import BatchDetail from '../../../components/BatchDetail';
 import { useBack } from '../../../lib/useBack';
 
@@ -8,13 +8,8 @@ export const Route = createFileRoute('/_shell/batches/$batchId')({
 
 function BatchDetailRoute() {
   const { batchId } = Route.useParams();
-  const navigate = useNavigate();
   const back = useBack('/batches');
-  return (
-    <BatchDetail
-      batchId={batchId}
-      onBack={back}
-      onSelectTransaction={(id) => navigate({ to: '/receipt/$receiptId', params: { receiptId: id } })}
-    />
-  );
+  // Produced transaction IDs render as real <Link>s inside BatchDetail, so no
+  // onSelectTransaction callback is threaded through.
+  return <BatchDetail batchId={batchId} onBack={back} />;
 }

--- a/src/routes/_shell/index.tsx
+++ b/src/routes/_shell/index.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import Dashboard from '../../components/Dashboard';
-import { useAppCtx } from '../../lib/appContext';
+import { useAppCtx } from '../../lib/appCtx';
 
 export const Route = createFileRoute('/_shell/')({
   component: DashboardRoute,

--- a/src/routes/_shell/transactions.tsx
+++ b/src/routes/_shell/transactions.tsx
@@ -4,7 +4,7 @@ import {
   transactionsSearchSchema,
   type TransactionsSearch,
 } from '../../lib/transactionsFilterState';
-import { useAppCtx } from '../../lib/appContext';
+import { useAppCtx } from '../../lib/appCtx';
 
 /**
  * /transactions — the Ledger.

--- a/src/routes/add.tsx
+++ b/src/routes/add.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import Capture from '../components/Capture';
-import { useAppCtx } from '../lib/appContext';
+import { useAppCtx } from '../lib/appCtx';
 import { invalidateLedgerSurfaces } from '../lib/queryClient';
 
 /**


### PR DESCRIPTION
Makes `npm run lint` pass clean (was **26 problems → 0**; `--max-warnings 0` made the gate red on every run).

## Three buckets
**(A) `react-refresh/only-export-components` (17 warnings)**
- Turn the rule off for `src/routes/**` — TanStack Router file-based modules must `export const Route = createFileRoute(...)` alongside their component; that's not a primitive constant so the rule false-positives on every route file. Route HMR is handled by `@tanstack/router-plugin`.
- Move `AppCtx`/`AppCtxValue`/`useAppCtx` into a new non-component module `src/lib/appCtx.ts` so `appContext.tsx` exports only `<AppProvider>`. Importers updated.

**(B) `@typescript-eslint/no-unused-vars` (6 errors)** — remove dead imports (`CategoryIcon`, `placeName`, `useMemo`) and dead nav props left from the routing migration (`onSelect`, `onSelectTransaction`, `onSelectMerchant` — the targets are all real `<Link>`s now; the batch route wrapper's now-unused `useNavigate` went too).

**(C) `react-hooks/set-state-in-effect` (3 errors)** — migrate the last fetch-in-effect screens to TanStack Query (removes the synchronous setState-in-effect at the root): **BrandPage**, **MonthlyReview** (one query wrapping the 5-report `Promise.all`), **Products** (`['products',klass,search]` + `refetch()`).

## Verification (browser) — 6/6 PASS
`frontend-test-runner`: all 3 migrated screens render via Query; Products class-filter + search refetch on a new key; ledger + batch produced-id links still navigate after the dead-prop removals; no new console errors. Build + tsc pass; `npm run lint` → **0 problems**.

## Pre-existing backend gap surfaced (not a regression here)
`GET /v1/products?search=<q>` ignores the param server-side (curl: 70 rows regardless of `search`). The client sends it as designed; needs a backend fix — filing separately against `receipt-assistant`.