### PR TITLE
feat(query): ReceiptDetail + dialogs → useQuery/useMutation [Phase2 E]

### DIFF
--- a/src/components/DeleteReceiptDialog.tsx
+++ b/src/components/DeleteReceiptDialog.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useMutation } from '@tanstack/react-query';
 import { X, Loader2, AlertCircle, AlertTriangle, Trash2, FileMinus, Flame, ArrowLeft } from 'lucide-react';
 import { motion, AnimatePresence } from 'motion/react';
 import { cn } from '../lib/utils';
@@ -127,9 +128,8 @@ export default function DeleteReceiptDialog({
     return false;
   };
 
-  const runDelete = async (chosen: Mode) => {
-    setState({ kind: 'working' });
-    try {
+  const deleteMut = useMutation({
+    mutationFn: async (chosen: Mode) => {
       switch (chosen) {
         case 'soft':
           if (!documentId) throw new Error('No document linked');
@@ -152,8 +152,10 @@ export default function DeleteReceiptDialog({
           await hardDeleteTransaction(transactionId, transactionEtag);
           break;
       }
-      onDeleted();
-    } catch (err: unknown) {
+    },
+    onMutate: () => setState({ kind: 'working' }),
+    onSuccess: () => onDeleted(),
+    onError: (err: unknown) => {
       const problem = parseProblem(err);
       const handled = handleProblem(problem);
       if (!handled) {
@@ -162,12 +164,12 @@ export default function DeleteReceiptDialog({
           message: err instanceof Error ? err.message : String(err),
         });
       }
-    }
-  };
+    },
+  });
 
   const handleConfirm = () => {
     if (mode === 'cascade-hard' && !confirmHardOk) return;
-    void runDelete(mode);
+    deleteMut.mutate(mode);
   };
 
   const renderOptions = () => (
@@ -323,7 +325,7 @@ export default function DeleteReceiptDialog({
         onClick={() => {
           setMode('cascade-hard');
           setConfirmHardOk(true);
-          void runDelete('cascade-hard');
+          deleteMut.mutate('cascade-hard');
         }}
         className="w-full py-3 rounded-xl bg-error text-on-error font-bold hover:scale-[1.02] active:scale-95 transition-all"
       >
@@ -337,7 +339,7 @@ export default function DeleteReceiptDialog({
     if (state.kind === 'block-cannot-delete-reconciled') {
       // The receipt's own transaction was unreconciled — retry the
       // user's last chosen mode.
-      void runDelete(mode);
+      deleteMut.mutate(mode);
       return;
     }
     if (state.kind === 'block-cascade-reconciled') {
@@ -347,7 +349,7 @@ export default function DeleteReceiptDialog({
         (x) => x !== unreconcileTarget,
       );
       if (remaining.length === 0) {
-        void runDelete(mode);
+        deleteMut.mutate(mode);
       } else {
         setState({ ...state, reconciledTxnIds: remaining });
       }

--- a/src/components/EditReceiptModal.tsx
+++ b/src/components/EditReceiptModal.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useMutation } from '@tanstack/react-query';
 import { X, Save, Loader2, AlertCircle, RefreshCw } from 'lucide-react';
 import { motion, AnimatePresence } from 'motion/react';
 import {
@@ -22,7 +23,7 @@ interface EditReceiptModalProps {
   onStale: () => void;
 }
 
-type SaveState = 'idle' | 'saving' | 'error' | 'stale';
+type SaveState = 'idle' | 'error' | 'stale';
 
 export default function EditReceiptModal({
   isOpen,
@@ -48,13 +49,35 @@ export default function EditReceiptModal({
     }
   }, [isOpen, receipt.id, receipt.payee, receipt.narration, receipt.occurred_on]);
 
-  const handleSave = async () => {
+  const saveMut = useMutation({
+    mutationFn: (patch: UpdateTransactionRequest) =>
+      patchTransaction(receipt.id, patch, receipt.etag!),
+    onSuccess: ({ data, etag }) => {
+      onUpdated(data, etag);
+      onClose();
+    },
+    onError: (err: unknown) => {
+      const problem = (err as Error & { problem?: { status?: number } })?.problem;
+      const status = problem?.status ?? 0;
+      // 412 → ETag stale; 409 → some other conflict. Both mean "reload".
+      if (status === 412 || status === 409 || /412|409/.test(extractProblemMessage(err))) {
+        setState('stale');
+        setError(
+          'This receipt was modified elsewhere. Reload to see the latest version, then try again.',
+        );
+      } else {
+        setState('error');
+        setError(extractProblemMessage(err));
+      }
+    },
+  });
+
+  const handleSave = () => {
     if (!receipt.etag) {
       setState('error');
       setError('No ETag available — reload the receipt and try again.');
       return;
     }
-    setState('saving');
     setError(null);
 
     // Only send fields that actually changed; PATCH is merge-patch.
@@ -69,24 +92,8 @@ export default function EditReceiptModal({
       return;
     }
 
-    try {
-      const { data, etag } = await patchTransaction(receipt.id, patch, receipt.etag);
-      onUpdated(data, etag);
-      onClose();
-    } catch (err: unknown) {
-      const problem = (err as Error & { problem?: { status?: number } })?.problem;
-      const status = problem?.status ?? 0;
-      // 412 → ETag stale; 409 → some other conflict. Both mean "reload".
-      if (status === 412 || status === 409 || /412|409/.test(extractProblemMessage(err))) {
-        setState('stale');
-        setError(
-          'This receipt was modified elsewhere. Reload to see the latest version, then try again.',
-        );
-      } else {
-        setState('error');
-        setError(extractProblemMessage(err));
-      }
-    }
+    setState('idle');
+    saveMut.mutate(patch);
   };
 
   return (
@@ -183,15 +190,15 @@ export default function EditReceiptModal({
                 ) : (
                   <button
                     onClick={handleSave}
-                    disabled={state === 'saving'}
+                    disabled={saveMut.isPending}
                     className={cn(
                       'w-full py-4 rounded-xl font-bold text-lg transition-all flex items-center justify-center gap-2',
-                      state === 'saving'
+                      saveMut.isPending
                         ? 'bg-primary/50 text-on-primary cursor-wait'
                         : 'bg-primary text-on-primary hover:scale-[1.02] active:scale-95 shadow-lg shadow-primary/20',
                     )}
                   >
-                    {state === 'saving' ? (
+                    {saveMut.isPending ? (
                       <>
                         <Loader2 className="animate-spin" size={20} />
                         Saving...

--- a/src/components/ReceiptDetail.tsx
+++ b/src/components/ReceiptDetail.tsx
@@ -25,6 +25,8 @@ import EditReceiptModal from './EditReceiptModal';
 import ConfirmActionDialog from './ConfirmActionDialog';
 import DeleteReceiptDialog from './DeleteReceiptDialog';
 import DeletedBadge from './DeletedBadge';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { qk } from '../lib/queryKeys';
 import { removeTombstone } from '../lib/tombstones';
 
 interface ReceiptDetailProps {
@@ -58,11 +60,8 @@ function md<T = unknown>(meta: Metadata | undefined, key: string): T | undefined
  * Data source: fetchReceiptDetail → real backend. No mocks, no fixtures.
  */
 export default function ReceiptDetail({ receiptId, onBack, onAfterMutation }: ReceiptDetailProps) {
-  const [receipt, setReceipt] = useState<ReceiptView | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const queryClient = useQueryClient();
   const [activeDialog, setActiveDialog] = useState<'edit' | 'void' | 'delete' | null>(null);
-  const [restoring, setRestoring] = useState(false);
   const [restoreError, setRestoreError] = useState<string | null>(null);
   // Re-extract state machine. `idle` armed; `pending` (~30-60s — the
   // agent re-OCRs the image); `success` shows `changed_keys` toast;
@@ -75,63 +74,85 @@ export default function ReceiptDetail({ receiptId, onBack, onAfterMutation }: Re
     | { kind: 'error'; message: string }
   >({ kind: 'idle' });
 
-  const loadReceipt = () => {
-    fetchReceiptDetail(receiptId)
-      .then(setReceipt)
-      .catch((e: unknown) => setError(extractProblemMessage(e)))
-      .finally(() => setLoading(false));
-  };
+  // The receipt detail (a Transaction + its documents) with its ETag embedded
+  // in the view. Auto-polls every 5s while the extractor is still working
+  // (status draft/error) via a conditional refetchInterval — replaces the old
+  // setInterval effect.
+  const {
+    data: receipt = null,
+    isLoading: loading,
+    error: queryError,
+  } = useQuery({
+    queryKey: qk.receipt(receiptId),
+    queryFn: () => fetchReceiptDetail(receiptId),
+    refetchInterval: (query) => {
+      const s = query.state.data?.status;
+      return s === 'draft' || s === 'error' ? 5000 : false;
+    },
+  });
+  const error = queryError ? extractProblemMessage(queryError) : null;
 
+  const invalidateReceipt = () =>
+    queryClient.invalidateQueries({ queryKey: qk.receipt(receiptId) });
+
+  // ETag write-back invariant: a PATCH/void response carries a FRESH ETag.
+  // Write the updated view straight into the cache so a subsequent edit sends
+  // the current If-Match. Invalidate-and-refetch would leave a stale-etag
+  // window in which a fast second edit 412s — so this is setQueryData, not
+  // invalidate. (EditReceiptModal calls this via onUpdated on PATCH success.)
   const handleUpdated = (txn: BackendTransaction, etag: string | null) => {
-    setReceipt(toReceiptView(txn, etag));
+    queryClient.setQueryData(qk.receipt(receiptId), toReceiptView(txn, etag));
   };
 
-  const handleVoidConfirm = async (reason: string) => {
-    if (!receipt?.etag) {
-      const fresh = await getTransaction(receipt!.id);
-      if (!fresh.etag) throw new Error('No ETag — reload and retry.');
-      await voidTransaction(receipt!.id, reason, fresh.etag);
-    } else {
-      await voidTransaction(receipt.id, reason, receipt.etag);
-    }
-    setActiveDialog(null);
-    loadReceipt();
-    onAfterMutation?.();
-  };
+  const voidMut = useMutation({
+    mutationFn: async (reason: string) => {
+      // Defensive: if the cached view lacks an etag, re-fetch a fresh one.
+      let etag = receipt?.etag ?? null;
+      if (!etag) {
+        const fresh = await getTransaction(receipt!.id);
+        if (!fresh.etag) throw new Error('No ETag — reload and retry.');
+        etag = fresh.etag;
+      }
+      return voidTransaction(receipt!.id, reason, etag);
+    },
+    onSuccess: () => {
+      setActiveDialog(null);
+      invalidateReceipt();
+      onAfterMutation?.();
+    },
+  });
 
   const handleDeleted = () => {
     setActiveDialog(null);
+    // A delete soft-tombstones the document; refresh the tombstone list too.
+    queryClient.invalidateQueries({ queryKey: qk.tombstones });
     onAfterMutation?.();
     onBack();
   };
 
-  const handleRestore = async () => {
-    if (!receipt?.documentId) return;
-    setRestoring(true);
-    setRestoreError(null);
-    try {
-      await restoreDocument(receipt.documentId);
-      removeTombstone(receipt.documentId);
+  const restoreMut = useMutation({
+    mutationFn: () => restoreDocument(receipt!.documentId!),
+    onSuccess: () => {
+      removeTombstone(receipt!.documentId!);
+      invalidateReceipt();
+      queryClient.invalidateQueries({ queryKey: qk.tombstones });
       onAfterMutation?.();
-      loadReceipt();
-    } catch (err: unknown) {
-      setRestoreError(extractProblemMessage(err));
-    } finally {
-      setRestoring(false);
-    }
+    },
+    onError: (err: unknown) => setRestoreError(extractProblemMessage(err)),
+  });
+  const handleRestore = () => {
+    if (!receipt?.documentId) return;
+    setRestoreError(null);
+    restoreMut.mutate();
   };
 
-  const handleReExtract = async () => {
-    if (!receipt?.documentId) return;
-    if (reExtractState.kind === 'pending') return;
-    setReExtractState({ kind: 'pending' });
-    try {
-      const result: ReExtractDocumentResult = await postReExtractDocument(
-        receipt.documentId,
-      );
-      // Reload the transaction so the UI reflects any field changes the
+  const reExtractMut = useMutation({
+    mutationFn: () => postReExtractDocument(receipt!.documentId!),
+    onMutate: () => setReExtractState({ kind: 'pending' }),
+    onSuccess: (result: ReExtractDocumentResult) => {
+      // Refresh the transaction so the UI reflects any field changes the
       // agent committed (payee, occurred_on, occurred_at, etc).
-      loadReceipt();
+      invalidateReceipt();
       onAfterMutation?.();
       setReExtractState({
         kind: 'success',
@@ -139,31 +160,16 @@ export default function ReceiptDetail({ receiptId, onBack, onAfterMutation }: Re
         ocrChanged: result.ocr_text_changed,
       });
       setTimeout(() => {
-        setReExtractState((s) =>
-          s.kind === 'success' ? { kind: 'idle' } : s,
-        );
+        setReExtractState((s) => (s.kind === 'success' ? { kind: 'idle' } : s));
       }, 6000);
-    } catch (err: unknown) {
-      setReExtractState({
-        kind: 'error',
-        message: extractProblemMessage(err),
-      });
-    }
+    },
+    onError: (err: unknown) =>
+      setReExtractState({ kind: 'error', message: extractProblemMessage(err) }),
+  });
+  const handleReExtract = () => {
+    if (!receipt?.documentId || reExtractMut.isPending) return;
+    reExtractMut.mutate();
   };
-
-  useEffect(() => {
-    loadReceipt();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [receiptId]);
-
-  // Auto-poll while extractor is still working.
-  useEffect(() => {
-    if (!receipt) return;
-    if (receipt.status !== 'draft' && receipt.status !== 'error') return;
-    const interval = setInterval(loadReceipt, 5000);
-    return () => clearInterval(interval);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [receipt?.status]);
 
   if (loading) {
     return (
@@ -252,7 +258,7 @@ export default function ReceiptDetail({ receiptId, onBack, onAfterMutation }: Re
         canEdit={canEdit}
         canVoid={canVoid}
         canDelete={canDelete}
-        restoring={restoring}
+        restoring={restoreMut.isPending}
         onEdit={() => setActiveDialog('edit')}
         onVoid={() => setActiveDialog('void')}
         onDelete={() => setActiveDialog('delete')}
@@ -390,7 +396,7 @@ export default function ReceiptDetail({ receiptId, onBack, onAfterMutation }: Re
         onClose={() => setActiveDialog(null)}
         receipt={receipt}
         onUpdated={handleUpdated}
-        onStale={loadReceipt}
+        onStale={invalidateReceipt}
       />
 
       <ConfirmActionDialog
@@ -412,7 +418,7 @@ export default function ReceiptDetail({ receiptId, onBack, onAfterMutation }: Re
         destructive
         requireReason
         reasonPlaceholder="Why are you voiding this? (optional)"
-        onConfirm={handleVoidConfirm}
+        onConfirm={(reason) => voidMut.mutateAsync(reason).then(() => undefined)}
       />
 
       <DeleteReceiptDialog

--- a/src/components/UnreconcileDialog.tsx
+++ b/src/components/UnreconcileDialog.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useMutation } from '@tanstack/react-query';
 import ConfirmActionDialog from './ConfirmActionDialog';
 import { getTransaction, unreconcileTransaction } from '../lib/api';
 
@@ -20,17 +21,22 @@ export default function UnreconcileDialog({
   transactionId,
   onUnreconciled,
 }: UnreconcileDialogProps) {
-  const handleConfirm = async (reason: string) => {
-    if (!transactionId) throw new Error('No transaction selected');
-    const { etag } = await getTransaction(transactionId);
-    if (!etag) throw new Error('Missing ETag — refresh and retry.');
-    await unreconcileTransaction(
-      transactionId,
-      reason.trim() ? reason.trim() : undefined,
-      etag,
-    );
-    onUnreconciled();
-  };
+  const unreconcileMut = useMutation({
+    mutationFn: async (reason: string) => {
+      if (!transactionId) throw new Error('No transaction selected');
+      const { etag } = await getTransaction(transactionId);
+      if (!etag) throw new Error('Missing ETag — refresh and retry.');
+      return unreconcileTransaction(
+        transactionId,
+        reason.trim() ? reason.trim() : undefined,
+        etag,
+      );
+    },
+    onSuccess: () => onUnreconciled(),
+  });
+  // ConfirmActionDialog awaits this and manages working/error UI; a rejection
+  // surfaces there. Coerce to Promise<void> for its onConfirm contract.
+  const handleConfirm = (reason: string) => unreconcileMut.mutateAsync(reason).then(() => undefined);
 
   return (
     <ConfirmActionDialog


### PR DESCRIPTION
Phase 2 (#98), the core receipt screen. ReceiptDetail → `useQuery(qk.receipt(id))` + conditional `refetchInterval` (poll only while draft/error). void/restore/re-extract + shared dialogs (EditReceiptModal, UnreconcileDialog, DeleteReceiptDialog) → useMutation.

**ETag write-back invariant**: `handleUpdated` writes the fresh PATCH view+etag into the cache via `setQueryData` (not invalidate-only) so rapid edits don't 412.

Verified 7/7 via frontend-test-runner (local): **3 rapid consecutive edits all PATCH 200, version 7→10, zero 412s**; soft-delete→restore; re-extract starts; posted receipts don't poll; no errors. Build+tsc+lint(0). Part of #98.