### PR TITLE
feat(query): converge live-status trio on shared ['batch',id] [Phase2 F2]

### DIFF
--- a/src/components/ProcessingToast.tsx
+++ b/src/components/ProcessingToast.tsx
@@ -1,175 +1,45 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Loader2, CheckCircle, XCircle, Layers, X } from 'lucide-react';
 import { motion, AnimatePresence } from 'motion/react';
-import { getBatch, extractProblemMessage } from '../lib/api';
-import type { ProcessingJob } from './useProcessingJobs';
+import type { ProcessingItem, ProcessingJob } from './useProcessingJobs';
 
 /**
  * Receipt upload UX (floating toast variant).
  *
- * The old backend had per-image jobs queried via `GET /jobs/:id`. The
- * v1 backend uses *ingest batches* — a single upload creates a batch
- * with N ingests (we always use N=1 from the UI), and the batch
- * progresses through `pending → processing → extracted → reconciled`.
+ * Purely presentational now: it renders the projected {@link ProcessingItem}s
+ * that `useProcessingJobs` owns. The hook does all the work — polling each
+ * batch through the shared `['batch',id]` query cache, deriving terminal
+ * status, firing the ledger refresh once, and auto-dismissing. This toast and
+ * the inline `ProcessingCardList` are two views of that same `items` array, so
+ * there is a single poll per batch (the old per-component pollers are gone).
  *
- * We could SSE-subscribe via `subscribeToBatch(batchId, …)`, but for
- * minimum diff we keep polling: every 5s fetch the batch and watch for
- * `status=extracted` (or `reconciled`). On completion we extract the
- * first produced `transaction_id` to give callers a stable anchor.
- *
- * `ProcessingJob` now lives in ./useProcessingJobs.ts (the hook owns the
- * job shape so the inline `ProcessingCard` can share it); we re-export it
- * here so existing importers keep working.
+ * `ProcessingJob` lives in ./useProcessingJobs.ts; re-exported for importers.
  */
 export type { ProcessingJob };
 
-interface ToastState {
-  batchId: string;
-  ingestId: string;
-  filename: string;
-  status: 'processing' | 'done' | 'duplicate' | 'error';
-  transactionId?: string;
-  error?: string;
-}
-
 interface ProcessingToastProps {
-  jobs: ProcessingJob[];
+  /** Projected upload state from `useProcessingJobs` (shared with the inline
+   *  cards). The hook owns polling / terminal transitions / auto-dismiss. */
+  items: ProcessingItem[];
+  /** Manual dismiss (the X button). The hook auto-dismisses terminal items. */
   onJobDone: (batchId: string) => void;
-  onRefresh: () => void;
-  /** Tap a terminal toast to jump to the produced transaction. For a
-   *  dedup hit this is the *pre-existing* transaction the upload matched. */
+  /** Tap a terminal toast to jump to the produced transaction. For a dedup
+   *  hit this is the *pre-existing* transaction the upload matched. */
   onSelectTransaction?: (transactionId: string) => void;
 }
 
