### PR TITLE
fix(home): keep "all →" Ledger link visible when current month is empty

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -107,7 +107,11 @@ export default function Dashboard({
 
       <SectionTitle
         title="recent"
-        more={totalCount > 0 ? `all ${totalCount} →` : undefined}
+        // Always offer the Ledger entry point — this is the only path from the
+        // home view to /transactions. Don't gate on the current-month count
+        // (totalCount), which is 0 early in a month and used to make the link
+        // vanish entirely. Show the count when we have one, plain "all →" else.
+        more={totalCount > 0 ? `all ${totalCount} →` : 'all →'}
         onMore={onViewAllTransactions}
       />
       <ProcessingCardList


### PR DESCRIPTION
## Summary
The home view's only entry point to `/transactions` (the full Ledger) was the "recent" section's `all N →` link, gated on `totalCount > 0`. `totalCount` is the **current month's** spend count, so early in a month — or any month with no spending — the link rendered as `undefined` and disappeared entirely. The `FloatingDock` has no Ledger pill, so this left **no path from the home view to the Ledger**. The recent list itself is month-agnostic (`fetchTransactions({ limit: 4 })`, no month filter), so rows kept showing while the link to browse them all was gone.

User-reported: "从首页去不到 all transactions 那个 page 了" on 2026-06-02 (June had 0 transactions).

## Root cause
`src/components/Dashboard.tsx:110` — `more={totalCount > 0 ? \`all \${totalCount} →\` : undefined}`. Introduced in the Variant B redesign (#29), which replaced the always-on "View All" button with this month-count-gated link.

## Fix
Always render the entry point: `all N →` when there's a month count, plain `all →` otherwise.

## Acceptance criteria
- [x] With the current month at \$0, the `all →` link is present next to "recent".
- [x] Clicking it navigates to `/transactions`.
- [x] `tsc --noEmit` passes.

## Evidence (in-browser, not code analysis)
- **Repro** (deployed `:8080`, June \$0): "recent" heading had no link; bottom nav only Books/Add/Review/Settings → no path to Ledger.
- **Fixed** (local dev `:5175`, same June \$0 data): `button "all →"` appears next to "recent"; clicking navigated to `http://localhost:5175/transactions`.