### PR TITLE
fix(products): send contract's q param so search filters [Phase3 A]

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1379,8 +1379,12 @@ export interface ListProductsOptions {
 }
 
 export async function listProducts(opts: ListProductsOptions = {}): Promise<BackendProduct[]> {
+  // The catalog's free-text filter is the contract's `q` param (the backend
+  // ILIKEs name/custom_name/product_key). The UI calls it `search`; map it
+  // here. (Sending `search` was silently dropped by the server → #129.)
+  const { search, ...rest } = opts;
   const { data, error, response } = await client.GET('/v1/products', {
-    params: { query: opts },
+    params: { query: { ...rest, q: search?.trim() || undefined } },
   });
   return unwrap('listProducts', data, error, response.status).items;
 }


### PR DESCRIPTION
Phase 3 (#107), Line A. The product catalog search did nothing — `listProducts` sent `search`, but the contract/backend filter on `q`, so the unknown key was dropped server-side (all rows returned). Maps `search`→`q` (trimmed); the backend's existing ILIKE filter now fires. Frontend-only.

Resolves the products-search gap → closes TINKPA/receipt-assistant#129.

Verified (frontend-test-runner): search "milk" → 3 rows (was no-op), wire `?q=milk`, composes with `class=`. Build+tsc+lint(0).
