### PR TITLE
refactor(query): central queryKeys.ts factory [Phase2 A]

### DIFF
--- a/src/components/Batches.tsx
+++ b/src/components/Batches.tsx
@@ -7,6 +7,7 @@ import {
   type BatchStatus,
 } from '../lib/api';
 import { cn } from '../lib/utils';
+import { qk } from '../lib/queryKeys';
 
 interface BatchesProps {
   onSelectBatch: (batchId: string) => void;
@@ -37,7 +38,7 @@ function formatDate(iso: string): string {
 
 export default function Batches({ onSelectBatch }: BatchesProps) {
   const { data, isLoading: loading, error: queryError } = useQuery({
-    queryKey: ['batches', { limit: 50 }],
+    queryKey: qk.batches.list({ limit: 50 }),
     queryFn: () => listBatches({ limit: 50 }),
   });
   const items = data?.items ?? [];

--- a/src/components/BrandPage.tsx
+++ b/src/components/BrandPage.tsx
@@ -8,6 +8,7 @@ import {
   type BrandRollupSibling,
 } from '../lib/api';
 import { cn } from '../lib/utils';
+import { qk } from '../lib/queryKeys';
 import { brandLink, merchantLink, receiptLink } from '../lib/navLinks';
 import { MerchantIcon } from './MerchantIcon';
 import { statusBadge } from '../lib/transactionStatus';
@@ -49,7 +50,7 @@ export default function BrandPage({
     isLoading: loading,
     error: queryError,
   } = useQuery({
-    queryKey: ['brandRollup', brandId],
+    queryKey: qk.brandRollup(brandId),
     queryFn: () => fetchBrandRollup(brandId),
   });
   const error = queryError ? extractProblemMessage(queryError) : null;

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -10,6 +10,7 @@ import type { Transaction, Category } from '../types';
 import { isProcessing as txIsProcessing } from '../lib/transactionStatus';
 import { cn } from '../lib/utils';
 import { receiptLink, categoryLedgerLink } from '../lib/navLinks';
+import { qk } from '../lib/queryKeys';
 import { CategoryIcon } from './CategoryIcon';
 import { MerchantIcon } from './MerchantIcon';
 import ProcessingCardList from './ProcessingCard';
@@ -54,11 +55,11 @@ export default function Dashboard({
   // under ['transactions','recent'] so it shares the namespace the Ledger and
   // mutation invalidators target.
   const { data: transactions = [], isLoading: txLoading } = useQuery({
-    queryKey: ['transactions', 'recent', { limit: 4 }],
+    queryKey: qk.transactions.recent({ limit: 4 }),
     queryFn: () => fetchTransactions({ limit: 4 }),
   });
   const { data: summary = [], isLoading: sumLoading } = useQuery({
-    queryKey: ['summary', { from: monthRange.from, to: monthRange.to }],
+    queryKey: qk.summary.range({ from: monthRange.from, to: monthRange.to }),
     queryFn: () => fetchSummary({ from: monthRange.from, to: monthRange.to }),
   });
   const loading = txLoading || sumLoading;

--- a/src/components/MonthlyReview.tsx
+++ b/src/components/MonthlyReview.tsx
@@ -20,6 +20,7 @@ import {
 } from '../lib/api';
 import type { Category, Transaction } from '../types';
 import { cn } from '../lib/utils';
+import { qk } from '../lib/queryKeys';
 import { CategoryIcon } from './CategoryIcon';
 import { MerchantIcon } from './MerchantIcon';
 import { categoryLedgerLink, receiptLink } from '../lib/navLinks';
@@ -103,7 +104,7 @@ export default function MonthlyReview({ month }: { month?: string }) {
   // ~200-cap on the API call covers all but the most active months.
   // All five reports fetch together in one query keyed by the month pair.
   const { data, isLoading: loading, error: queryError } = useQuery({
-    queryKey: ['monthlyReview', yearMonthKey(now), yearMonthKey(prevMonth)],
+    queryKey: qk.monthlyReview(yearMonthKey(now), yearMonthKey(prevMonth)),
     queryFn: async () => {
       const [cf, tr, thisM, lastM, top] = await Promise.all([
         getCashflowReport({ from: startOfMonth(sixMonthsAgo(now)), to: endOfMonth(now) }),

--- a/src/components/Products.tsx
+++ b/src/components/Products.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { ChevronRight, ArrowLeft, RotateCw, GitMerge } from 'lucide-react';
+import { qk } from '../lib/queryKeys';
 import {
   listProducts,
   getProduct,
@@ -66,7 +67,7 @@ export default function Products({ onBack }: ProductsProps) {
     error: queryError,
     refetch,
   } = useQuery({
-    queryKey: ['products', klass, search.trim()],
+    queryKey: qk.products(klass, search.trim()),
     queryFn: () =>
       listProducts({
         class: klass === 'all' ? undefined : klass,

--- a/src/components/Transactions.tsx
+++ b/src/components/Transactions.tsx
@@ -13,6 +13,7 @@ import {
   type BackendDocument,
 } from '../lib/api';
 import { listTombstones, removeTombstone } from '../lib/tombstones';
+import { qk } from '../lib/queryKeys';
 import { useDebouncedValue } from '../lib/useDebouncedValue';
 import { cn } from '../lib/utils';
 import type { Transaction } from '../types';
@@ -190,7 +191,7 @@ export default function Transactions({
     hasNextPage,
     fetchNextPage,
   } = useInfiniteQuery({
-    queryKey: ['transactions', 'list', queryArgs],
+    queryKey: qk.transactions.list(queryArgs),
     queryFn: ({ pageParam }) =>
       fetchTransactionsPage({ ...queryArgs, cursor: pageParam }),
     initialPageParam: undefined as string | undefined,
@@ -223,7 +224,7 @@ export default function Transactions({
   // backend (stale ones self-prune). Its own query so a restore/hard-delete can
   // invalidate it independently of the main list. Disabled unless showDeleted.
   const { data: tombstones = [], isLoading: tombstoneLoading } = useQuery({
-    queryKey: ['tombstones'],
+    queryKey: qk.tombstones,
     enabled: showDeleted,
     queryFn: async (): Promise<TombstoneRow[]> => {
       const ids = listTombstones();
@@ -294,8 +295,8 @@ export default function Transactions({
     await hardDeleteTransaction(hardDeleteTarget.id, hardDeleteTarget.etag);
     setHardDeleteTarget(null);
     // Hard delete drops the row from the list and creates a tombstone.
-    queryClient.invalidateQueries({ queryKey: ['transactions'] });
-    queryClient.invalidateQueries({ queryKey: ['tombstones'] });
+    queryClient.invalidateQueries({ queryKey: qk.transactions.all });
+    queryClient.invalidateQueries({ queryKey: qk.tombstones });
   };
 
   const handleRestoreTombstone = async (id: string) => {
@@ -303,8 +304,8 @@ export default function Transactions({
       await restoreDocument(id);
       removeTombstone(id);
       // Restore re-adds the row to the main list and removes the tombstone.
-      queryClient.invalidateQueries({ queryKey: ['transactions'] });
-      queryClient.invalidateQueries({ queryKey: ['tombstones'] });
+      queryClient.invalidateQueries({ queryKey: qk.transactions.all });
+      queryClient.invalidateQueries({ queryKey: qk.tombstones });
     } catch (err: unknown) {
       setRowError(extractProblemMessage(err));
     }
@@ -451,7 +452,7 @@ export default function Transactions({
         transactionId={unreconcileTarget}
         onUnreconciled={() => {
           setUnreconcileTarget(null);
-          queryClient.invalidateQueries({ queryKey: ['transactions'] });
+          queryClient.invalidateQueries({ queryKey: qk.transactions.all });
         }}
       />
     </div>

--- a/src/lib/queryClient.ts
+++ b/src/lib/queryClient.ts
@@ -1,4 +1,5 @@
 import { QueryClient } from '@tanstack/react-query';
+import { qk } from './queryKeys';
 
 /**
  * Single app-wide QueryClient.
@@ -43,7 +44,7 @@ export const queryClient = new QueryClient({
  * the processing toast) can't drift apart. Replaces the migration bridge.
  */
 export function invalidateLedgerSurfaces() {
-  queryClient.invalidateQueries({ queryKey: ['transactions'] });
-  queryClient.invalidateQueries({ queryKey: ['summary'] });
-  queryClient.invalidateQueries({ queryKey: ['batches'] });
+  queryClient.invalidateQueries({ queryKey: qk.transactions.all });
+  queryClient.invalidateQueries({ queryKey: qk.summary.all });
+  queryClient.invalidateQueries({ queryKey: qk.batches.all });
 }

--- a/src/lib/queryKeys.ts
+++ b/src/lib/queryKeys.ts
@@ -1,0 +1,43 @@
+/**
+ * Central TanStack Query key factory.
+ *
+ * Every `useQuery` / `useInfiniteQuery` / `invalidateQueries` key in the app is
+ * built here — no inline `['...']` literals scattered across components. This
+ * is the single source of truth that keeps reads and their invalidators in
+ * agreement (a typo'd literal silently never invalidates).
+ *
+ * Convention: each namespace exposes `.all` (the bare prefix, for broad
+ * invalidation — TanStack matches by prefix) plus specific builders for the
+ * exact keys queries register under. Single-entity namespaces are a function
+ * `(id) => ['name', id]` whose `[0]` doubles as the prefix.
+ */
+export const qk = {
+  transactions: {
+    all: ['transactions'] as const,
+    list: (args: unknown) => ['transactions', 'list', args] as const,
+    recent: (args: { limit: number }) => ['transactions', 'recent', args] as const,
+  },
+  tombstones: ['tombstones'] as const,
+  summary: {
+    all: ['summary'] as const,
+    range: (args: { from: string; to: string }) => ['summary', args] as const,
+  },
+  batches: {
+    all: ['batches'] as const,
+    list: (args: { limit: number }) => ['batches', args] as const,
+  },
+  /** A single ingest batch — shared by BatchDetail, ProcessingToast, and the
+   *  upload-job poller so all three collapse onto one cache entry per batch. */
+  batch: (id: string) => ['batch', id] as const,
+  receipt: (id: string) => ['receipt', id] as const,
+  merchant: (id: string) => ['merchant', id] as const,
+  place: (id: string) => ['place', id] as const,
+  brands: ['brands'] as const,
+  brand: (id: string) => ['brand', id] as const,
+  brandRollup: (id: string) => ['brandRollup', id] as const,
+  products: (klass: string, search: string) => ['products', klass, search] as const,
+  product: (id: string) => ['product', id] as const,
+  monthlyReview: (now: string, prev: string) => ['monthlyReview', now, prev] as const,
+  yearlyReview: (now: string, prev: string) => ['yearlyReview', now, prev] as const,
+  buildInfo: ['buildInfo'] as const,
+} as const;


### PR DESCRIPTION
Phase 2 (#98) foundation. Adds `src/lib/queryKeys.ts` — one typed factory for every query key — and routes all 9 existing literal keys + `invalidateLedgerSurfaces` through it. **Behavior-neutral** (byte-identical key arrays). Verified 4/4 via frontend-test-runner: key shapes unchanged, prefix-invalidation still matches, no errors. Build+tsc+lint(0) green.

Part of #98.