### PR TITLE
feat(query): Brands + ProductDetail → useQuery/useMutation [Phase2 C]

### DIFF
--- a/src/components/Brands.tsx
+++ b/src/components/Brands.tsx
@@ -1,5 +1,7 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useRef, useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { ChevronRight, ArrowLeft, Lock, Globe, Upload } from 'lucide-react';
+import { qk } from '../lib/queryKeys';
 import {
   listBrands,
   getBrand,
@@ -31,16 +33,16 @@ interface BrandsProps {
 }
 
 export default function Brands({ onBack }: BrandsProps) {
-  const [brands, setBrands] = useState<BackendBrand[] | null>(null);
-  const [error, setError] = useState<string | null>(null);
+  const queryClient = useQueryClient();
   const [search, setSearch] = useState('');
   const [selected, setSelected] = useState<string | null>(null);
 
-  useEffect(() => {
-    listBrands()
-      .then(setBrands)
-      .catch((e: unknown) => setError(extractProblemMessage(e)));
-  }, []);
+  const { data, error: queryError } = useQuery({
+    queryKey: qk.brands,
+    queryFn: listBrands,
+  });
+  const brands = data ?? null;
+  const error = queryError ? extractProblemMessage(queryError) : null;
 
   if (selected) {
     return (
@@ -50,7 +52,7 @@ export default function Brands({ onBack }: BrandsProps) {
         onPatched={(b) => {
           // Update the cached list in-place so the locked indicator
           // refreshes without a roundtrip.
-          setBrands((prev) =>
+          queryClient.setQueryData(qk.brands, (prev: BackendBrand[] | undefined) =>
             prev ? prev.map((x) => (x.brand_id === b.brand_id ? b : x)) : prev,
           );
         }}
@@ -167,55 +169,31 @@ function BrandDetail({
   onBack: () => void;
   onPatched: (b: BackendBrand) => void;
 }) {
-  const [brand, setBrand] = useState<BackendBrand | null>(null);
-  const [assets, setAssets] = useState<BackendBrandAsset[] | null>(null);
-  const [error, setError] = useState<string | null>(null);
-  const [busy, setBusy] = useState<string | null>(null);
+  const queryClient = useQueryClient();
   const [banner, setBanner] = useState<{ tone: 'ok' | 'err'; text: string } | null>(null);
-  const [uploading, setUploading] = useState(false);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
 
-  const loadAll = () => {
-    Promise.all([getBrand(brandId), listBrandAssets(brandId)])
-      .then(([b, a]) => {
-        setBrand(b);
-        setAssets(a);
-      })
-      .catch((e: unknown) => setError(extractProblemMessage(e)));
-  };
+  const { data, error: queryError } = useQuery({
+    queryKey: qk.brand(brandId),
+    queryFn: () =>
+      Promise.all([getBrand(brandId), listBrandAssets(brandId)]).then(([brand, assets]) => ({
+        brand,
+        assets,
+      })),
+  });
+  const brand = data?.brand ?? null;
+  const assets = data?.assets ?? null;
+  const error = queryError ? extractProblemMessage(queryError) : null;
 
-  useEffect(loadAll, [brandId]);
-
-  const handleUpload = async (file: File) => {
-    if (!brand) return;
-    setUploading(true);
-    setBanner(null);
-    try {
-      await uploadBrandAsset(brand.brand_id, file);
-      // Re-fetch both brand (preferred_asset_id + user_chose_at) and assets.
-      const [b, a] = await Promise.all([getBrand(brand.brand_id), listBrandAssets(brand.brand_id)]);
-      setBrand(b);
-      setAssets(a);
-      onPatched(b);
-      setBanner({
-        tone: 'ok',
-        text: `Uploaded "${file.name}" — set as preferred and locked from re-extract overrides.`,
-      });
-    } catch (e: unknown) {
-      setBanner({ tone: 'err', text: extractProblemMessage(e) });
-    } finally {
-      setUploading(false);
-      if (fileInputRef.current) fileInputRef.current.value = '';
-    }
-  };
-
-  const setPreferred = async (assetId: string | null) => {
-    if (!brand) return;
-    setBusy(assetId ?? 'clear');
-    setBanner(null);
-    try {
-      const updated = await patchBrand(brand.brand_id, { preferred_asset_id: assetId });
-      setBrand(updated);
+  const preferredMut = useMutation({
+    mutationFn: (assetId: string | null) =>
+      patchBrand(brandId, { preferred_asset_id: assetId }),
+    onSuccess: (updated, assetId) => {
+      queryClient.setQueryData(
+        qk.brand(brandId),
+        (old: { brand: BackendBrand; assets: BackendBrandAsset[] } | undefined) =>
+          old ? { ...old, brand: updated } : old,
+      );
       onPatched(updated);
       setBanner({
         tone: 'ok',
@@ -223,11 +201,44 @@ function BrandDetail({
           ? 'Preferred asset set — locked from re-extract overrides.'
           : 'Preferred asset cleared.',
       });
-    } catch (e: unknown) {
-      setBanner({ tone: 'err', text: extractProblemMessage(e) });
-    } finally {
-      setBusy(null);
-    }
+    },
+    onError: (e: unknown) => setBanner({ tone: 'err', text: extractProblemMessage(e) }),
+  });
+  // `busy` held the assetId in flight (or 'clear' when clearing) so the
+  // matching row could show its spinner. Mirror that from the mutation's
+  // in-flight variables.
+  const busy = preferredMut.isPending ? (preferredMut.variables ?? 'clear') : null;
+
+  const uploadMut = useMutation({
+    mutationFn: async (file: File) => {
+      await uploadBrandAsset(brandId, file);
+      // Re-fetch both brand (preferred_asset_id + user_chose_at) and assets.
+      const [b, a] = await Promise.all([getBrand(brandId), listBrandAssets(brandId)]);
+      return { brand: b, assets: a };
+    },
+    onSuccess: ({ brand: b, assets: a }, file) => {
+      queryClient.setQueryData(qk.brand(brandId), { brand: b, assets: a });
+      onPatched(b);
+      setBanner({
+        tone: 'ok',
+        text: `Uploaded "${file.name}" — set as preferred and locked from re-extract overrides.`,
+      });
+    },
+    onError: (e: unknown) => setBanner({ tone: 'err', text: extractProblemMessage(e) }),
+    onSettled: () => {
+      if (fileInputRef.current) fileInputRef.current.value = '';
+    },
+  });
+  const uploading = uploadMut.isPending;
+
+  const handleUpload = (file: File) => {
+    setBanner(null);
+    uploadMut.mutate(file);
+  };
+
+  const setPreferred = (assetId: string | null) => {
+    setBanner(null);
+    preferredMut.mutate(assetId);
   };
 
   if (error) {
@@ -324,7 +335,7 @@ function BrandDetail({
             className="hidden"
             onChange={(e) => {
               const f = e.target.files?.[0];
-              if (f) void handleUpload(f);
+              if (f) handleUpload(f);
             }}
           />
         </div>

--- a/src/components/Products.tsx
+++ b/src/components/Products.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
+import React, { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { ChevronRight, ArrowLeft, RotateCw, GitMerge } from 'lucide-react';
 import { qk } from '../lib/queryKeys';
 import {
@@ -187,88 +187,74 @@ function ProductDetail({
   onBack: () => void;
   onMerged: () => void;
 }) {
-  const [product, setProduct] = useState<BackendProduct | null>(null);
-  const [owned, setOwned] = useState<BackendOwnedItem[] | null>(null);
-  const [error, setError] = useState<string | null>(null);
-  const [customName, setCustomName] = useState('');
-  const [notes, setNotes] = useState('');
-  const [editDirty, setEditDirty] = useState(false);
-  const [saving, setSaving] = useState(false);
+  const queryClient = useQueryClient();
   const [mergeTarget, setMergeTarget] = useState('');
-  const [mergeBusy, setMergeBusy] = useState(false);
-  const [recomputing, setRecomputing] = useState(false);
   const [banner, setBanner] = useState<{ tone: 'ok' | 'err'; text: string } | null>(null);
 
-  const loadAll = () => {
-    Promise.all([getProduct(productId), listOwnedItems({ product_id: productId, limit: 50 })])
-      .then(([p, o]) => {
-        setProduct(p);
-        setOwned(o);
-        setCustomName(p.custom_name ?? '');
-        setNotes(p.notes ?? '');
-        setEditDirty(false);
-      })
-      .catch((e: unknown) => setError(extractProblemMessage(e)));
-  };
+  const { data, error: queryError } = useQuery({
+    queryKey: qk.product(productId),
+    queryFn: () =>
+      Promise.all([
+        getProduct(productId),
+        listOwnedItems({ product_id: productId, limit: 50 }),
+      ]).then(([product, owned]) => ({ product, owned })),
+  });
+  const product = data?.product ?? null;
+  const owned = data?.owned ?? null;
+  const error = queryError ? extractProblemMessage(queryError) : null;
 
-  useEffect(loadAll, [productId]);
-
-  const onSave = async () => {
-    if (!product) return;
-    setSaving(true);
-    setBanner(null);
-    try {
-      const patch: { custom_name?: string | null; notes?: string | null } = {};
-      if (customName !== (product.custom_name ?? '')) {
-        patch.custom_name = customName.trim() === '' ? null : customName.trim();
-      }
-      if (notes !== (product.notes ?? '')) {
-        patch.notes = notes.trim() === '' ? null : notes.trim();
-      }
-      const updated = await patchProduct(product.id, patch);
-      setProduct(updated);
-      setEditDirty(false);
-      setBanner({ tone: 'ok', text: 'Saved.' });
-    } catch (e: unknown) {
-      setBanner({ tone: 'err', text: extractProblemMessage(e) });
-    } finally {
-      setSaving(false);
-    }
-  };
-
-  const onMerge = async () => {
-    const target = mergeTarget.trim();
-    if (!target || !product) return;
-    setMergeBusy(true);
-    setBanner(null);
-    try {
-      const r = await mergeProductInto(product.id, target);
+  const mergeMut = useMutation({
+    mutationFn: (target: string) => mergeProductInto(productId, target),
+    onSuccess: (r) => {
       setBanner({
         tone: 'ok',
         text: `Merged → moved ${r.moved_transaction_items} line items, ${r.moved_owned_items} owned items.`,
       });
       setMergeTarget('');
       setTimeout(onMerged, 800);
-    } catch (e: unknown) {
-      setBanner({ tone: 'err', text: extractProblemMessage(e) });
-    } finally {
-      setMergeBusy(false);
-    }
+    },
+    onError: (e: unknown) => setBanner({ tone: 'err', text: extractProblemMessage(e) }),
+  });
+  const mergeBusy = mergeMut.isPending;
+
+  const recomputeMut = useMutation({
+    mutationFn: () => recomputeProduct(productId),
+    onSuccess: (r) => {
+      queryClient.setQueryData(
+        qk.product(productId),
+        (old: { product: BackendProduct; owned: BackendOwnedItem[] } | undefined) =>
+          old
+            ? {
+                ...old,
+                product: {
+                  ...old.product,
+                  purchase_count: r.purchase_count,
+                  total_spent_minor: r.total_spent_minor,
+                  first_purchased_on: r.first_purchased_on,
+                  last_purchased_on: r.last_purchased_on,
+                },
+              }
+            : old,
+      );
+      setBanner({
+        tone: 'ok',
+        text: `Recomputed: ${r.purchase_count}× / ${formatMinor(r.total_spent_minor)}.`,
+      });
+    },
+    onError: (e: unknown) => setBanner({ tone: 'err', text: extractProblemMessage(e) }),
+  });
+  const recomputing = recomputeMut.isPending;
+
+  const onMerge = () => {
+    const target = mergeTarget.trim();
+    if (!target) return;
+    setBanner(null);
+    mergeMut.mutate(target);
   };
 
-  const onRecompute = async () => {
-    if (!product) return;
-    setRecomputing(true);
+  const onRecompute = () => {
     setBanner(null);
-    try {
-      const r = await recomputeProduct(product.id);
-      setProduct({ ...product, purchase_count: r.purchase_count, total_spent_minor: r.total_spent_minor, first_purchased_on: r.first_purchased_on, last_purchased_on: r.last_purchased_on });
-      setBanner({ tone: 'ok', text: `Recomputed: ${r.purchase_count}× / ${formatMinor(r.total_spent_minor)}.` });
-    } catch (e: unknown) {
-      setBanner({ tone: 'err', text: extractProblemMessage(e) });
-    } finally {
-      setRecomputing(false);
-    }
+    recomputeMut.mutate();
   };
 
   if (error) {
@@ -332,40 +318,20 @@ function ProductDetail({
         </div>
       )}
 
-      <Section title="Customize">
-        <label className="block text-[11px] tracking-[0.14em] uppercase text-[var(--color-ink-muted)]">
-          Custom name (your label)
-        </label>
-        <input
-          type="text"
-          value={customName}
-          onChange={(e) => {
-            setCustomName(e.target.value);
-            setEditDirty(true);
-          }}
-          placeholder={product.canonical_name}
-          className="mt-1 w-full px-4 py-2 rounded-[14px] border border-[var(--color-rule)] bg-[var(--color-surface)] text-sm focus:outline-none focus:border-[var(--color-ink)]"
-        />
-        <label className="block text-[11px] tracking-[0.14em] uppercase text-[var(--color-ink-muted)] mt-3">
-          Notes
-        </label>
-        <textarea
-          value={notes}
-          onChange={(e) => {
-            setNotes(e.target.value);
-            setEditDirty(true);
-          }}
-          rows={2}
-          className="mt-1 w-full px-4 py-2 rounded-[14px] border border-[var(--color-rule)] bg-[var(--color-surface)] text-sm focus:outline-none focus:border-[var(--color-ink)]"
-        />
-        <div className="mt-3 flex gap-2">
-          <button
-            onClick={onSave}
-            disabled={!editDirty || saving}
-            className="px-4 py-2 rounded-full bg-[var(--color-ink)] text-[var(--color-paper)] text-sm font-medium disabled:opacity-40"
-          >
-            {saving ? 'Saving…' : 'Save'}
-          </button>
+      <ProductEditForm
+        key={product.id}
+        product={product}
+        onSaved={(updated) => {
+          queryClient.setQueryData(
+            qk.product(productId),
+            (old: { product: BackendProduct; owned: BackendOwnedItem[] } | undefined) =>
+              old ? { ...old, product: updated } : old,
+          );
+          setBanner({ tone: 'ok', text: 'Saved.' });
+        }}
+        onError={(text) => setBanner({ tone: 'err', text })}
+        onSaveStart={() => setBanner(null)}
+        recomputeSlot={
           <button
             onClick={onRecompute}
             disabled={recomputing}
@@ -373,8 +339,8 @@ function ProductDetail({
           >
             <RotateCw size={14} /> {recomputing ? 'Recomputing…' : 'Recompute stats'}
           </button>
-        </div>
-      </Section>
+        }
+      />
 
       <Section title={`Owned items (${owned?.length ?? 0})`}>
         {owned === null && (
@@ -444,6 +410,94 @@ function ProductDetail({
         </div>
       </Section>
     </div>
+  );
+}
+
+/**
+ * Editable name/notes form for a product. Split out of ProductDetail so its
+ * `customName` / `notes` / `editDirty` state can be seeded directly from the
+ * `product` prop via lazy `useState` initializers — no seed `useEffect`
+ * (the repo's `react-hooks/set-state-in-effect` lint rule forbids setState
+ * in effects). Re-mounting via `key={product.id}` in the parent re-runs the
+ * initializers whenever the product changes.
+ */
+function ProductEditForm({
+  product,
+  onSaved,
+  onError,
+  onSaveStart,
+  recomputeSlot,
+}: {
+  product: BackendProduct;
+  onSaved: (updated: BackendProduct) => void;
+  onError: (text: string) => void;
+  onSaveStart: () => void;
+  recomputeSlot: React.ReactNode;
+}) {
+  const [customName, setCustomName] = useState(() => product.custom_name ?? '');
+  const [notes, setNotes] = useState(() => product.notes ?? '');
+  const [editDirty, setEditDirty] = useState(false);
+
+  const saveMut = useMutation({
+    mutationFn: () => {
+      const patch: { custom_name?: string | null; notes?: string | null } = {};
+      if (customName !== (product.custom_name ?? '')) {
+        patch.custom_name = customName.trim() === '' ? null : customName.trim();
+      }
+      if (notes !== (product.notes ?? '')) {
+        patch.notes = notes.trim() === '' ? null : notes.trim();
+      }
+      return patchProduct(product.id, patch);
+    },
+    onSuccess: (updated) => {
+      setEditDirty(false);
+      onSaved(updated);
+    },
+    onError: (e: unknown) => onError(extractProblemMessage(e)),
+  });
+  const saving = saveMut.isPending;
+
+  return (
+    <Section title="Customize">
+      <label className="block text-[11px] tracking-[0.14em] uppercase text-[var(--color-ink-muted)]">
+        Custom name (your label)
+      </label>
+      <input
+        type="text"
+        value={customName}
+        onChange={(e) => {
+          setCustomName(e.target.value);
+          setEditDirty(true);
+        }}
+        placeholder={product.canonical_name}
+        className="mt-1 w-full px-4 py-2 rounded-[14px] border border-[var(--color-rule)] bg-[var(--color-surface)] text-sm focus:outline-none focus:border-[var(--color-ink)]"
+      />
+      <label className="block text-[11px] tracking-[0.14em] uppercase text-[var(--color-ink-muted)] mt-3">
+        Notes
+      </label>
+      <textarea
+        value={notes}
+        onChange={(e) => {
+          setNotes(e.target.value);
+          setEditDirty(true);
+        }}
+        rows={2}
+        className="mt-1 w-full px-4 py-2 rounded-[14px] border border-[var(--color-rule)] bg-[var(--color-surface)] text-sm focus:outline-none focus:border-[var(--color-ink)]"
+      />
+      <div className="mt-3 flex gap-2">
+        <button
+          onClick={() => {
+            onSaveStart();
+            saveMut.mutate();
+          }}
+          disabled={!editDirty || saving}
+          className="px-4 py-2 rounded-full bg-[var(--color-ink)] text-[var(--color-paper)] text-sm font-medium disabled:opacity-40"
+        >
+          {saving ? 'Saving…' : 'Save'}
+        </button>
+        {recomputeSlot}
+      </div>
+    </Section>
   );
 }
 


### PR DESCRIPTION
Phase 2 (#98). Brands (list + inline detail) and Products·ProductDetail migrated: reads→useQuery, writes→useMutation. ProductDetail's editable form extracted into a `key={product.id}` child with lazy-init useState (no seed effect → lint stays 0). Verified 6/6 via frontend-test-runner on the local DB: reads render, set-preferred/save/recompute mutations work with banners + live updates, form re-inits per product. Build+tsc+lint(0). Part of #98.