### PR TITLE
feat(batches): Needs-review queue for flagged near-dup transactions

### DIFF
--- a/src/components/Batches.tsx
+++ b/src/components/Batches.tsx
@@ -1,13 +1,17 @@
 import React from 'react';
-import { useQuery } from '@tanstack/react-query';
-import { Loader2, FileStack, CheckCircle2, AlertCircle, Clock, Cog } from 'lucide-react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { Loader2, FileStack, CheckCircle2, AlertCircle, Clock, Cog, ShieldAlert, X } from 'lucide-react';
+import { Link } from '@tanstack/react-router';
 import {
   listBatches,
+  listTransactions,
+  dismissNearDupFlag,
   extractProblemMessage,
   type BatchStatus,
 } from '../lib/api';
 import { cn } from '../lib/utils';
 import { qk } from '../lib/queryKeys';
+import { receiptLink } from '../lib/navLinks';
 
 interface BatchesProps {
   onSelectBatch: (batchId: string) => void;
@@ -52,6 +56,8 @@ export default function Batches({ onSelectBatch }: BatchesProps) {
           Every receipt you upload is ingested as a batch. Open one to watch extraction + reconciliation progress in real time.
         </p>
       </div>
+
+      <NeedsReviewSection />
 
       <div className="glass-panel border border-outline-variant/10 rounded-xl overflow-hidden shadow-2xl">
         {loading ? (
@@ -144,6 +150,83 @@ export default function Batches({ onSelectBatch }: BatchesProps) {
           </table>
         )}
       </div>
+    </div>
+  );
+}
+
+/**
+ * #134 branch-4 review queue: transactions the extraction agent
+ * inserted but flagged (a same-amount/date candidate existed and
+ * neither side carried a strong tiebreaker). Hidden entirely when
+ * empty — most sessions never see it. Dismiss = "I checked; they are
+ * distinct purchases"; merging instead is the reconcile-apply flow.
+ */
+function NeedsReviewSection() {
+  const queryClient = useQueryClient();
+  const flaggedKey = ['transactions', 'flagged', 'near_dup'] as const;
+  const { data } = useQuery({
+    queryKey: flaggedKey,
+    queryFn: () => listTransactions({ flagged: 'near_dup', limit: 50 }),
+  });
+  const dismiss = useMutation({
+    mutationFn: (id: string) => dismissNearDupFlag(id),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: flaggedKey }),
+  });
+  const flagged = data?.items ?? [];
+  if (flagged.length === 0) return null;
+  return (
+    <div className="glass-panel border border-amber-400/20 rounded-xl overflow-hidden">
+      <div className="px-8 py-4 flex items-center gap-3 border-b border-amber-400/10 bg-amber-400/5">
+        <ShieldAlert size={18} className="text-amber-300" />
+        <div>
+          <p className="font-headline font-bold text-amber-200">
+            Needs review · {flagged.length} possible duplicate{flagged.length === 1 ? '' : 's'}
+          </p>
+          <p className="text-xs text-on-surface-variant mt-0.5">
+            Each was saved alongside a same-amount, same-day transaction without a
+            receipt/order number to tell them apart. Open both, then dismiss if they are
+            genuinely separate purchases.
+          </p>
+        </div>
+      </div>
+      <ul className="divide-y divide-outline-variant/5">
+        {flagged.map((t) => {
+          const check = (t.metadata as Record<string, any> | null)?.near_dup_check ?? {};
+          const candidate: string | undefined = check.candidate_transaction_id;
+          return (
+            <li key={t.id} className="px-8 py-4 flex items-center gap-4">
+              <div className="min-w-0 flex-1">
+                <Link
+                  {...receiptLink(t.id)}
+                  className="text-sm font-bold text-white hover:text-primary transition-colors"
+                >
+                  {t.payee ?? 'Unknown payee'}
+                </Link>
+                <p className="text-xs text-on-surface-variant mt-0.5">
+                  {t.occurred_on}
+                  {check.reason ? ` · ${String(check.reason).slice(0, 90)}` : ''}
+                </p>
+              </div>
+              {candidate && (
+                <Link
+                  {...receiptLink(candidate)}
+                  className="text-xs text-amber-300 hover:text-amber-200 underline underline-offset-2 shrink-0"
+                >
+                  view candidate
+                </Link>
+              )}
+              <button
+                onClick={() => dismiss.mutate(t.id)}
+                disabled={dismiss.isPending}
+                className="shrink-0 flex items-center gap-1.5 text-xs font-bold text-on-surface-variant hover:text-white border border-outline-variant/20 hover:border-outline-variant/50 rounded-full px-3 py-1.5 transition-colors disabled:opacity-50"
+              >
+                <X size={12} />
+                Not a duplicate
+              </button>
+            </li>
+          );
+        })}
+      </ul>
     </div>
   );
 }

