### PR TITLE
feat: render near_dup ingest status across batch surfaces

### DIFF
--- a/src/components/BatchDetail.tsx
+++ b/src/components/BatchDetail.tsx
@@ -35,6 +35,10 @@ const INGEST_STATUS_META: Record<
   processing: { label: 'Processing', badge: 'bg-tertiary/10 text-tertiary', icon: Cog },
   done: { label: 'Done', badge: 'bg-primary/10 text-primary', icon: CheckCircle2 },
   dedup: { label: 'Duplicate', badge: 'bg-sky-400/10 text-sky-300', icon: Layers },
+  // #134: probabilistic attach — the agent judged this a copy of an
+  // existing transaction and linked the document to it. Amber (not sky)
+  // because, unlike byte-certain `dedup`, this one is reviewable.
+  near_dup: { label: 'Matched existing', badge: 'bg-amber-400/10 text-amber-300', icon: Layers },
   error: { label: 'Error', badge: 'bg-error/10 text-error', icon: AlertCircle },
   unsupported: { label: 'Unsupported', badge: 'bg-error/10 text-error', icon: AlertCircle },
 };
@@ -114,7 +118,8 @@ export default function BatchDetail({ batchId, onBack }: BatchDetailProps) {
 
   const { counts } = batch;
   // dedup + unsupported are terminal too, so they count toward completion.
-  const terminalDone = counts.done + counts.dedup + counts.error + counts.unsupported;
+  const terminalDone =
+    counts.done + counts.dedup + counts.near_dup + counts.error + counts.unsupported;
   const pct = counts.total > 0 ? Math.round((terminalDone / counts.total) * 100) : 0;
 
   return (
@@ -149,7 +154,7 @@ export default function BatchDetail({ batchId, onBack }: BatchDetailProps) {
           <StatCard label="Queued" value={counts.queued} tone="muted" />
           <StatCard label="Processing" value={counts.processing} tone="tertiary" />
           <StatCard label="Done" value={counts.done} tone="primary" />
-          <StatCard label="Duplicate" value={counts.dedup} tone="info" />
+          <StatCard label="Duplicate" value={counts.dedup + counts.near_dup} tone="info" />
           <StatCard label="Error" value={counts.error + counts.unsupported} tone="error" />
         </div>
 

--- a/src/components/Batches.tsx
+++ b/src/components/Batches.tsx
@@ -81,9 +81,9 @@ export default function Batches({ onSelectBatch }: BatchesProps) {
               {items.map((b) => {
                 const meta = STATUS_META[b.status];
                 const Icon = meta.icon;
-                const { done, error: errored, dedup, total } = b.counts;
+                const { done, error: errored, dedup, near_dup: nearDup, total } = b.counts;
                 const pct =
-                  total > 0 ? Math.round(((done + dedup + errored) / total) * 100) : 0;
+                  total > 0 ? Math.round(((done + dedup + nearDup + errored) / total) * 100) : 0;
                 return (
                   <tr
                     key={b.id}
@@ -116,8 +116,8 @@ export default function Batches({ onSelectBatch }: BatchesProps) {
                         </div>
                         <span className="text-[11px] text-on-surface-variant font-mono w-28 text-right">
                           {done}/{total}
-                          {dedup > 0 && (
-                            <span className="text-sky-300"> · {dedup} deduped</span>
+                          {dedup + nearDup > 0 && (
+                            <span className="text-sky-300"> · {dedup + nearDup} deduped</span>
                           )}
                           {errored > 0 && <span className="text-error"> · {errored} err</span>}
                         </span>

--- a/src/components/useProcessingJobs.ts
+++ b/src/components/useProcessingJobs.ts
@@ -127,7 +127,7 @@ export function useProcessingJobs({ onRefresh }: { onRefresh?: () => void } = {}
             // status 'dedup', pointing at the pre-existing transaction.
             const item = batch.items.find((it) => it.id === j.ingestId);
             const transactionId = item?.produced?.transaction_ids?.[0];
-            return item?.status === 'dedup'
+            return item?.status === 'dedup' || item?.status === 'near_dup'
               ? { ...base, status: 'duplicate', transactionId }
               : { ...base, status: 'done', transactionId };
           }

--- a/src/generated/buildInfo.json
+++ b/src/generated/buildInfo.json
@@ -1,8 +1,8 @@
 {
   "service": "receipt-assistant-frontend",
   "version": "0.0.0",
-  "gitSha": "a95c5b80ff606d9c6634762e73e0c93cd80017f5",
-  "gitShortSha": "a95c5b8",
-  "gitBranch": "main",
-  "builtAt": "2026-06-10T12:55:53.313Z"
+  "gitSha": "7d2b373f22f8ab108570f2de5b859eeda84e6759",
+  "gitShortSha": "7d2b373",
+  "gitBranch": "feat/near-dup-ui",
+  "builtAt": "2026-06-10T15:04:02.131Z"
 }

--- a/src/generated/buildInfo.ts
+++ b/src/generated/buildInfo.ts
@@ -1,8 +1,8 @@
 export const buildInfo = {
   "service": "receipt-assistant-frontend",
   "version": "0.0.0",
-  "gitSha": "a95c5b80ff606d9c6634762e73e0c93cd80017f5",
-  "gitShortSha": "a95c5b8",
-  "gitBranch": "main",
-  "builtAt": "2026-06-10T12:55:53.313Z"
+  "gitSha": "7d2b373f22f8ab108570f2de5b859eeda84e6759",
+  "gitShortSha": "7d2b373",
+  "gitBranch": "feat/near-dup-ui",
+  "builtAt": "2026-06-10T15:04:02.131Z"
 } as const;

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -4561,6 +4561,7 @@ export interface components {
             workspace_id: string;
             /** @enum {string} */
             kind: "receipt_image" | "receipt_email" | "receipt_pdf" | "statement_pdf" | "other";
+            /** @description Server-side storage path, relative to the server's uploads dir (#128). Opaque to clients — fetch bytes via /content or /rendered. */
             file_path: string | null;
             mime_type: string | null;
             sha256: string;
@@ -4613,9 +4614,10 @@ export interface components {
             error: number;
             unsupported: number;
             dedup: number;
+            near_dup: number;
         };
         /** @enum {string} */
-        IngestStatus: "queued" | "processing" | "done" | "error" | "unsupported" | "dedup";
+        IngestStatus: "queued" | "processing" | "done" | "error" | "unsupported" | "dedup" | "near_dup";
         /** @enum {string|null} */
         IngestClassification: "receipt_image" | "receipt_email" | "receipt_pdf" | "statement_pdf" | "unsupported" | null;
         IngestProduced: {


### PR DESCRIPTION
## Summary
Frontend half of TINKPA/receipt-assistant#134 PR 2. Renders the new probabilistic `near_dup` terminal state: BatchDetail badge ("Matched existing", amber) + stats/completion math, Batches list chip/progress, ProcessingToast duplicate state with tap-through to the existing transaction. `api-types` regenerated.

Browser verification happens post-deploy on the mini against the real near_dup batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)