-// `useProcessingJobs` hook lives in ./useProcessingJobs.ts (separate
-// file so react-refresh/only-export-components stays happy).
-
-const TERMINAL_DONE = new Set(['extracted', 'reconciled']);
-const TERMINAL_ERROR = new Set(['failed', 'reconcile_error']);
-
-/** Per-batch status overrides. `jobs` (the source list) is the
- *  persistent record of outstanding uploads; this map stores in-memory
- *  terminal state + error text. Toasts are then *derived* from
- *  (jobs, statusMap, dismissed), which sidesteps the
- *  react-hooks/set-state-in-effect lint. */
-type StatusOverride = {
-  status: 'done' | 'duplicate' | 'error';
-  transactionId?: string;
-  error?: string;
-};
-
 export default function ProcessingToast({
-  jobs,
+  items,
   onJobDone,
-  onRefresh,
   onSelectTransaction,
 }: ProcessingToastProps) {
-  const [statusMap, setStatusMap] = useState<Record<string, StatusOverride>>({});
-  const [dismissed, setDismissed] = useState<Set<string>>(new Set());
-  // Keep the latest callbacks in a ref so the polling interval can use
-  // them without re-creating the timer every render.
-  const callbacksRef = useRef({ onJobDone, onRefresh });
-  useEffect(() => {
-    callbacksRef.current = { onJobDone, onRefresh };
-  }, [onJobDone, onRefresh]);
+  const dismiss = (batchId: string) => onJobDone(batchId);
 
-  const toasts: ToastState[] = useMemo(() => {
-    return jobs
-      .filter((j) => !dismissed.has(j.batchId))
-      .map<ToastState>((j) => {
-        const override = statusMap[j.batchId];
-        return {
-          batchId: j.batchId,
-          ingestId: j.ingestId,
-          filename: j.filename,
-          status: override?.status ?? 'processing',
-          transactionId: override?.transactionId,
-          error: override?.error,
-        };
-      });
-  }, [jobs, statusMap, dismissed]);
-
-  // Poll batches that are still in `processing` state.
-  useEffect(() => {
-    const active = jobs.filter(
-      (j) => !dismissed.has(j.batchId) && !statusMap[j.batchId],
-    );
-    if (active.length === 0) return;
-
-    let cancelled = false;
-    const interval = setInterval(async () => {
-      for (const job of active) {
-        if (cancelled) return;
-        try {
-          const batch = await getBatch(job.batchId);
-          if (TERMINAL_DONE.has(batch.status)) {
-            // Per-file outcome: dedup is decided by the *ingest item's*
-            // own status, not the batch's. A byte-identical re-upload is
-            // born terminal with `status='dedup'` and points at the
-            // pre-existing transaction — no new row was written, so we
-            // surface a neutral "already in your ledger" state and skip
-            // onRefresh (there's nothing new to fetch).
-            const item = batch.items.find((i) => i.id === job.ingestId);
-            const transactionId = item?.produced?.transaction_ids?.[0];
-            if (item?.status === 'dedup') {
-              setStatusMap((prev) => ({
-                ...prev,
-                [job.batchId]: { status: 'duplicate', transactionId },
-              }));
-              // Intentionally no onRefresh() — dedup adds no new data.
-              setTimeout(() => {
-                setDismissed((prev) => new Set(prev).add(job.batchId));
-                callbacksRef.current.onJobDone(job.batchId);
-              }, 5000);
-            } else {
-              setStatusMap((prev) => ({
-                ...prev,
-                [job.batchId]: { status: 'done', transactionId },
-              }));
-              callbacksRef.current.onRefresh();
-              setTimeout(() => {
-                setDismissed((prev) => new Set(prev).add(job.batchId));
-                callbacksRef.current.onJobDone(job.batchId);
-              }, 3000);
-            }
-          } else if (TERMINAL_ERROR.has(batch.status)) {
-            const ingestErr = batch.items.find((i) => i.id === job.ingestId)?.error ?? null;
-            setStatusMap((prev) => ({
-              ...prev,
-              [job.batchId]: {
-                status: 'error',
-                error: ingestErr ?? `Batch ${batch.status}`,
-              },
-            }));
-            setTimeout(() => {
-              setDismissed((prev) => new Set(prev).add(job.batchId));
-              callbacksRef.current.onJobDone(job.batchId);
-            }, 5000);
-          }
-        } catch (err: unknown) {
-          // Ignore individual poll failures; next tick retries.
-          console.debug('batch poll error', job.batchId, extractProblemMessage(err));
-        }
-      }
-    }, 5000);
-
-    return () => {
-      cancelled = true;
-      clearInterval(interval);
-    };
-  }, [jobs, dismissed, statusMap]);
-
-  const dismiss = (batchId: string) => {
-    setDismissed((prev) => new Set(prev).add(batchId));
-    onJobDone(batchId);
-  };
-
-  if (toasts.length === 0) return null;
+  if (items.length === 0) return null;
 
   return (
     <div className="fixed bottom-6 right-6 z-50 flex flex-col gap-3">
       <AnimatePresence>
-        {toasts.map((toast) => {
+        {items.map((toast) => {
           // A terminal toast that produced a transaction is tappable —
           // jump to that transaction. For dedup this is the pre-existing
           // row the upload matched, so the user can confirm it's already

--- a/src/components/useProcessingJobs.ts
+++ b/src/components/useProcessingJobs.ts
@@ -1,5 +1,11 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { getBatch, extractProblemMessage } from '../lib/api';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useQueries } from '@tanstack/react-query';
+import { getBatch } from '../lib/api';
+import { qk } from '../lib/queryKeys';
+
+/** Stable empty reference so the common (no-uploads) case never churns the
+ *  context value / consumers. */
+const EMPTY_ITEMS: ProcessingItem[] = [];
 
 const STORAGE_KEY = 'receipt-processing-batches-v1';
 const LEGACY_STORAGE_KEY = 'receipt-processing-jobs';
@@ -26,16 +32,6 @@ export interface ProcessingItem {
   transactionId?: string;
   error?: string;
 }
-
-/** Per-batch terminal override. `jobs` is the persistent record of
- *  outstanding uploads; this map layers terminal state on top, so items
- *  stay *derived* from (jobs, statusMap, dismissed) — sidestepping the
- *  react-hooks/set-state-in-effect lint. */
-type StatusOverride = {
-  status: 'done' | 'duplicate' | 'error';
-  transactionId?: string;
-  error?: string;
-};
 
 const TERMINAL_DONE = new Set(['extracted', 'reconciled']);
 const TERMINAL_ERROR = new Set(['failed', 'reconcile_error']);
@@ -78,7 +74,6 @@ export function useProcessingJobs({ onRefresh }: { onRefresh?: () => void } = {}
       return [];
     }
   });
-  const [statusMap, setStatusMap] = useState<Record<string, StatusOverride>>({});
   const [dismissed, setDismissed] = useState<Set<string>>(new Set());
 
   // Keep the latest callback in a ref so the polling interval can use it
@@ -107,89 +102,65 @@ export function useProcessingJobs({ onRefresh }: { onRefresh?: () => void } = {}
   // against `removeJob`. It's the same operation as `dismiss`.
   const removeJob = dismiss;
 
-  const items: ProcessingItem[] = useMemo(() => {
-    return jobs
-      .filter((j) => !dismissed.has(j.batchId))
-      .map<ProcessingItem>((j) => {
-        const override = statusMap[j.batchId];
-        return {
-          batchId: j.batchId,
-          ingestId: j.ingestId,
-          filename: j.filename,
-          status: override?.status ?? 'processing',
-          transactionId: override?.transactionId,
-          error: override?.error,
-        };
-      });
-  }, [jobs, statusMap, dismissed]);
+  // Poll each visible (non-dismissed) batch through the SHARED ['batch',id]
+  // cache — the same key BatchDetail uses — so there is exactly one network
+  // poll per batch no matter how many surfaces are watching. Polling stops
+  // automatically once a batch hits a terminal status.
+  const visibleJobs = jobs.filter((j) => !dismissed.has(j.batchId));
+  const batchQueries = useQueries({
+    queries: visibleJobs.map((j) => ({
+      queryKey: qk.batch(j.batchId),
+      queryFn: () => getBatch(j.batchId),
+      refetchInterval: (q: { state: { data?: { status: string } } }) => {
+        const s = q.state.data?.status;
+        return s && (TERMINAL_DONE.has(s) || TERMINAL_ERROR.has(s)) ? false : 5000;
+      },
+    })),
+  });
 
-  // Poll batches that are still in a non-terminal state.
-  useEffect(() => {
-    const active = jobs.filter(
-      (j) => !dismissed.has(j.batchId) && !statusMap[j.batchId],
-    );
-    if (active.length === 0) return;
-
-    let cancelled = false;
-    const autoDismiss = (batchId: string, delay: number) => {
-      setTimeout(() => {
-        setDismissed((prev) => new Set(prev).add(batchId));
-        setJobs((prev) => prev.filter((j) => j.batchId !== batchId));
-      }, delay);
-    };
-
-    const interval = setInterval(async () => {
-      for (const job of active) {
-        if (cancelled) return;
-        try {
-          const batch = await getBatch(job.batchId);
+  // Project (jobs × live batch snapshots) → render-ready items. Status is
+  // DERIVED from the query data — no statusMap state — so there is no
+  // setState-in-effect anywhere. Stable EMPTY reference while idle so the
+  // context value doesn't churn when there are no uploads.
+  const items: ProcessingItem[] =
+    visibleJobs.length === 0
+      ? EMPTY_ITEMS
+      : visibleJobs.map<ProcessingItem>((j, i) => {
+          const batch = batchQueries[i]?.data;
+          const base = { batchId: j.batchId, ingestId: j.ingestId, filename: j.filename };
+          if (!batch) return { ...base, status: 'processing' };
           if (TERMINAL_DONE.has(batch.status)) {
-            // Per-file outcome: dedup is decided by the *ingest item's*
-            // own status, not the batch's. A byte-identical re-upload is
-            // born terminal with `status='dedup'` and points at the
-            // pre-existing transaction — no new row was written, so we
-            // surface a neutral "already in your ledger" state and skip
-            // onRefresh (there's nothing new to fetch).
-            const item = batch.items.find((i) => i.id === job.ingestId);
+            // Per-file outcome: dedup is decided by the ingest item's own
+            // status. A byte-identical re-upload is born terminal with
+            // status 'dedup', pointing at the pre-existing transaction.
+            const item = batch.items.find((it) => it.id === j.ingestId);
             const transactionId = item?.produced?.transaction_ids?.[0];
-            if (item?.status === 'dedup') {
-              setStatusMap((prev) => ({
-                ...prev,
-                [job.batchId]: { status: 'duplicate', transactionId },
-              }));
-              // Intentionally no onRefresh() — dedup adds no new data.
-              autoDismiss(job.batchId, 5000);
-            } else {
-              setStatusMap((prev) => ({
-                ...prev,
-                [job.batchId]: { status: 'done', transactionId },
-              }));
-              onRefreshRef.current?.();
-              autoDismiss(job.batchId, 3000);
-            }
-          } else if (TERMINAL_ERROR.has(batch.status)) {
-            const ingestErr = batch.items.find((i) => i.id === job.ingestId)?.error ?? null;
-            setStatusMap((prev) => ({
-              ...prev,
-              [job.batchId]: {
-                status: 'error',
-                error: ingestErr ?? `Batch ${batch.status}`,
-              },
-            }));
-            autoDismiss(job.batchId, 5000);
+            return item?.status === 'dedup'
+              ? { ...base, status: 'duplicate', transactionId }
+              : { ...base, status: 'done', transactionId };
           }
-        } catch (err: unknown) {
-          // Ignore individual poll failures; next tick retries.
-          console.debug('batch poll error', job.batchId, extractProblemMessage(err));
-        }
-      }
-    }, 5000);
+          if (TERMINAL_ERROR.has(batch.status)) {
+            const ingestErr = batch.items.find((it) => it.id === j.ingestId)?.error ?? null;
+            return { ...base, status: 'error', error: ingestErr ?? `Batch ${batch.status}` };
+          }
+          return { ...base, status: 'processing' };
+        });
 
-    return () => {
-      cancelled = true;
-      clearInterval(interval);
-    };
-  }, [jobs, dismissed, statusMap]);
+  // Terminal side-effects, exactly once per batch. A freshly-done upload
+  // refreshes the ledger surfaces (dedup/error add nothing new, so they
+  // don't); every terminal item auto-dismisses after a beat. `notifiedRef`
+  // guarantees once-only. Nothing here setStates synchronously — onRefresh
+  // invalidates, dismiss is deferred via setTimeout — so this stays clear of
+  // the react-hooks/set-state-in-effect lint.
+  const notifiedRef = useRef<Set<string>>(new Set());
+  useEffect(() => {
+    for (const it of items) {
+      if (it.status === 'processing' || notifiedRef.current.has(it.batchId)) continue;
+      notifiedRef.current.add(it.batchId);
+      if (it.status === 'done') onRefreshRef.current?.();
+      setTimeout(() => dismiss(it.batchId), it.status === 'done' ? 3000 : 5000);
+    }
+  }, [items, dismiss]);
 
   return { jobs, addJob, removeJob, items, dismiss };
 }

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -1,7 +1,6 @@
 import { createRootRoute, Outlet, useNavigate } from '@tanstack/react-router';
 import { AppProvider } from '../lib/appContext';
 import { useAppCtx } from '../lib/appCtx';
-import { invalidateLedgerSurfaces } from '../lib/queryClient';
 import ProcessingToast from '../components/ProcessingToast';
 
 export const Route = createRootRoute({
@@ -23,13 +22,12 @@ function RootComponent() {
  * list from AppCtx and jumps to the produced transaction on tap.
  */
 function ToastHost() {
-  const { jobs, removeJob } = useAppCtx();
+  const { items, removeJob } = useAppCtx();
   const navigate = useNavigate();
   return (
     <ProcessingToast
-      jobs={jobs}
+      items={items}
       onJobDone={removeJob}
-      onRefresh={invalidateLedgerSurfaces}
       onSelectTransaction={(id) =>
         navigate({ to: '/receipt/$receiptId', params: { receiptId: id } })
       }


### PR DESCRIPTION
Phase 2 (#98), trio part 2. useProcessingJobs + ProcessingToast each polled the same jobs (2×/5s) — converged: the hook is sole owner (per-batch `useQueries(qk.batch(id))`, status derived from query data so no statusMap, once-only `notifiedRef`+`setTimeout` terminal-watcher); ProcessingToast is presentational over the hook's `items`. Fixes the double-poll.

Verified 6/6 via frontend-test-runner (local, ms-precise): **single poll per ~5s** (gaps ~5015ms, double-poll gone), stops at terminal, **terminal fires once** (done → single ledger refetch → new row → 3s auto-dismiss), dedup short-circuits, no render loop/errors. Build+tsc+lint(0). Part of #98.