--- a/src/generated/buildInfo.json
+++ b/src/generated/buildInfo.json
@@ -1,8 +1,8 @@
 {
   "service": "receipt-assistant-frontend",
   "version": "0.0.0",
-  "gitSha": "7d2b373f22f8ab108570f2de5b859eeda84e6759",
-  "gitShortSha": "7d2b373",
-  "gitBranch": "feat/near-dup-ui",
-  "builtAt": "2026-06-10T15:04:02.131Z"
+  "gitSha": "f98f5dc9ba86a23e0de1ee3ed0faf6ef5e74c904",
+  "gitShortSha": "f98f5dc",
+  "gitBranch": "feat/near-dup-review-ui",
+  "builtAt": "2026-06-12T00:38:47.148Z"
 }

--- a/src/generated/buildInfo.ts
+++ b/src/generated/buildInfo.ts
@@ -1,8 +1,8 @@
 export const buildInfo = {
   "service": "receipt-assistant-frontend",
   "version": "0.0.0",
-  "gitSha": "7d2b373f22f8ab108570f2de5b859eeda84e6759",
-  "gitShortSha": "7d2b373",
-  "gitBranch": "feat/near-dup-ui",
-  "builtAt": "2026-06-10T15:04:02.131Z"
+  "gitSha": "f98f5dc9ba86a23e0de1ee3ed0faf6ef5e74c904",
+  "gitShortSha": "f98f5dc",
+  "gitBranch": "feat/near-dup-review-ui",
+  "builtAt": "2026-06-12T00:38:47.148Z"
 } as const;

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -460,6 +460,7 @@ export interface paths {
                     trip_id?: string;
                     has_document?: boolean | null;
                     source_ingest_id?: string;
+                    flagged?: "near_dup";
                     sort?: "occurred_on" | "amount" | "created_at";
                     order?: "asc" | "desc";
                     cursor?: string;
@@ -716,6 +717,57 @@ export interface paths {
                     };
                     content: {
                         "application/json": components["schemas"]["Transaction"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/transactions/{id}/near-dup-review": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Resolve a near-duplicate review flag (#134 branch 4); v1 action: dismiss */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["NearDupReviewRequest"];
+                };
+            };
+            responses: {
+                /** @description Flag cleared */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["NearDupReviewResponse"];
+                    };
+                };
+                /** @description Not found or not flagged */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
                     };
                 };
             };
@@ -5090,6 +5142,20 @@ export interface components {
         };
         VoidTransactionRequest: {
             reason?: string;
+        };
+        NearDupReviewResponse: {
+            /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            id: string;
+            flagged_for_review: boolean;
+            /** Format: date-time */
+            reviewed_at: string;
+        };
+        NearDupReviewRequest: {
+            /** @enum {string} */
+            action: "dismiss";
         };
         UnreconcileTransactionRequest: {
             reason?: string;

--- a/src/lib/api/transactions.ts
+++ b/src/lib/api/transactions.ts
@@ -38,6 +38,8 @@ export interface ListTransactionsFilters {
   trip_id?: string;
   has_document?: boolean;
   source_ingest_id?: string;
+  /** flagged=near_dup → only #134 branch-4 flagged transactions. */
+  flagged?: 'near_dup';
   sort?: 'occurred_on' | 'amount' | 'created_at';
   order?: 'asc' | 'desc';
   cursor?: string;
@@ -249,4 +251,16 @@ export async function unreconcileTransaction(
     },
   );
   return unwrap('unreconcileTransaction', data, error, response.status);
+}
+
+/** Resolve a #134 branch-4 near-dup review flag (v1: dismiss only). */
+export async function dismissNearDupFlag(id: string): Promise<void> {
+  const { data, error, response } = await client.POST(
+    '/v1/transactions/{id}/near-dup-review',
+    {
+      params: { path: { id } },
+      body: { action: 'dismiss' },
+    },
+  );
+  unwrap('dismissNearDupFlag', data, error, response.status);
 }


### PR DESCRIPTION
Frontend half of the #134 branch-4 review surface (backend: TINKPA/receipt-assistant#142). Amber "Needs review" panel on the Uploads screen, hidden when no transaction carries `near_dup_check.flagged_for_review=true`; rows deep-link to the receipt + the candidate, dismiss via the new endpoint. Browser verification post-deploy with a real flagged pair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)