### PR TITLE
feat(system): editorial reskin Settings/Uploads/BatchDetail + Settings pieces

### DIFF
--- a/src/components/BatchDetail.tsx
+++ b/src/components/BatchDetail.tsx
@@ -1,15 +1,5 @@
-import React, { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import {
-  ArrowLeft,
-  CheckCircle2,
-  AlertCircle,
-  Clock,
-  Cog,
-  FileText,
-  Layers,
-  Zap,
-} from 'lucide-react';
 import { Link } from '@tanstack/react-router';
 import {
   getBatch,
@@ -27,20 +17,24 @@ interface BatchDetailProps {
   onBack: () => void;
 }
 
-const INGEST_STATUS_META: Record<
-  IngestStatus,
-  { label: string; badge: string; icon: React.ComponentType<{ size?: number; className?: string }> }
-> = {
-  queued: { label: 'Queued', badge: 'bg-surface-container-highest text-on-surface-variant', icon: Clock },
-  processing: { label: 'Processing', badge: 'bg-tertiary/10 text-tertiary', icon: Cog },
-  done: { label: 'Done', badge: 'bg-primary/10 text-primary', icon: CheckCircle2 },
-  dedup: { label: 'Duplicate', badge: 'bg-sky-400/10 text-sky-300', icon: Layers },
-  // #134: probabilistic attach — the agent judged this a copy of an
-  // existing transaction and linked the document to it. Amber (not sky)
-  // because, unlike byte-certain `dedup`, this one is reviewable.
-  near_dup: { label: 'Matched existing', badge: 'bg-amber-400/10 text-amber-300', icon: Layers },
-  error: { label: 'Error', badge: 'bg-error/10 text-error', icon: AlertCircle },
-  unsupported: { label: 'Unsupported', badge: 'bg-error/10 text-error', icon: AlertCircle },
+/** Ingest status → editorial dot-badge (board screen 28). */
+const INGEST_META: Record<IngestStatus, { label: string; tone: string }> = {
+  queued: { label: 'queued', tone: 'queued' },
+  processing: { label: 'extracting', tone: 'proc' },
+  done: { label: 'done', tone: 'done' },
+  dedup: { label: 'dedup', tone: 'dedup' },
+  near_dup: { label: 'near-dup', tone: 'neardup' },
+  error: { label: 'error', tone: 'err' },
+  unsupported: { label: 'unsupported', tone: 'err' },
+};
+
+const TONE: Record<string, { box: string; dot: string; pulse?: boolean }> = {
+  queued: { box: 'bg-[var(--color-paper-deep)] text-[var(--color-ink-muted)]', dot: 'bg-[var(--color-ink-faint)]' },
+  proc: { box: 'bg-[color:rgba(188,134,36,0.16)] text-[var(--color-amber)]', dot: 'bg-[var(--color-amber)]', pulse: true },
+  done: { box: 'bg-[color:rgba(92,107,61,0.15)] text-[var(--color-olive)]', dot: 'bg-[var(--color-olive)]' },
+  dedup: { box: 'bg-[color:rgba(63,85,99,0.13)] text-[var(--color-slate)]', dot: 'bg-[var(--color-slate)]' },
+  neardup: { box: 'bg-[color:rgba(188,134,36,0.16)] text-[var(--color-amber)]', dot: 'bg-[var(--color-amber)]' },
+  err: { box: 'bg-[color:rgba(181,52,26,0.13)] text-[var(--color-accent)]', dot: 'bg-[var(--color-accent)]' },
 };
 
 interface LiveEvent {
@@ -50,46 +44,39 @@ interface LiveEvent {
   payload: unknown;
 }
 
+function fmtElapsed(batch: { created_at: string; completed_at?: string | null }): string {
+  const start = new Date(batch.created_at).getTime();
+  const end = batch.completed_at ? new Date(batch.completed_at).getTime() : Date.now();
+  const s = Math.max(0, Math.round((end - start) / 1000));
+  if (s < 90) return `${s}s`;
+  const m = Math.round(s / 60);
+  return m < 90 ? `${m}m` : `${Math.round(m / 60)}h`;
+}
+
 export default function BatchDetail({ batchId, onBack }: BatchDetailProps) {
   const queryClient = useQueryClient();
   const [events, setEvents] = useState<LiveEvent[]>([]);
+  const [connected, setConnected] = useState(false);
   const eventCounter = useRef(0);
 
-  // Snapshot of the batch. SSE (below) is the freshness driver — each
-  // meaningful event invalidates this query rather than the screen polling.
-  const {
-    data: batch = null,
-    isLoading: loading,
-    error: queryError,
-  } = useQuery({
+  const { data: batch = null, isLoading: loading, error: queryError } = useQuery({
     queryKey: qk.batch(batchId),
     queryFn: () => getBatch(batchId),
   });
   const error = queryError ? extractProblemMessage(queryError) : null;
 
-  // Subscribe to the live stream. Each recognized event refetches the
-  // batch so status/counts stay in sync; we also accumulate a running log.
   useEffect(() => {
     const controller = subscribeToBatch(
       batchId,
       (name, payload) => {
+        setConnected(true);
         eventCounter.current += 1;
-        const evt: LiveEvent = {
-          id: eventCounter.current,
-          at: new Date(),
-          name,
-          payload,
-        };
+        const evt: LiveEvent = { id: eventCounter.current, at: new Date(), name, payload };
         setEvents((prev) => [evt, ...prev].slice(0, 50));
-        // Any meaningful state change → invalidate the batch snapshot so the
-        // useQuery refetches (coalesced across bursts, unlike the old N×refetch).
         if (name !== 'hello' && name !== 'message')
           queryClient.invalidateQueries({ queryKey: qk.batch(batchId) });
       },
-      () => {
-        // EventSource errors are common when the server closes after a
-        // terminal frame. Leave the snapshot as-is.
-      },
+      () => setConnected(false),
     );
     return () => controller.abort();
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -97,215 +84,152 @@ export default function BatchDetail({ batchId, onBack }: BatchDetailProps) {
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center h-[60vh] gap-3">
-        <Cog className="animate-spin text-primary" size={32} />
-        <span className="text-on-surface-variant">Loading batch...</span>
-      </div>
+      <p className="py-16 text-center font-display italic text-[var(--color-ink-muted)]">loading…</p>
     );
   }
-
   if (error || !batch) {
     return (
-      <div className="space-y-6 animate-in fade-in duration-500">
-        <button onClick={onBack} className="flex items-center gap-2 text-primary font-bold hover:opacity-80 transition-opacity">
-          <ArrowLeft size={20} />
-          Back
+      <div className="space-y-4">
+        <button
+          type="button"
+          onClick={onBack}
+          className="font-mono text-[10px] uppercase tracking-[0.1em] text-[var(--color-accent)]"
+        >
+          ← Back to batches
         </button>
-        <div className="text-center py-20 text-error">{error || 'Batch not found'}</div>
+        <p className="py-16 text-center text-[var(--color-stamp)]">{error || 'Batch not found'}</p>
       </div>
     );
   }
 
   const { counts } = batch;
-  // dedup + unsupported are terminal too, so they count toward completion.
-  const terminalDone =
-    counts.done + counts.dedup + counts.near_dup + counts.error + counts.unsupported;
-  const pct = counts.total > 0 ? Math.round((terminalDone / counts.total) * 100) : 0;
+  const done = counts.done + counts.dedup + counts.near_dup;
 
   return (
-    <div className="space-y-8 animate-in fade-in slide-in-from-bottom-4 duration-700 max-w-5xl">
-      <button onClick={onBack} className="flex items-center gap-2 text-primary font-bold hover:opacity-80 transition-opacity">
-        <ArrowLeft size={20} />
-        Back to batches
-      </button>
-
-      <div className="glass-panel rounded-xl p-8 border border-outline-variant/10">
-        <div className="flex items-start justify-between flex-wrap gap-4">
-          <div>
-            <p className="text-xs text-on-surface-variant uppercase tracking-widest mb-2">Batch</p>
-            <p className="font-mono text-xl font-semibold">
-              {batch.id.slice(0, 8)}…{batch.id.slice(-4)}
-            </p>
-            <p className="text-sm text-on-surface-variant mt-1">
-              Uploaded {new Date(batch.created_at).toLocaleString()} ·{' '}
-              {batch.auto_reconcile ? 'auto-reconcile on' : 'manual reconcile'}
-            </p>
-          </div>
-          <div className="text-right">
-            <p className="text-xs text-on-surface-variant uppercase tracking-widest mb-2">Status</p>
-            <p className="font-display text-xl font-medium capitalize">
-              {batch.status.replace('_', ' ')}
-            </p>
-          </div>
-        </div>
-
-        <div className="grid grid-cols-3 md:grid-cols-6 gap-4 mt-6 pt-6 border-t border-outline-variant/10">
-          <StatCard label="Total" value={counts.total} />
-          <StatCard label="Queued" value={counts.queued} tone="muted" />
-          <StatCard label="Processing" value={counts.processing} tone="tertiary" />
-          <StatCard label="Done" value={counts.done} tone="primary" />
-          <StatCard label="Duplicate" value={counts.dedup + counts.near_dup} tone="info" />
-          <StatCard label="Error" value={counts.error + counts.unsupported} tone="error" />
-        </div>
-
-        <div className="mt-6 flex items-center gap-3">
-          <div className="flex-1 h-2 bg-surface-container-highest rounded-full overflow-hidden">
-            <div
-              className={cn('h-full transition-all duration-500', counts.error > 0 ? 'bg-error' : 'bg-primary')}
-              style={{ width: `${pct}%` }}
-            />
-          </div>
-          <span className="text-sm text-on-surface-variant font-mono">{pct}%</span>
-        </div>
+    <div className="space-y-4">
+      <div className="flex items-center justify-between pt-2">
+        <button
+          type="button"
+          onClick={onBack}
+          className="font-mono text-[10px] uppercase tracking-[0.1em] text-[var(--color-accent)]"
+        >
+          ← Back to batches
+        </button>
+        <span className="font-mono text-[8.5px] uppercase tracking-[0.14em] text-[var(--color-ink-muted)]">
+          {batch.id.slice(0, 8)} · {batch.auto_reconcile ? 'auto-reconcile' : 'manual'}
+        </span>
       </div>
 
-      <div className="glass-panel rounded-xl border border-outline-variant/10 overflow-hidden">
-        <div className="px-8 py-5 border-b border-outline-variant/10">
-          <h3 className="font-display font-medium flex items-center gap-2">
-            <FileText size={18} />
-            Files ({batch.items.length})
-          </h3>
-        </div>
-        <table className="w-full text-left">
-          <thead>
-            <tr className="bg-surface-container-low/50">
-              <th className="px-8 py-3 text-xs font-bold text-on-surface-variant uppercase tracking-widest">File</th>
-              <th className="px-8 py-3 text-xs font-bold text-on-surface-variant uppercase tracking-widest">Classification</th>
-              <th className="px-8 py-3 text-xs font-bold text-on-surface-variant uppercase tracking-widest">Status</th>
-              <th className="px-8 py-3 text-xs font-bold text-on-surface-variant uppercase tracking-widest">Produced</th>
-            </tr>
-          </thead>
-          <tbody className="divide-y divide-outline-variant/5">
-            {batch.items.map((ing) => (
-              <IngestRow key={ing.id} ingest={ing} />
-            ))}
-          </tbody>
-        </table>
+      {/* b-meta */}
+      <div className="grid grid-cols-3 divide-x divide-[var(--color-rule-soft)] rounded-[12px] border-[0.5px] border-[var(--color-rule-soft)] bg-[var(--color-surface)] py-3">
+        <Meta label="Files" value={String(counts.total)} />
+        <Meta label="Done" value={String(done)} />
+        <Meta label="Elapsed" value={fmtElapsed(batch)} />
       </div>
 
-      <div className="glass-panel rounded-xl border border-outline-variant/10 overflow-hidden">
-        <div className="px-8 py-5 border-b border-outline-variant/10 flex items-center justify-between">
-          <h3 className="font-display font-medium flex items-center gap-2">
-            <Zap size={18} />
-            Live events
-          </h3>
-          <span className="text-xs text-on-surface-variant">
-            {events.length === 0 ? 'Waiting for server...' : `${events.length} event(s)`}
+      {/* Ingests */}
+      <section>
+        <h2 className="mb-1.5 font-mono text-[9px] uppercase tracking-[0.16em] text-[var(--color-ink-muted)]">
+          Ingests
+        </h2>
+        <div className="overflow-hidden rounded-[14px] border-[0.5px] border-[var(--color-rule-soft)] bg-[var(--color-surface)]">
+          {batch.items.map((ing, idx) => (
+            <IngestRow key={ing.id} ingest={ing} first={idx === 0} />
+          ))}
+        </div>
+      </section>
+
+      {/* LIVE TRACE */}
+      <section className="rounded-[13px] bg-[var(--color-ink)] px-4 py-3">
+        <div className="mb-2.5 flex items-center gap-1.5 font-mono text-[7.5px] uppercase tracking-[0.18em] text-[var(--color-paper-fold)]">
+          <span
+            className={cn('h-1.5 w-1.5 rounded-full', connected ? 'animate-pulse' : '')}
+            style={{ background: connected ? '#8FA468' : 'var(--color-ink-faint)' }}
+          />
+          Live trace
+          <span className="ml-auto normal-case tracking-[0.06em] text-[var(--color-ink-faint)]">
+            sse · /api/v1/batches/{batch.id.slice(0, 6)}/stream
           </span>
         </div>
-        <div className="max-h-64 overflow-y-auto">
+        <div className="max-h-64 space-y-0.5 overflow-y-auto">
           {events.length === 0 ? (
-            <p className="px-8 py-6 text-sm text-on-surface-variant/60">
-              Stream is open. Upload activity will appear here.
+            <p className="font-mono text-[8.5px] text-[var(--color-ink-faint)]">
+              stream open · activity will appear here
             </p>
           ) : (
-            <ul className="divide-y divide-outline-variant/5">
-              {events.map((e) => (
-                <li key={e.id} className="px-8 py-3 flex items-center gap-4 text-xs font-mono">
-                  <span className="text-on-surface-variant/60 w-20">
-                    {e.at.toLocaleTimeString([], { hour12: false })}
-                  </span>
-                  <span className="text-primary font-bold w-44 truncate">{e.name}</span>
-                  <span className="text-on-surface-variant truncate flex-1">
-                    {typeof e.payload === 'object' && e.payload !== null
-                      ? JSON.stringify(e.payload)
-                      : String(e.payload)}
-                  </span>
-                </li>
-              ))}
-            </ul>
+            events.map((e) => (
+              <div key={e.id} className="flex gap-2.5 font-mono text-[8.5px] leading-[1.7]">
+                <span className="flex-shrink-0 text-[var(--color-ink-faint)]">
+                  {e.at.toLocaleTimeString([], { hour12: false })}
+                </span>
+                <span className="text-[#8FA468]">{e.name}</span>
+                <span className="min-w-0 flex-1 truncate text-[var(--color-paper-fold)]">
+                  {typeof e.payload === 'object' && e.payload !== null
+                    ? JSON.stringify(e.payload)
+                    : String(e.payload)}
+                </span>
+              </div>
+            ))
           )}
         </div>
-      </div>
+      </section>
+
+      <p className="px-1 font-display italic text-[12.5px] leading-snug text-[var(--color-ink-soft)]">
+        The same trace Langfuse keeps, retold at phone width. Nothing the extractor does is off the record.
+      </p>
     </div>
   );
 }
 
-function StatCard({
-  label,
-  value,
-  tone = 'default',
-}: {
-  label: string;
-  value: number;
-  tone?: 'default' | 'muted' | 'primary' | 'tertiary' | 'info' | 'error';
-}) {
-  const valueClass =
-    tone === 'primary'
-      ? 'text-primary'
-      : tone === 'tertiary'
-        ? 'text-tertiary'
-        : tone === 'info'
-          ? 'text-sky-300'
-          : tone === 'error'
-            ? 'text-error'
-            : tone === 'muted'
-              ? 'text-on-surface-variant'
-              : 'text-[var(--color-ink)]';
+function Meta({ label, value }: { label: string; value: string }) {
   return (
-    <div>
-      <p className="text-xs text-on-surface-variant uppercase tracking-widest">{label}</p>
-      <p className={cn('text-2xl font-bold font-headline mt-1', valueClass)}>{value}</p>
+    <div className="px-2 text-center">
+      <p className="font-mono text-[8px] uppercase tracking-[0.14em] text-[var(--color-ink-muted)]">
+        {label}
+      </p>
+      <p className="mt-0.5 font-display text-[16px] tnum">{value}</p>
     </div>
   );
 }
 
-function IngestRow({ ingest }: { ingest: BackendIngest }) {
-  const meta = INGEST_STATUS_META[ingest.status];
-  const Icon = meta.icon;
+function IngestRow({ ingest, first }: { ingest: BackendIngest; first: boolean }) {
+  const meta = INGEST_META[ingest.status];
+  const tone = TONE[meta.tone];
   const txnIds = ingest.produced?.transaction_ids ?? [];
   return (
-    <tr className="hover:bg-surface-container-high/30 transition-colors">
-      <td className="px-8 py-4">
-        <p className="font-mono text-[11px] font-medium">{ingest.filename}</p>
-        {ingest.mime_type && (
-          <p className="text-[11px] text-on-surface-variant/70 mt-0.5 font-mono">{ingest.mime_type}</p>
-        )}
-        {ingest.error && (
-          <p className="text-[11px] text-error mt-1 truncate max-w-md">{ingest.error}</p>
-        )}
-      </td>
-      <td className="px-8 py-4 text-sm text-on-surface-variant">
-        {ingest.classification ? ingest.classification.replace('_', ' ') : '—'}
-      </td>
-      <td className="px-8 py-4">
-        <span
-          className={cn(
-            'inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-[11px] font-bold uppercase tracking-wider',
-            meta.badge,
+    <div
+      className={cn(
+        'flex items-center gap-3 px-4 py-2.5',
+        !first && 'border-t border-[var(--color-rule-soft)]',
+      )}
+    >
+      <span className="min-w-0 flex-1">
+        <span className="block truncate font-mono text-[9.5px]">{ingest.filename}</span>
+        <span className="mt-0.5 block truncate font-mono text-[7.5px] tracking-[0.04em] text-[var(--color-ink-faint)]">
+          {ingest.error ? (
+            <span className="text-[var(--color-accent)]">{ingest.error.slice(0, 60)}</span>
+          ) : txnIds.length > 0 ? (
+            <>
+              → {txnIds.map((id) => (
+                <Link key={id} {...receiptLink(id)} className="text-[var(--color-accent)]">
+                  {id.slice(0, 8)}
+                </Link>
+              ))}
+            </>
+          ) : (
+            ingest.classification?.replace('_', ' ') ?? '—'
           )}
-        >
-          <Icon size={12} />
-          {meta.label}
         </span>
-      </td>
-      <td className="px-8 py-4 text-sm">
-        {txnIds.length === 0 ? (
-          <span className="text-on-surface-variant/60">—</span>
-        ) : (
-          <div className="flex flex-wrap gap-2">
-            {txnIds.map((id) => (
-              <Link
-                key={id}
-                {...receiptLink(id)}
-                className="text-primary font-mono text-[11px] hover:underline"
-              >
-                {id.slice(0, 8)}…
-              </Link>
-            ))}
-          </div>
+      </span>
+      <span
+        className={cn(
+          'inline-flex flex-shrink-0 items-center gap-1.5 rounded-full px-2.5 py-[3px] font-mono text-[7.5px] uppercase tracking-[0.1em]',
+          tone.box,
         )}
-      </td>
-    </tr>
+      >
+        <span className={cn('h-[5px] w-[5px] rounded-full', tone.dot, tone.pulse && 'animate-pulse')} />
+        {meta.label}
+      </span>
+    </div>
   );
 }

--- a/src/components/Batches.tsx
+++ b/src/components/Batches.tsx
@@ -1,13 +1,11 @@
-import React from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { Loader2, FileStack, CheckCircle2, AlertCircle, Clock, Cog, ShieldAlert, X } from 'lucide-react';
 import { Link } from '@tanstack/react-router';
 import {
   listBatches,
   listTransactions,
   dismissNearDupFlag,
   extractProblemMessage,
-  type BatchStatus,
+  type BackendBatchSummary,
 } from '../lib/api';
 import { cn } from '../lib/utils';
 import { qk } from '../lib/queryKeys';
@@ -17,29 +15,48 @@ interface BatchesProps {
   onSelectBatch: (batchId: string) => void;
 }
 
-const STATUS_META: Record<
-  BatchStatus,
-  { label: string; badge: string; icon: React.ComponentType<{ size?: number; className?: string }> }
-> = {
-  pending: { label: 'Pending', badge: 'bg-surface-container-highest text-on-surface-variant', icon: Clock },
-  processing: { label: 'Processing', badge: 'bg-tertiary/10 text-tertiary', icon: Cog },
-  extracted: { label: 'Extracted', badge: 'bg-primary/10 text-primary', icon: CheckCircle2 },
-  reconciling: { label: 'Reconciling', badge: 'bg-tertiary/10 text-tertiary', icon: Cog },
-  reconciled: { label: 'Reconciled', badge: 'bg-primary/20 text-primary', icon: CheckCircle2 },
-  failed: { label: 'Failed', badge: 'bg-error/10 text-error', icon: AlertCircle },
-  reconcile_error: { label: 'Reconcile error', badge: 'bg-error/10 text-error', icon: AlertCircle },
-};
-
-function formatDate(iso: string): string {
-  const d = new Date(iso);
-  return d.toLocaleString(undefined, {
-    month: 'short',
-    day: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-  });
+/** Batch-row status → editorial badge (board screen 27). A near-dup or
+ *  failed count promotes the row badge above the raw lifecycle status. */
+function badgeFor(batch: BackendBatchSummary): { label: string; tone: string } {
+  const c = batch.counts ?? ({} as BackendBatchSummary['counts']);
+  if ((c.error ?? 0) > 0) return { label: `${c.error} failed`, tone: 'err' };
+  if ((c.near_dup ?? 0) > 0) return { label: 'near-dup', tone: 'flag' };
+  if ((c.dedup ?? 0) > 0 && (c.done ?? 0) === 0) return { label: 'dedup · skipped', tone: 'skip' };
+  switch (batch.status) {
+    case 'reconciled':
+      return { label: 'reconciled', tone: 'ok' };
+    case 'failed':
+    case 'reconcile_error':
+      return { label: 'failed', tone: 'err' };
+    default:
+      return { label: 'processing', tone: 'proc' };
+  }
 }
 
+const TONE: Record<string, { box: string; dot: string; pulse?: boolean }> = {
+  ok: { box: 'bg-[color:rgba(92,107,61,0.15)] text-[var(--color-olive)]', dot: 'bg-[var(--color-olive)]' },
+  proc: { box: 'bg-[color:rgba(188,134,36,0.16)] text-[var(--color-amber)]', dot: 'bg-[var(--color-amber)]', pulse: true },
+  flag: { box: 'bg-[color:rgba(188,134,36,0.16)] text-[var(--color-amber)]', dot: 'bg-[var(--color-amber)]' },
+  err: { box: 'bg-[color:rgba(181,52,26,0.13)] text-[var(--color-accent)]', dot: 'bg-[var(--color-accent)]' },
+  skip: { box: 'bg-[color:rgba(63,85,99,0.13)] text-[var(--color-slate)]', dot: 'bg-[var(--color-slate)]' },
+};
+
+function fmtWhen(iso: string): string {
+  const d = new Date(iso);
+  const today = new Date();
+  const time = d.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
+  if (d.toDateString() === today.toDateString()) return `Today · ${time}`;
+  const y = new Date(today);
+  y.setDate(y.getDate() - 1);
+  if (d.toDateString() === y.toDateString()) return `Yesterday · ${time}`;
+  return `${d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })} · ${time}`;
+}
+
+/**
+ * Uploads — the ingest batch history (board screen 27): an amber
+ * near-dup needs-review panel over a list of batches, each with an
+ * editorial status badge. Tap a row for the live trace.
+ */
 export default function Batches({ onSelectBatch }: BatchesProps) {
   const { data, isLoading: loading, error: queryError } = useQuery({
     queryKey: qk.batches.list({ limit: 50 }),
@@ -49,108 +66,92 @@ export default function Batches({ onSelectBatch }: BatchesProps) {
   const error = queryError ? extractProblemMessage(queryError) : null;
 
   return (
-    <div className="space-y-10 animate-in fade-in slide-in-from-bottom-4 duration-700">
-      <div>
-        <h2 className="font-display text-3xl font-medium tracking-tight">Upload Batches</h2>
-        <p className="text-on-surface-variant mt-2 font-inter">
-          Every receipt you upload is ingested as a batch. Open one to watch extraction + reconciliation progress in real time.
+    <div className="space-y-4">
+      <header className="pt-2">
+        <h1 className="font-display text-3xl tracking-tight">Uploads</h1>
+        <p className="mt-1 font-mono text-[10px] uppercase tracking-[0.14em] text-[var(--color-ink-muted)]">
+          {items.length} batches · every file accountable
         </p>
-      </div>
+      </header>
 
       <NeedsReviewSection />
 
-      <div className="glass-panel border border-outline-variant/10 rounded-xl overflow-hidden shadow-2xl">
-        {loading ? (
-          <div className="flex items-center justify-center py-20">
-            <Loader2 className="animate-spin text-primary" size={32} />
-            <span className="ml-3 text-on-surface-variant">Loading batches...</span>
-          </div>
-        ) : error ? (
-          <div className="text-center py-20 text-error">{error}</div>
-        ) : items.length === 0 ? (
-          <div className="flex flex-col items-center py-20 gap-3 text-on-surface-variant">
-            <FileStack size={40} className="opacity-50" />
-            <p>No uploads yet. Drop a receipt from the Add Transaction button to get started.</p>
-          </div>
-        ) : (
-          <table className="w-full text-left border-collapse">
-            <thead>
-              <tr className="bg-surface-container-low/50">
-                <th className="px-8 py-5 text-xs font-bold text-on-surface-variant uppercase tracking-widest font-headline">Uploaded</th>
-                <th className="px-8 py-5 text-xs font-bold text-on-surface-variant uppercase tracking-widest font-headline">Files</th>
-                <th className="px-8 py-5 text-xs font-bold text-on-surface-variant uppercase tracking-widest font-headline">Progress</th>
-                <th className="px-8 py-5 text-xs font-bold text-on-surface-variant uppercase tracking-widest font-headline">Status</th>
-                <th className="px-8 py-5 text-xs font-bold text-on-surface-variant uppercase tracking-widest font-headline">Auto-reconcile</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-outline-variant/5">
-              {items.map((b) => {
-                const meta = STATUS_META[b.status];
-                const Icon = meta.icon;
-                const { done, error: errored, dedup, near_dup: nearDup, total } = b.counts;
-                const pct =
-                  total > 0 ? Math.round(((done + dedup + nearDup + errored) / total) * 100) : 0;
-                return (
-                  <tr
-                    key={b.id}
-                    onClick={() => onSelectBatch(b.id)}
-                    className="hover:bg-surface-container-high/30 transition-colors cursor-pointer group"
-                  >
-                    <td className="px-8 py-6">
-                      <div className="flex flex-col">
-                        <span className="font-display text-sm font-medium group-hover:text-[var(--color-accent)] transition-colors">
-                          {formatDate(b.created_at)}
-                        </span>
-                        <span className="text-[11px] text-on-surface-variant/70 mt-0.5 font-mono">
-                          {b.id.slice(0, 8)}…
-                        </span>
-                      </div>
-                    </td>
-                    <td className="px-8 py-6 text-sm text-on-surface-variant">
-                      {b.file_count} {b.file_count === 1 ? 'file' : 'files'}
-                    </td>
-                    <td className="px-8 py-6">
-                      <div className="w-40 flex items-center gap-3">
-                        <div className="flex-1 h-1.5 bg-surface-container-highest rounded-full overflow-hidden">
-                          <div
-                            className={cn(
-                              'h-full transition-all',
-                              errored > 0 ? 'bg-error' : 'bg-primary',
-                            )}
-                            style={{ width: `${pct}%` }}
-                          />
-                        </div>
-                        <span className="text-[11px] text-on-surface-variant font-mono w-28 text-right">
-                          {done}/{total}
-                          {dedup + nearDup > 0 && (
-                            <span className="text-sky-300"> · {dedup + nearDup} deduped</span>
-                          )}
-                          {errored > 0 && <span className="text-error"> · {errored} err</span>}
-                        </span>
-                      </div>
-                    </td>
-                    <td className="px-8 py-6">
-                      <span
-                        className={cn(
-                          'inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-[11px] font-bold uppercase tracking-wider',
-                          meta.badge,
-                        )}
-                      >
-                        <Icon size={12} />
-                        {meta.label}
-                      </span>
-                    </td>
-                    <td className="px-8 py-6 text-sm text-on-surface-variant">
-                      {b.auto_reconcile ? 'On' : 'Off'}
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
-        )}
+      <div className="flex items-baseline justify-between pt-1">
+        <h2 className="font-display italic text-[1.2rem] font-medium leading-none tracking-tight">
+          batches
+        </h2>
       </div>
+
+      {loading ? (
+        <p className="py-8 text-center font-display italic text-[var(--color-ink-muted)]">loading…</p>
+      ) : error ? (
+        <p className="py-8 text-center text-[var(--color-stamp)]">{error}</p>
+      ) : items.length === 0 ? (
+        <div className="rounded-[var(--radius-card)] border-[0.5px] border-dashed border-[var(--color-rule)] px-5 py-8 text-center">
+          <p className="font-display italic text-[15px] text-[var(--color-ink-soft)]">
+            No uploads yet. Snap a receipt to start a batch.
+          </p>
+        </div>
+      ) : (
+        <div className="overflow-hidden rounded-[14px] border-[0.5px] border-[var(--color-rule-soft)] bg-[var(--color-surface)]">
+          {items.map((b, idx) => (
+            <BatchRow key={b.id} batch={b} first={idx === 0} onClick={() => onSelectBatch(b.id)} />
+          ))}
+        </div>
+      )}
+
+      <p className="px-1 pt-1 font-display italic text-[12.5px] leading-snug text-[var(--color-ink-soft)]">
+        Exact duplicates skip silently;{' '}
+        <span className="font-mono not-italic text-[10px] text-[var(--color-amber)]">near_dup</span>{' '}
+        earns an amber flag and waits for a human verdict.
+      </p>
     </div>
+  );
+}
+
+function BatchRow({
+  batch,
+  first,
+  onClick,
+}: {
+  batch: BackendBatchSummary;
+  first: boolean;
+  onClick: () => void;
+}) {
+  const total = batch.file_count ?? 0;
+  const badge = badgeFor(batch);
+  const tone = TONE[badge.tone];
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        'flex w-full items-center gap-3 px-4 py-3 text-left',
+        !first && 'border-t border-[var(--color-rule-soft)]',
+      )}
+    >
+      <span
+        aria-hidden="true"
+        className="flex h-[34px] w-[34px] flex-shrink-0 items-center justify-center rounded-[9px] border-[0.5px] border-[var(--color-rule-soft)] bg-[var(--color-paper-deep)] text-[13px] text-[var(--color-ink-soft)]"
+      >
+        ⇪
+      </span>
+      <span className="min-w-0 flex-1">
+        <span className="block font-display text-[12.5px] font-medium">{fmtWhen(batch.created_at)}</span>
+        <span className="mt-0.5 block font-mono text-[8.5px] tracking-[0.04em] text-[var(--color-ink-muted)]">
+          {total} file{total === 1 ? '' : 's'} · {batch.id.slice(0, 8)}
+        </span>
+      </span>
+      <span
+        className={cn(
+          'inline-flex flex-shrink-0 items-center gap-1.5 rounded-full px-2.5 py-[3px] font-mono text-[7.5px] uppercase tracking-[0.1em]',
+          tone.box,
+        )}
+      >
+        <span className={cn('h-[5px] w-[5px] rounded-full', tone.dot, tone.pulse && 'animate-pulse')} />
+        {badge.label}
+      </span>
+    </button>
   );
 }
 
@@ -158,8 +159,7 @@ export default function Batches({ onSelectBatch }: BatchesProps) {
  * #134 branch-4 review queue: transactions the extraction agent
  * inserted but flagged (a same-amount/date candidate existed and
  * neither side carried a strong tiebreaker). Hidden entirely when
- * empty — most sessions never see it. Dismiss = "I checked; they are
- * distinct purchases"; merging instead is the reconcile-apply flow.
+ * empty. Dismiss = "I checked; they are distinct purchases".
  */
 function NeedsReviewSection() {
   const queryClient = useQueryClient();
@@ -174,59 +174,52 @@ function NeedsReviewSection() {
   });
   const flagged = data?.items ?? [];
   if (flagged.length === 0) return null;
+
   return (
-    <div className="glass-panel border border-amber-400/20 rounded-xl overflow-hidden">
-      <div className="px-8 py-4 flex items-center gap-3 border-b border-amber-400/10 bg-amber-400/5">
-        <ShieldAlert size={18} className="text-amber-300" />
-        <div>
-          <p className="font-headline font-bold text-amber-200">
-            Needs review · {flagged.length} possible duplicate{flagged.length === 1 ? '' : 's'}
-          </p>
-          <p className="text-xs text-on-surface-variant mt-0.5">
-            Each was saved alongside a same-amount, same-day transaction without a
-            receipt/order number to tell them apart. Open both, then dismiss if they are
-            genuinely separate purchases.
-          </p>
-        </div>
-      </div>
-      <ul className="divide-y divide-outline-variant/5">
+    <section className="rounded-[13px] border-[0.5px] border-l-[3px] border-[color:rgba(188,134,36,0.45)] border-l-[var(--color-amber)] bg-[color:rgba(188,134,36,0.10)] px-3.5 py-3">
+      <p className="flex items-center justify-between font-mono text-[8px] uppercase tracking-[0.16em] text-[var(--color-amber)]">
+        <span>⚠ Needs review · near-duplicate</span>
+        <span>{flagged.length} flagged</span>
+      </p>
+      <div className="mt-2.5 space-y-2">
         {flagged.map((t) => {
           const check = (t.metadata as Record<string, any> | null)?.near_dup_check ?? {};
           const candidate: string | undefined = check.candidate_transaction_id;
           return (
-            <li key={t.id} className="px-8 py-4 flex items-center gap-4">
-              <div className="min-w-0 flex-1">
-                <Link
-                  {...receiptLink(t.id)}
-                  className="font-display text-sm font-medium hover:text-[var(--color-accent)] transition-colors"
-                >
-                  {t.payee ?? 'Unknown payee'}
-                </Link>
-                <p className="text-xs text-on-surface-variant mt-0.5">
-                  {t.occurred_on}
-                  {check.reason ? ` · ${String(check.reason).slice(0, 90)}` : ''}
-                </p>
-              </div>
-              {candidate && (
-                <Link
-                  {...receiptLink(candidate)}
-                  className="text-xs text-amber-300 hover:text-amber-200 underline underline-offset-2 shrink-0"
-                >
-                  view candidate
-                </Link>
-              )}
-              <button
-                onClick={() => dismiss.mutate(t.id)}
-                disabled={dismiss.isPending}
-                className="shrink-0 flex items-center gap-1.5 text-xs font-bold text-on-surface-variant hover:text-[var(--color-ink)] border border-outline-variant/20 hover:border-outline-variant/50 rounded-full px-3 py-1.5 transition-colors disabled:opacity-50"
+            <div key={t.id} className="rounded-[10px] bg-[var(--color-surface)] px-3 py-2">
+              <Link
+                {...receiptLink(t.id)}
+                className="block font-display text-[13.5px] font-medium leading-tight hover:text-[var(--color-accent)]"
               >
-                <X size={12} />
-                Not a duplicate
-              </button>
-            </li>
+                {t.payee ?? 'Unknown payee'}{' '}
+                <span className="font-mono text-[9px] text-[var(--color-ink-muted)]">· {t.occurred_on}</span>
+              </Link>
+              <p className="mt-0.5 text-[10.5px] leading-snug text-[var(--color-ink-soft)]">
+                Same amount + day as an existing transaction, no order number to tell them apart.
+                {check.reason ? ` ${String(check.reason).slice(0, 80)}` : ''}
+              </p>
+              <div className="mt-2 flex items-center gap-2">
+                {candidate && (
+                  <Link
+                    {...receiptLink(candidate)}
+                    className="rounded-full bg-[var(--color-ink)] px-3 py-1 font-mono text-[8.5px] uppercase tracking-[0.06em] text-[var(--color-paper)]"
+                  >
+                    view candidate ›
+                  </Link>
+                )}
+                <button
+                  type="button"
+                  onClick={() => dismiss.mutate(t.id)}
+                  disabled={dismiss.isPending}
+                  className="rounded-full border-[0.5px] border-[var(--color-rule)] px-3 py-1 font-mono text-[8.5px] uppercase tracking-[0.06em] text-[var(--color-ink-soft)] disabled:opacity-50"
+                >
+                  not a duplicate ✕
+                </button>
+              </div>
+            </div>
           );
         })}
-      </ul>
-    </div>
+      </div>
+    </section>
   );
 }

--- a/src/components/BuildInfoPanel.tsx
+++ b/src/components/BuildInfoPanel.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { buildInfo as frontendBuildInfo } from '@/generated/buildInfo';
 
 export interface BuildInfoShape {
@@ -10,43 +9,49 @@ export interface BuildInfoShape {
   builtAt: string;
 }
 
-function InfoRow({ label, value }: { label: string; value: string }) {
+function fmtDate(iso: string): string {
+  try {
+    return new Date(iso).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+  } catch {
+    return iso;
+  }
+}
+
+/**
+ * Build & Deploy receipt (board screen 24 build-card): an ink-dark
+ * status line — the exact frontend + backend commit currently live,
+ * plus the host and extractor health rows that frame Settings as the
+ * engine room rather than a preferences page.
+ */
+export default function BuildInfoPanel({ backendBuildInfo }: { backendBuildInfo: BuildInfoShape | null }) {
+  const fe = frontendBuildInfo as BuildInfoShape;
+  const backendUp = backendBuildInfo != null;
+
   return (
-    <div className="flex items-start justify-between gap-4 py-2 border-b border-outline-variant/10 last:border-b-0">
-      <span className="text-sm text-on-surface-variant">{label}</span>
-      <code className="text-sm text-white text-right break-all">{value}</code>
+    <div className="rounded-[14px] bg-[var(--color-ink)] px-4 py-3.5 text-[var(--color-paper)]">
+      <p className="mb-2.5 flex items-center gap-1.5 font-mono text-[7.5px] uppercase tracking-[0.18em] text-[var(--color-paper-fold)]">
+        <span
+          className="h-1.5 w-1.5 rounded-full animate-pulse"
+          style={{ background: backendUp ? '#8FA468' : 'var(--color-accent)' }}
+        />
+        Build &amp; Deploy · live on mini
+      </p>
+      <BuildRow label="frontend" value={`${fe.gitShortSha} · ${fmtDate(fe.builtAt)}`} />
+      <BuildRow
+        label="backend"
+        value={backendBuildInfo ? `${backendBuildInfo.gitShortSha} · ${fmtDate(backendBuildInfo.builtAt)}` : '—'}
+      />
+      <BuildRow label="host" value="mini · orbstack · tailscale" />
+      <BuildRow label="extractor" value={backendUp ? 'claude worker · healthy' : 'unreachable'} />
     </div>
   );
 }
 
-export default function BuildInfoPanel({ backendBuildInfo }: { backendBuildInfo: BuildInfoShape | null }) {
-  const cards = [
-    { title: 'Frontend', info: frontendBuildInfo },
-    { title: 'Backend', info: backendBuildInfo },
-  ];
-
+function BuildRow({ label, value }: { label: string; value: string }) {
   return (
-    <div className="grid gap-4 lg:grid-cols-2 w-full max-w-5xl">
-      {cards.map((card) => (
-        <section key={card.title} className="rounded-2xl border border-outline-variant/20 bg-surface-container-low p-5 text-left">
-          <div className="flex items-center justify-between gap-3 mb-4">
-            <h3 className="text-lg font-bold text-white">{card.title}</h3>
-            <span className="px-2.5 py-1 rounded-full text-xs font-semibold bg-surface-container-high text-primary border border-primary/20">
-              {card.info ? `${card.info.version} (${card.info.gitShortSha})` : 'Unavailable'}
-            </span>
-          </div>
-          {card.info ? (
-            <div>
-              <InfoRow label="Service" value={card.info.service} />
-              <InfoRow label="Branch" value={card.info.gitBranch} />
-              <InfoRow label="Commit" value={card.info.gitSha} />
-              <InfoRow label="Built at" value={new Date(card.info.builtAt).toLocaleString()} />
-            </div>
-          ) : (
-            <p className="text-sm text-on-surface-variant">Backend build info unavailable.</p>
-          )}
-        </section>
-      ))}
+    <div className="flex justify-between py-1 font-mono text-[9px] tracking-[0.03em] text-[var(--color-ink-faint)]">
+      <span>{label}</span>
+      <span className="text-[var(--color-paper)]">{value}</span>
     </div>
   );
 }

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -1,9 +1,11 @@
-import React from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { Boxes, Tag, History, ChevronRight } from 'lucide-react';
 import BuildInfoPanel from './BuildInfoPanel';
-import { fetchBackendBuildInfo } from '../lib/api';
+import { fetchBackendBuildInfo, fetchTransactions } from '../lib/api';
+import { listProducts } from '../lib/api/products';
+import { listBrands } from '../lib/api/brands';
+import { listBatches } from '../lib/api/ingest';
 import { qk } from '../lib/queryKeys';
+import { cn } from '../lib/utils';
 
 interface SettingsProps {
   /** Open the Products catalog screen (route: /settings/products). */
@@ -16,81 +18,144 @@ interface SettingsProps {
 }
 
 /**
- * Settings landing screen. Extracted verbatim from the old App.tsx switch
- * arm when the app moved from state-based navigation to TanStack Router —
- * each catalog card now drives a real route via the injected callbacks.
+ * Settings — the engine-room stack behind the Home gear (board screen
+ * 24): profile row, three registry cards with live counts, and the
+ * ink-dark Build & Deploy receipt. Each card drives a real route via
+ * the injected callbacks.
  */
 export default function Settings({ onOpenProducts, onOpenBrands, onOpenUploads }: SettingsProps) {
   const { data: backendBuildInfo = null } = useQuery({
     queryKey: qk.buildInfo,
     queryFn: fetchBackendBuildInfo,
   });
+  // Counts: the registries are small (< 500 rows), so a single page is
+  // the whole set — length is the count.
+  const { data: products } = useQuery({
+    queryKey: ['settings', 'count', 'products'],
+    queryFn: () => listProducts({ limit: 500 }),
+  });
+  const { data: brands } = useQuery({
+    queryKey: ['settings', 'count', 'brands'],
+    queryFn: () => listBrands(),
+  });
+  const { data: batches } = useQuery({
+    queryKey: ['settings', 'count', 'batches'],
+    queryFn: () => listBatches({ limit: 200 }),
+  });
+  const { data: earliest } = useQuery({
+    queryKey: ['settings', 'earliest-tx'],
+    queryFn: () => fetchTransactions({ sort: 'occurred_on', order: 'asc', limit: 1 }),
+  });
+
+  const tenure = (() => {
+    const first = earliest?.[0]?.date;
+    if (!first) return 'your ledger';
+    const start = new Date(first + 'T00:00:00');
+    const weeks = Math.max(1, Math.round((Date.now() - start.getTime()) / (7 * 86400000)));
+    const since = start.toLocaleDateString(undefined, { year: 'numeric', month: '2-digit' });
+    return `${weeks} weeks of receipts · since ${since}`;
+  })();
 
   return (
-    <div className="space-y-6">
-      <div className="space-y-2">
-        <h2 className="font-display text-3xl italic font-medium tracking-tight">Settings</h2>
-        <p className="text-[color:var(--color-ink-muted)] max-w-2xl">
-          Catalog management and deployment metadata.
+    <div className="space-y-4">
+      <header className="pt-2">
+        <h1 className="font-display text-3xl tracking-tight">Settings</h1>
+        <p className="mt-1 font-mono text-[10px] uppercase tracking-[0.14em] text-[var(--color-ink-muted)]">
+          the stack behind the gear
         </p>
+      </header>
+
+      {/* profile row */}
+      <div className="flex items-center gap-3 pt-1">
+        <div
+          aria-hidden="true"
+          className="h-11 w-11 rounded-full border-[1.5px] border-[var(--color-paper-warm)] shadow-[0_2px_8px_rgba(26,22,18,0.18)]"
+          style={{ background: 'radial-gradient(circle at 30% 30%, var(--color-amber), var(--color-accent) 70%)' }}
+        />
+        <div>
+          <p className="font-display text-[17px] font-medium leading-tight">Daniel</p>
+          <p className="font-mono text-[8.5px] tracking-[0.04em] text-[var(--color-ink-muted)]">
+            {tenure}
+          </p>
+        </div>
       </div>
 
-      <div className="grid sm:grid-cols-2 gap-3">
+      <div className="flex flex-col gap-2.5">
         <SettingsCard
-          icon={<Boxes size={18} />}
+          glyph="▦"
           title="Products"
-          subtitle="Catalog SSOT, owned items, merge duplicates"
+          subtitle="Catalog SSOT · merge duplicates · recompute"
+          count={products?.length}
           onClick={onOpenProducts}
         />
         <SettingsCard
-          icon={<Tag size={18} />}
+          glyph="◉"
           title="Brands"
-          subtitle="Brand registry + icon asset picker"
+          subtitle="Registry + icon asset picker · your pick locks"
+          count={brands?.length}
           onClick={onOpenBrands}
         />
         <SettingsCard
-          icon={<History size={18} />}
+          glyph="⇪"
           title="Uploads"
-          subtitle="Batch history, processing status, dedup skips"
+          subtitle="Batch history · near-dup review · dedup skips"
+          count={batches?.items?.length}
           onClick={onOpenUploads}
         />
       </div>
 
-      <div className="space-y-2 pt-4">
-        <h3 className="font-display text-xl italic font-medium tracking-tight">Build &amp; Deploy</h3>
-        <p className="text-[color:var(--color-ink-muted)] text-sm">
-          Which frontend / backend build is currently deployed.
-        </p>
-      </div>
       <BuildInfoPanel backendBuildInfo={backendBuildInfo} />
+
+      <p className="px-1 pt-1 font-display italic text-[12.5px] leading-snug text-[var(--color-ink-soft)]">
+        Settings is not preferences. It's the engine room — three registries and a deploy receipt.
+      </p>
     </div>
   );
 }
 
 function SettingsCard({
-  icon,
+  glyph,
   title,
   subtitle,
+  count,
   onClick,
 }: {
-  icon: React.ReactNode;
+  glyph: string;
   title: string;
   subtitle: string;
+  count?: number;
   onClick: () => void;
 }) {
   return (
     <button
+      type="button"
       onClick={onClick}
-      className="text-left rounded-[18px] border border-[color:var(--color-rule)] bg-[color:var(--color-surface)] px-5 py-4 flex items-center gap-4 hover:bg-[color:var(--color-paper-deep)]/30 transition-colors"
+      className={cn(
+        'flex w-full items-center gap-3 rounded-[14px] px-3.5 py-3 text-left',
+        'border-[0.5px] border-[var(--color-rule-soft)] bg-[var(--color-surface)]',
+        'transition-colors hover:border-[var(--color-rule)]',
+      )}
     >
-      <div className="shrink-0 w-10 h-10 rounded-full bg-[color:var(--color-paper-deep)] flex items-center justify-center text-[color:var(--color-ink)]">
-        {icon}
-      </div>
-      <div className="min-w-0 flex-1">
-        <div className="font-medium text-[15px]">{title}</div>
-        <div className="text-[12px] text-[color:var(--color-ink-muted)] mt-0.5">{subtitle}</div>
-      </div>
-      <ChevronRight size={16} className="text-[color:var(--color-ink-muted)]" />
+      <span
+        aria-hidden="true"
+        className="flex h-[38px] w-[38px] flex-shrink-0 items-center justify-center rounded-[10px] border-[0.5px] border-[var(--color-rule-soft)] bg-[var(--color-paper-deep)] text-[16px]"
+      >
+        {glyph}
+      </span>
+      <span className="min-w-0 flex-1">
+        <span className="block font-display text-[14px] font-medium">{title}</span>
+        <span className="mt-0.5 block text-[10px] leading-snug text-[var(--color-ink-muted)]">
+          {subtitle}
+        </span>
+      </span>
+      {count != null && (
+        <span className="flex-shrink-0 rounded-full bg-[var(--color-paper-deep)] px-2 py-0.5 font-mono text-[9px] text-[var(--color-ink-muted)]">
+          {count}
+        </span>
+      )}
+      <span aria-hidden="true" className="flex-shrink-0 text-[14px] text-[var(--color-ink-faint)]">
+        ›
+      </span>
     </button>
   );
 }


### PR DESCRIPTION
Conformance-audit follow-up (P1+P2). The three System-lane screens were still on the legacy dark-Material theme; rewritten to editorial cream matching board screens 24/27/28. Settings gains profile row + live card counts + host/extractor build rows. All data wiring preserved (SSE, dismissNearDupFlag, counts). Browser-verified against live backend — notes/reskin-*.jpeg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)