### PR TITLE
P4 mockup-only polish: brand pill bar, parties sheet, insight figures+viz

### DIFF
--- a/src/components/ReceiptDetail/parts/PartyChips.tsx
+++ b/src/components/ReceiptDetail/parts/PartyChips.tsx
@@ -1,6 +1,8 @@
+import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { Link } from '@tanstack/react-router';
-import { listTransactionParties } from '../../../lib/api/parties';
+import { motion, AnimatePresence } from 'motion/react';
+import { listTransactionParties, type TransactionParty } from '../../../lib/api/parties';
 import { brandLink } from '../../../lib/navLinks';
 import { cn } from '../../../lib/utils';
 
@@ -12,14 +14,20 @@ const ROLE_DOT: Record<string, string> = {
   acquirer: 'bg-[var(--color-ink-muted)]',
 };
 
+const ROLE_ORDER = ['channel', 'seller', 'maker', 'acquirer'];
+
 /**
  * The board's dot-chips (screens 02-03): every party the receipt
  * stated, channel/seller/maker/acquirer, deduped by (role, name).
- * Chips with a resolved brand link into the Brand page. Renders
- * nothing while the graph is empty — receipts ingested before prompt
- * v2.16 only carry the backfilled channel row.
+ * Chips with a resolved brand link into the Brand page. Below the chips,
+ * the board screen 03.8 handle ("N rows · M parties") opens a bottom
+ * sheet with the full graph — including the per-line-item maker/seller
+ * rows the deduped chips collapse. Renders nothing while the graph is
+ * empty — receipts ingested before prompt v2.16 only carry the
+ * backfilled channel row.
  */
 export function PartyChips({ transactionId }: { transactionId: string }) {
+  const [sheetOpen, setSheetOpen] = useState(false);
   const { data: parties = [] } = useQuery({
     queryKey: ['tx-parties', transactionId],
     queryFn: () => listTransactionParties(transactionId),
@@ -34,35 +42,189 @@ export function PartyChips({ transactionId }: { transactionId: string }) {
     return true;
   });
 
+  // Only surface the handle when the full graph holds more than the
+  // chips already show — otherwise the chips ARE the whole story.
+  const hasMore = parties.length > chips.length;
+
   return (
-    <div className="mt-3 flex flex-wrap items-center justify-center gap-1.5">
-      {chips.map((p) => {
-        const body = (
-          <>
-            <span
-              aria-hidden="true"
-              className={cn('h-[6px] w-[6px] rounded-full', ROLE_DOT[p.role] ?? ROLE_DOT.acquirer)}
-            />
-            <span className="font-mono text-[9px] tracking-[0.04em] text-[var(--color-ink-soft)]">
-              {p.display_name}
-            </span>
-            <span className="font-mono text-[7px] uppercase tracking-[0.1em] text-[var(--color-ink-faint)]">
-              {p.role}
-            </span>
-          </>
-        );
-        const cls =
-          'inline-flex items-center gap-1.5 rounded-full border-[0.5px] border-[var(--color-rule-soft)] bg-[var(--color-surface)] px-2.5 py-1';
-        return p.brand_id ? (
-          <Link key={p.id} {...brandLink(p.brand_id)} className={cn(cls, 'hover:border-[var(--color-rule)]')}>
-            {body}
-          </Link>
-        ) : (
-          <span key={p.id} className={cls}>
-            {body}
+    <>
+      <div className="mt-3 flex flex-wrap items-center justify-center gap-1.5">
+        {chips.map((p) => (
+          <PartyChip key={p.id} party={p} />
+        ))}
+      </div>
+
+      {hasMore && (
+        <button
+          type="button"
+          onClick={() => setSheetOpen(true)}
+          className="group mx-auto mt-2 flex flex-col items-center gap-1"
+        >
+          <span aria-hidden="true" className="h-1 w-9 rounded-full bg-[var(--color-rule)] transition-colors group-hover:bg-[var(--color-ink-muted)]" />
+          <span className="font-mono text-[8.5px] uppercase tracking-[0.12em] text-[var(--color-ink-faint)] transition-colors group-hover:text-[var(--color-ink-muted)]">
+            {parties.length} rows · {chips.length} parties · view graph
           </span>
-        );
-      })}
-    </div>
+        </button>
+      )}
+
+      <PartiesSheet
+        open={sheetOpen}
+        onClose={() => setSheetOpen(false)}
+        transactionId={transactionId}
+        parties={parties}
+        distinctCount={chips.length}
+      />
+    </>
+  );
+}
+
+function PartyChip({ party: p }: { party: TransactionParty }) {
+  const body = (
+    <>
+      <span
+        aria-hidden="true"
+        className={cn('h-[6px] w-[6px] rounded-full', ROLE_DOT[p.role] ?? ROLE_DOT.acquirer)}
+      />
+      <span className="font-mono text-[9px] tracking-[0.04em] text-[var(--color-ink-soft)]">
+        {p.display_name}
+      </span>
+      <span className="font-mono text-[7px] uppercase tracking-[0.1em] text-[var(--color-ink-faint)]">
+        {p.role}
+      </span>
+    </>
+  );
+  const cls =
+    'inline-flex items-center gap-1.5 rounded-full border-[0.5px] border-[var(--color-rule-soft)] bg-[var(--color-surface)] px-2.5 py-1';
+  return p.brand_id ? (
+    <Link {...brandLink(p.brand_id)} className={cn(cls, 'hover:border-[var(--color-rule)]')}>
+      {body}
+    </Link>
+  ) : (
+    <span className={cls}>{body}</span>
+  );
+}
+
+/**
+ * Board screen 03.8 — the full transaction_parties graph as a bottom
+ * sheet (mirrors the DeleteReceiptDialog sheet shell). Splits the graph
+ * into transaction-level parties and the per-line-item rows so the user
+ * sees why "N rows" exceeds "M parties".
+ */
+function PartiesSheet({
+  open,
+  onClose,
+  transactionId,
+  parties,
+  distinctCount,
+}: {
+  open: boolean;
+  onClose: () => void;
+  transactionId: string;
+  parties: TransactionParty[];
+  distinctCount: number;
+}) {
+  const txLevel = parties.filter((p) => p.transaction_item_id == null);
+  const itemLevel = parties.filter((p) => p.transaction_item_id != null);
+  const byRole = (rows: TransactionParty[]) =>
+    [...rows].sort(
+      (a, b) =>
+        (ROLE_ORDER.indexOf(a.role) + 1 || 99) - (ROLE_ORDER.indexOf(b.role) + 1 || 99) ||
+        a.display_name.localeCompare(b.display_name),
+    );
+
+  return (
+    <AnimatePresence>
+      {open && (
+        <div className="fixed inset-0 z-[110] flex items-end justify-center">
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            onClick={onClose}
+            className="absolute inset-0 bg-[color:rgba(26,22,18,0.38)]"
+          />
+          <motion.div
+            initial={{ y: '100%' }}
+            animate={{ y: 0 }}
+            exit={{ y: '100%' }}
+            transition={{ type: 'tween', ease: [0.16, 1, 0.3, 1], duration: 0.32 }}
+            className="relative flex max-h-[80vh] w-full max-w-lg flex-col overflow-hidden rounded-t-[20px] bg-[var(--color-paper)] pb-[env(safe-area-inset-bottom,0px)] shadow-[0_-12px_40px_rgba(26,22,18,0.28)]"
+          >
+            <div aria-hidden="true" className="mx-auto mb-2 mt-2.5 h-1 w-9 rounded-full bg-[var(--color-rule)]" />
+            <div className="flex items-baseline justify-between px-5 pb-3">
+              <div>
+                <h2 className="font-display text-[19px] font-medium tracking-tight">
+                  The party graph
+                </h2>
+                <p className="mt-0.5 font-mono text-[9px] tracking-[0.04em] text-[var(--color-ink-muted)]">
+                  {parties.length} rows · {distinctCount} parties · tx_{transactionId.slice(0, 8)}
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={onClose}
+                className="font-mono text-[10px] uppercase tracking-[0.1em] text-[var(--color-ink-faint)] hover:text-[var(--color-ink-muted)]"
+              >
+                done
+              </button>
+            </div>
+
+            <div className="min-h-0 flex-1 overflow-y-auto px-5 pb-5">
+              <PartyGroup title="Transaction" rows={byRole(txLevel)} />
+              {itemLevel.length > 0 && (
+                <PartyGroup title="Per line item" rows={byRole(itemLevel)} />
+              )}
+            </div>
+          </motion.div>
+        </div>
+      )}
+    </AnimatePresence>
+  );
+}
+
+function PartyGroup({ title, rows }: { title: string; rows: TransactionParty[] }) {
+  if (rows.length === 0) return null;
+  return (
+    <section className="mb-4 last:mb-0">
+      <h3 className="mb-1.5 font-mono text-[8.5px] uppercase tracking-[0.16em] text-[var(--color-ink-muted)]">
+        {title} · {rows.length}
+      </h3>
+      <div className="rounded-[12px] border-[0.5px] border-[var(--color-rule-soft)] bg-[var(--color-surface)] px-3.5">
+        {rows.map((p, i) => {
+          const inner = (
+            <>
+              <span
+                aria-hidden="true"
+                className={cn('h-2 w-2 flex-shrink-0 rounded-full', ROLE_DOT[p.role] ?? ROLE_DOT.acquirer)}
+              />
+              <span className="min-w-0 flex-1 truncate font-display text-[13px] font-medium text-[var(--color-ink)]">
+                {p.display_name}
+              </span>
+              <span className="flex-shrink-0 font-mono text-[8px] uppercase tracking-[0.12em] text-[var(--color-ink-muted)]">
+                {p.role}
+              </span>
+              {p.brand_id && (
+                <span aria-hidden="true" className="flex-shrink-0 text-[11px] text-[var(--color-ink-faint)]">
+                  ›
+                </span>
+              )}
+            </>
+          );
+          const cls = cn(
+            'flex items-center gap-2.5 py-2.5',
+            i > 0 && 'border-t border-[var(--color-rule-soft)]',
+          );
+          return p.brand_id ? (
+            <Link key={p.id} {...brandLink(p.brand_id)} className={cn(cls, 'transition-opacity hover:opacity-70')}>
+              {inner}
+            </Link>
+          ) : (
+            <div key={p.id} className={cls}>
+              {inner}
+            </div>
+          );
+        })}
+      </div>
+    </section>
   );
 }

--- a/src/components/Transactions.tsx
+++ b/src/components/Transactions.tsx
@@ -82,6 +82,10 @@ export default function Transactions({
   const [hardDeleteTarget, setHardDeleteTarget] = useState<{ id: string; etag: string } | null>(null);
   const [unreconcileTarget, setUnreconcileTarget] = useState<string | null>(null);
   const [rowError, setRowError] = useState<string | null>(null);
+  // Board screen 02.5: a lightweight brand quick-filter above the rows.
+  // Ephemeral (not URL-persisted) — the structured Category/Type/Sort
+  // filters own the URL; this is a one-tap narrowing over what's loaded.
+  const [brandFilter, setBrandFilter] = useState<string | null>(null);
 
   // All view state is derived from the URL — single source of truth.
   const { filters, sortId, q: searchQuery, showDeleted } = useMemo(
@@ -250,6 +254,26 @@ export default function Transactions({
     },
   });
 
+  // Brand pills derived from what's loaded: rank brands by frequency,
+  // keep the top few, label by prettified brand_id. Stays in sync with
+  // the visible month — no extra fetch, no stale global brand list.
+  const brandPills = useMemo(() => {
+    const count = new Map<string, number>();
+    for (const tx of transactions) {
+      if (tx.merchantBrandId) count.set(tx.merchantBrandId, (count.get(tx.merchantBrandId) ?? 0) + 1);
+    }
+    return [...count.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 8)
+      .map(([id, n]) => ({ id, label: prettifyBrandId(id), count: n }));
+  }, [transactions]);
+
+  // A brand can scroll out of the visible set (month change, filter); if
+  // the active pill no longer exists, fall back to All so rows reappear.
+  useEffect(() => {
+    if (brandFilter && !brandPills.some((p) => p.id === brandFilter)) setBrandFilter(null);
+  }, [brandPills, brandFilter]);
+
   const filteredTransactions = useMemo(() => {
     let out = transactions;
     if (filters.transactionTypes.length > 0) {
@@ -260,8 +284,11 @@ export default function Transactions({
       const catSet = new Set<string>(filters.categories);
       out = out.filter((tx) => tx.category !== null && catSet.has(tx.category));
     }
+    if (brandFilter) {
+      out = out.filter((tx) => tx.merchantBrandId === brandFilter);
+    }
     return out;
-  }, [transactions, filters.categories, filters.transactionTypes]);
+  }, [transactions, filters.categories, filters.transactionTypes, brandFilter]);
 
   const totalExpenses = filteredTransactions
     .filter((tx) => tx.amount < 0)
@@ -336,12 +363,19 @@ export default function Transactions({
           // leaves sort (view config) untouched — same semantics as
           // before, now expressed as one URL write.
           setSearchInput('');
+          setBrandFilter(null);
           pushState({ filters: DEFAULT_FILTERS, q: '' });
         }}
         showDeleted={showDeleted}
         onToggleShowDeleted={toggleShowDeleted}
         sortId={sortId}
         onSortChange={setSortId}
+      />
+
+      <BrandPillBar
+        pills={brandPills}
+        active={brandFilter}
+        onSelect={setBrandFilter}
       />
 
       {rowError && (
@@ -456,6 +490,76 @@ export default function Transactions({
         }}
       />
     </div>
+  );
+}
+
+/* ── Brand pill bar (board screen 02.5) ──────────────────────────── */
+
+/** `apple-store` → `Apple Store`. Stable, no fetch; small joiner words stay low. */
+function prettifyBrandId(id: string): string {
+  const small = new Set(['and', 'or', 'of', 'the', 'a']);
+  return id
+    .split('-')
+    .map((w, i) => (i > 0 && small.has(w) ? w : w.charAt(0).toUpperCase() + w.slice(1)))
+    .join(' ');
+}
+
+function BrandPillBar({
+  pills,
+  active,
+  onSelect,
+}: {
+  pills: Array<{ id: string; label: string; count: number }>;
+  active: string | null;
+  onSelect: (id: string | null) => void;
+}) {
+  // Below two brands there's nothing to choose between — hide entirely.
+  if (pills.length < 2) return null;
+  return (
+    <div className="-mx-5 flex gap-1.5 overflow-x-auto px-5 pb-0.5 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+      <Pill label="All" active={active === null} onClick={() => onSelect(null)} />
+      {pills.map((p) => (
+        <Pill
+          key={p.id}
+          label={p.label}
+          count={p.count}
+          active={active === p.id}
+          onClick={() => onSelect(active === p.id ? null : p.id)}
+        />
+      ))}
+    </div>
+  );
+}
+
+function Pill({
+  label,
+  count,
+  active,
+  onClick,
+}: {
+  label: string;
+  count?: number;
+  active: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        'flex flex-shrink-0 items-center gap-1.5 whitespace-nowrap rounded-full border-[0.5px] px-3 py-1 font-mono text-[10px] uppercase tracking-[0.08em] transition-colors',
+        active
+          ? 'border-[var(--color-ink)] bg-[var(--color-ink)] text-[var(--color-paper)]'
+          : 'border-[var(--color-rule-soft)] bg-[var(--color-surface)] text-[var(--color-ink-soft)] hover:border-[var(--color-rule)]',
+      )}
+    >
+      {label}
+      {count != null && (
+        <span className={cn('tnum text-[8.5px]', active ? 'text-[var(--color-paper-fold)]' : 'text-[var(--color-ink-faint)]')}>
+          {count}
+        </span>
+      )}
+    </button>
   );
 }
 

--- a/src/routes/_shell/insights/index.tsx
+++ b/src/routes/_shell/insights/index.tsx
@@ -14,12 +14,39 @@ export const Route = createFileRoute('/_shell/insights/')({
   component: InsightsRoute,
 });
 
-const KIND_STYLE: Record<string, { border: string; tag: string; glyph: string }> = {
-  anomaly: { border: 'border-l-[var(--color-amber)]', tag: 'text-[var(--color-amber)]', glyph: '⚠' },
-  trend: { border: 'border-l-[var(--color-accent)]', tag: 'text-[var(--color-accent)]', glyph: '↯' },
-  milestone: { border: 'border-l-[var(--color-olive)]', tag: 'text-[var(--color-olive)]', glyph: '★' },
-  opportunity: { border: 'border-l-[var(--color-slate)]', tag: 'text-[var(--color-slate)]', glyph: '◇' },
+const KIND_STYLE: Record<string, { border: string; tag: string; glyph: string; bar: string }> = {
+  anomaly: { border: 'border-l-[var(--color-amber)]', tag: 'text-[var(--color-amber)]', glyph: '⚠', bar: 'var(--color-amber)' },
+  trend: { border: 'border-l-[var(--color-accent)]', tag: 'text-[var(--color-accent)]', glyph: '↯', bar: 'var(--color-accent)' },
+  milestone: { border: 'border-l-[var(--color-olive)]', tag: 'text-[var(--color-olive)]', glyph: '★', bar: 'var(--color-olive)' },
+  opportunity: { border: 'border-l-[var(--color-slate)]', tag: 'text-[var(--color-slate)]', glyph: '◇', bar: 'var(--color-slate)' },
 };
+
+/** Numeric figures the rule engine attaches per kind (`payload.figures`). */
+interface Figures {
+  current?: number;
+  previous?: number;
+  pct?: number;
+  days?: number;
+  mark?: number;
+}
+
+function readFigures(payload: Insight['payload']): Figures | null {
+  if (typeof payload !== 'object' || payload === null) return null;
+  const f = (payload as Record<string, unknown>).figures;
+  if (typeof f !== 'object' || f === null) return null;
+  const out: Figures = {};
+  for (const k of ['current', 'previous', 'pct', 'days', 'mark'] as const) {
+    const v = (f as Record<string, unknown>)[k];
+    if (typeof v === 'number' && Number.isFinite(v)) out[k] = v;
+  }
+  return Object.keys(out).length > 0 ? out : null;
+}
+
+/** anomaly figures are dollar amounts; trend figures are visit counts. */
+function fmtFigure(kind: string, n: number): string {
+  if (kind === 'anomaly') return `$${Math.round(n).toLocaleString()}`;
+  return n.toLocaleString();
+}
 
 /**
  * /insights — board screens 18-19: the ask bar, the discovered-cards
@@ -220,6 +247,7 @@ function InsightCard({
         {card.title}
       </h3>
       <p className="mt-1 text-[11.5px] leading-snug text-[var(--color-ink-muted)]">{card.body}</p>
+      <CardFigures kind={card.kind} figures={readFigures(card.payload)} bar={style.bar} />
       {deepLink && (
         <button
           type="button"
@@ -230,6 +258,105 @@ function InsightCard({
         </button>
       )}
     </article>
+  );
+}
+
+/**
+ * Board screens 18.4/18.5 — the emphatic figure + mini bar-viz on each
+ * card. `compare` kinds (anomaly/trend) get two stacked bars (this vs
+ * prior, the active one kind-colored); `milestone` gets a day-count
+ * figure with a thin progress line crossing its mark. Pure CSS, no chart
+ * lib — the data is one or two numbers.
+ */
+function CardFigures({
+  kind,
+  figures,
+  bar,
+}: {
+  kind: string;
+  figures: Figures | null;
+  bar: string;
+}) {
+  if (!figures) return null;
+
+  // milestone: days held past a round mark
+  if (figures.days != null) {
+    const mark = figures.mark ?? figures.days;
+    const frac = mark > 0 ? Math.min(1, mark / figures.days) : 1;
+    return (
+      <div className="mt-3 flex items-end gap-3">
+        <div className="leading-none">
+          <span className="font-mono text-[22px] font-semibold tnum text-[var(--color-ink)]">
+            {figures.days.toLocaleString()}
+          </span>
+          <span className="ml-1 font-mono text-[8.5px] uppercase tracking-[0.12em] text-[var(--color-ink-muted)]">
+            days
+          </span>
+        </div>
+        <div className="mb-1 min-w-0 flex-1">
+          <div className="relative h-1.5 overflow-hidden rounded-full bg-[var(--color-paper-fold)]">
+            <span className="absolute inset-y-0 left-0 rounded-full" style={{ width: '100%', background: bar, opacity: 0.85 }} />
+            {/* the round-number mark, as a tick along the filled bar */}
+            <span className="absolute inset-y-0 w-px bg-[var(--color-paper)]" style={{ left: `${frac * 100}%` }} />
+          </div>
+          <p className="mt-1 font-mono text-[8px] uppercase tracking-[0.1em] text-[var(--color-ink-faint)]">
+            past {mark.toLocaleString()} mark
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  // anomaly / trend: this month vs prior, two mini bars
+  if (figures.current != null && figures.previous != null) {
+    const max = Math.max(figures.current, figures.previous, 1);
+    return (
+      <div className="mt-3 flex items-center gap-3.5">
+        {figures.pct != null && (
+          <div className="flex-shrink-0 leading-none">
+            <span className="font-mono text-[20px] font-semibold tnum" style={{ color: bar }}>
+              {figures.pct > 0 ? '+' : ''}
+              {figures.pct}%
+            </span>
+          </div>
+        )}
+        <div className="min-w-0 flex-1 space-y-1">
+          <MiniBar label="now" value={figures.current} max={max} text={fmtFigure(kind, figures.current)} color={bar} />
+          <MiniBar label="prior" value={figures.previous} max={max} text={fmtFigure(kind, figures.previous)} color="var(--color-ink-faint)" />
+        </div>
+      </div>
+    );
+  }
+
+  return null;
+}
+
+function MiniBar({
+  label,
+  value,
+  max,
+  text,
+  color,
+}: {
+  label: string;
+  value: number;
+  max: number;
+  text: string;
+  color: string;
+}) {
+  const pct = max > 0 ? (value / max) * 100 : 0;
+  return (
+    <div className="flex items-center gap-2">
+      <span className="w-7 flex-shrink-0 font-mono text-[7.5px] uppercase tracking-[0.1em] text-[var(--color-ink-faint)]">
+        {label}
+      </span>
+      <span className="relative h-2 min-w-0 flex-1 overflow-hidden rounded-[2px] bg-[var(--color-paper-fold)]">
+        <span className="absolute inset-y-0 left-0 rounded-[2px]" style={{ width: `${Math.max(pct, value > 0 ? 4 : 0)}%`, background: color }} />
+      </span>
+      <span className="w-12 flex-shrink-0 text-right font-mono text-[9px] tnum text-[var(--color-ink-soft)]">
+        {text}
+      </span>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary
Backfills the three `[mockup]` items the design-vs-impl audit flagged as present-in-design / absent-in-code — the P4 (nice-to-have) tier of the mobile redesign (`receipt-assistant#149`).

## Items
- **02.5 Ledger brand pill bar** — horizontal quick-filter above the rows, derived client-side from the loaded month (rank brands by frequency, top 8, label = prettified `brand_id`). Ephemeral local state; structured Category/Type/Sort filters keep owning the URL. Hidden below two brands. Narrows by `merchantBrandId`; falls back to **All** if the active brand scrolls out.
- **03.8 ReceiptDetail parties bottom-sheet** — grabber handle (`"N rows · M parties · view graph"`) under the dot-chips, shown only when the full graph exceeds the deduped chips. Opens a bottom sheet (mirrors the `DeleteReceiptDialog` shell) splitting **transaction-level** vs **per-line-item** rows. Brand-resolved rows link to the Brand page.
- **18.4/18.5 Insight card figures + mini bar-viz** — reads the rule engine's `payload.figures`. `anomaly`/`trend` → two stacked mini bars (now vs prior, active one kind-colored) + signed `pct`; `milestone` → big day-count + thin progress line crossing its round-number mark. Pure CSS, no chart lib.

## Acceptance criteria
- [ ] Ledger shows brand pills; tapping one narrows the rows; **All** clears; bar hidden when <2 brands.
- [ ] A receipt with line-item parties shows the handle; tapping opens the sheet with tx-level + per-item groups.
- [ ] Insight cards render figures + mini-viz for all three figure shapes.
- [ ] `tsc --noEmit` + `vite build` clean.

## Notes
Verified on the mini after deploy (browser evidence in the close comment, per project UI rule). No backend/contract change — all three read existing data.