### PR TITLE
feat(receipt): editorial ReceiptDetail typography — P1c-1 of redesign v2

### DIFF
--- a/src/components/ReceiptDetail/index.tsx
+++ b/src/components/ReceiptDetail/index.tsx
@@ -181,7 +181,7 @@ export default function ReceiptDetail({ receiptId, onBack, onAfterMutation }: Re
       <div className="space-y-4">
         <SimpleBackBar onBack={onBack} />
         <div className="py-16 text-center">
-          <p className="font-hand text-xl text-[var(--color-ink-muted)]">loading…</p>
+          <p className="font-display italic text-lg text-[var(--color-ink-muted)]">loading…</p>
         </div>
       </div>
     );
@@ -355,7 +355,7 @@ export default function ReceiptDetail({ receiptId, onBack, onAfterMutation }: Re
               )}
               title="Re-run OCR with the current model and prompt"
             >
-              <span className="font-display italic text-base leading-none text-[var(--color-terracotta)] group-hover:translate-x-px transition-transform">
+              <span className="font-display text-base leading-none text-[var(--color-accent)] group-hover:translate-x-px transition-transform">
                 ↺
               </span>
               {reExtractState.kind === 'pending'

--- a/src/components/ReceiptDetail/parts/AmountHero.tsx
+++ b/src/components/ReceiptDetail/parts/AmountHero.tsx
@@ -27,7 +27,7 @@ export function AmountHero({
    *  plain <h1> (no link) — e.g. while processing or with no brand. */
   brandTo?: ReturnType<typeof brandLink>;
 }) {
-  const merchantClass = 'font-display italic font-medium text-2xl sm:text-3xl leading-tight';
+  const merchantClass = 'font-display font-medium text-2xl sm:text-3xl leading-tight';
   // FE#48: small square icon next to the merchant name. Skipped while
   // processing (the row says "Processing…", not a real merchant yet).
   const showIcon = !isProcessing;
@@ -35,14 +35,14 @@ export function AmountHero({
     <div className="text-center pt-2">
       <p
         className={cn(
-          'font-display italic font-medium tracking-tight tnum',
+          'font-display font-light tracking-tight tnum',
           'text-[3.25rem] sm:text-[4rem] leading-none',
           voided && 'line-through text-[var(--color-ink-muted)]',
         )}
       >
         {isProcessing ? '—' : `$${amount.toFixed(2)}`}
       </p>
-      <p className="mt-1 text-[11px] tracking-[0.14em] uppercase text-[var(--color-ink-muted)]">
+      <p className="mt-1 font-mono text-[9px] tracking-[0.16em] uppercase text-[var(--color-ink-muted)]">
         {currency}
       </p>
       {brandTo ? (
@@ -58,7 +58,7 @@ export function AmountHero({
           )}
           <span className="inline-flex items-baseline gap-1">
             {merchant}
-            <span className="font-display italic text-base leading-none text-[var(--color-terracotta)]">→</span>
+            <span className="font-display text-base leading-none text-[var(--color-accent)]">→</span>
           </span>
         </Link>
       ) : (

--- a/src/components/ReceiptDetail/parts/ExtractionDetailsCollapsible.tsx
+++ b/src/components/ReceiptDetail/parts/ExtractionDetailsCollapsible.tsx
@@ -22,7 +22,7 @@ export function ExtractionDetailsCollapsible({
         onClick={() => setOpen((s) => !s)}
         className="w-full px-5 py-4 flex items-center justify-between text-left hover:bg-[var(--color-paper-deep)]/30 transition-colors"
       >
-        <span className="font-display italic font-medium text-lg leading-none">
+        <span className="font-display font-medium text-lg leading-none">
           Extraction details
         </span>
         <span className="flex items-center gap-2">

--- a/src/components/ReceiptDetail/parts/FieldsGrid.tsx
+++ b/src/components/ReceiptDetail/parts/FieldsGrid.tsx
@@ -50,7 +50,7 @@ function SmallFieldCard({
       <p
         className={cn(
           'mt-1 text-[15px] font-medium',
-          numeric && 'font-display italic font-medium text-lg tnum',
+          numeric && 'font-mono font-semibold text-[15px] tracking-tight tnum',
         )}
       >
         {value}

--- a/src/components/ReceiptDetail/parts/LineItemsCard.tsx
+++ b/src/components/ReceiptDetail/parts/LineItemsCard.tsx
@@ -35,7 +35,7 @@ export function LineItemsCard({
   return (
     <div className="rounded-[18px] border border-[var(--color-rule)] bg-[var(--color-surface)] overflow-hidden">
       <div className="px-5 py-4 border-b border-[var(--color-rule)] flex items-baseline justify-between">
-        <h3 className="font-display italic font-medium text-lg leading-none">
+        <h3 className="font-display font-medium text-lg leading-none">
           Items <span className="text-[var(--color-ink-muted)]">({items.length})</span>
         </h3>
         <span className="text-[10px] tracking-[0.16em] uppercase text-[var(--color-ink-muted)]">
@@ -73,7 +73,7 @@ export function LineItemsCard({
                   </div>
                 )}
               </div>
-              <span className="font-display italic font-medium text-base tnum">
+              <span className="font-mono font-semibold text-[13.5px] tracking-tight tnum">
                 {formatMinor(item.line_total_minor, item.currency || currency)}
               </span>
             </li>

--- a/src/components/ReceiptDetail/parts/NoteCard.tsx
+++ b/src/components/ReceiptDetail/parts/NoteCard.tsx
@@ -15,7 +15,7 @@ export function NoteCard({ text }: { text: string }) {
       >
         your note
       </span>
-      <p className="font-hand text-lg text-[var(--color-ink)]">{text}</p>
+      <p className="font-display italic text-[15px] text-[var(--color-ink)]">{text}</p>
     </div>
   );
 }

--- a/src/components/ReceiptDetail/parts/OriginalReceiptCollapsible.tsx
+++ b/src/components/ReceiptDetail/parts/OriginalReceiptCollapsible.tsx
@@ -26,7 +26,7 @@ function EmailHeaderStrip({
   return (
     <div className="rounded-[10px] border border-[var(--color-rule)] bg-[var(--color-surface)] px-4 py-3">
       {subject && (
-        <p className="font-display italic font-medium text-[15px] leading-snug text-[var(--color-ink)]">
+        <p className="font-display font-medium text-[15px] leading-snug text-[var(--color-ink)]">
           {subject}
         </p>
       )}
@@ -61,7 +61,7 @@ export function OriginalReceiptCollapsible({
         onClick={() => setOpen((s) => !s)}
         className="w-full px-5 py-4 flex items-center justify-between text-left hover:bg-[var(--color-paper-deep)]/30 transition-colors"
       >
-        <span className="font-display italic font-medium text-lg leading-none">
+        <span className="font-display font-medium text-lg leading-none">
           {isEmail ? 'Original email' : 'Original receipt'}
         </span>
         {open ? <ChevronDown size={18} className="text-[var(--color-ink-muted)]" /> : <ChevronRight size={18} className="text-[var(--color-ink-muted)]" />}

--- a/src/components/ReceiptDetail/parts/ProcessingNote.tsx
+++ b/src/components/ReceiptDetail/parts/ProcessingNote.tsx
@@ -13,7 +13,7 @@ export function ProcessingNote() {
         className="mt-1 inline-block h-2.5 w-2.5 rounded-full bg-[var(--color-terracotta)] animate-pulse"
       />
       <div>
-        <p className="font-display italic font-medium">Still reading your receipt</p>
+        <p className="font-display font-medium">Still reading your receipt</p>
         <p className="mt-1 text-sm text-[var(--color-ink-muted)]">
           Claude is extracting fields — this page will refresh on its own.
         </p>

--- a/src/components/ReceiptDetail/parts/SimpleBackBar.tsx
+++ b/src/components/ReceiptDetail/parts/SimpleBackBar.tsx
@@ -6,7 +6,7 @@ export function SimpleBackBar({ onBack }: { onBack: () => void }) {
         onClick={onBack}
         className="flex items-center gap-2 hover:text-[var(--color-ink)] transition-colors"
       >
-        <span className="font-display italic text-lg leading-none text-[var(--color-terracotta)]">←</span>
+        <span className="font-display text-lg leading-none text-[var(--color-accent)]">←</span>
         Back
       </button>
     </div>

--- a/src/components/ReceiptDetail/parts/TopBar.tsx
+++ b/src/components/ReceiptDetail/parts/TopBar.tsx
@@ -49,7 +49,7 @@ export function TopBar({
         onClick={onBack}
         className="flex items-center gap-2 hover:text-[var(--color-ink)] transition-colors"
       >
-        <span className="font-display italic text-lg leading-none text-[var(--color-terracotta)]">←</span>
+        <span className="font-display text-lg leading-none text-[var(--color-accent)]">←</span>
         Back
       </button>
       <div className="flex items-center gap-3">

--- a/src/components/ReceiptDetail/parts/banners.tsx
+++ b/src/components/ReceiptDetail/parts/banners.tsx
@@ -47,7 +47,7 @@ export function ReExtractBanner({
           'border border-[var(--color-stamp)]/40 bg-[var(--color-stamp)]/5 text-[var(--color-stamp)]',
       )}
     >
-      <p className="font-hand text-base leading-snug">{children}</p>
+      <p className="font-display italic text-[13.5px] leading-snug">{children}</p>
       <button
         type="button"
         onClick={onDismiss}


### PR DESCRIPTION
Part of TINKPA/receipt-assistant#149 (P1). Board screen 03 typography: light Fraunces hero, mono numerics, italic retired from titles, font-hand fully removed from ReceiptDetail. Screenshot in project notes/p1c-receipt.jpeg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)