### PR TITLE
feat: render product images in Things/Owned grid + product detail (#133)

### DIFF
--- a/src/components/ProductImage.tsx
+++ b/src/components/ProductImage.tsx
@@ -1,0 +1,97 @@
+import { useState } from 'react';
+import { classGlyph } from '../lib/things';
+
+/**
+ * #133 — product imagery for the Things/Owned grid and the product
+ * detail hero, mirroring `MerchantIcon` (#48) exactly. The cascade is
+ * deliberately just one step:
+ *
+ *   product.image  (GET /v1/products/:id/image — server resolves
+ *                   preferred_asset_id; 404 when none)
+ *     → classGlyph(item_class)  (final fallback — the class glyph)
+ *
+ * There is **no inter-candidate cascade**: we never fall back to a
+ * brand/merchant icon, only to the class glyph. If the product has no
+ * `preferred_asset_id` (server 404s) or the bytes fail to load
+ * (`<img onError>`), or there's no `productId` at all, we render the
+ * glyph directly — and skip the `<img>` so we don't fire a wasted 404
+ * on every render.
+ *
+ * Unlike `MerchantIcon` this fills its container (the grid cell's
+ * `aspect-[4/3]` tile or the detail hero) rather than rendering a
+ * fixed-size square, so the call sites control sizing via `className`.
+ */
+interface ProductImageProps {
+  /** Product id (uuid) from `owned_item.product_id` / `product.id`.
+   *  When null/empty, skips the image attempt and renders the glyph. */
+  productId: string | null | undefined;
+  /** Item class drives the fallback glyph (`durable`, `consumable`,
+   *  `service`, `food_drink`, …). */
+  itemClass: string | null | undefined;
+  /** Optional className passthrough — applied to the outer wrapper. */
+  className?: string;
+}
+
+export function ProductImage({ productId, itemClass, className }: ProductImageProps) {
+  const [errored, setErrored] = useState(false);
+
+  // No product to query OR a prior load errored → render the class
+  // glyph fallback directly. Skipping the `<img>` tag also avoids a
+  // wasted 404 request on every render for products with no image.
+  if (!productId || errored) {
+    return (
+      <span
+        aria-hidden="true"
+        className={className}
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          width: '100%',
+          height: '100%',
+          fontSize: '34px',
+          color: 'var(--color-ink-faint)',
+        }}
+      >
+        {classGlyph(itemClass)}
+      </span>
+    );
+  }
+
+  // The product-image endpoint is proxied through Vite at `/api/v1/...`
+  // — same convention as the brand-icon path (#48) and merchant
+  // photos (#67).
+  const src = `/api/v1/products/${productId}/image`;
+
+  return (
+    <span
+      className={className}
+      style={{
+        display: 'flex',
+        width: '100%',
+        height: '100%',
+        overflow: 'hidden',
+        // White backdrop so PNGs with transparent backgrounds (the
+        // common case for clean product cutouts) read on any surface,
+        // matching MerchantIcon's treatment.
+        background: '#fff',
+        // Light inset rule so the white tile doesn't visually merge
+        // with the surrounding card on white themes.
+        boxShadow: 'inset 0 0 0 1px var(--color-rule)',
+      }}
+    >
+      <img
+        src={src}
+        alt=""
+        loading="lazy"
+        decoding="async"
+        onError={() => setErrored(true)}
+        style={{
+          width: '100%',
+          height: '100%',
+          objectFit: 'contain',
+        }}
+      />
+    </span>
+  );
+}

--- a/src/generated/buildInfo.json
+++ b/src/generated/buildInfo.json
@@ -1,8 +1,8 @@
 {
   "service": "receipt-assistant-frontend",
   "version": "0.0.0",
-  "gitSha": "f98f5dc9ba86a23e0de1ee3ed0faf6ef5e74c904",
-  "gitShortSha": "f98f5dc",
-  "gitBranch": "feat/near-dup-review-ui",
-  "builtAt": "2026-06-12T00:38:47.148Z"
+  "gitSha": "0917b02352d348372b92ad29317930eab639e106",
+  "gitShortSha": "0917b02",
+  "gitBranch": "feat/product-images-ui",
+  "builtAt": "2026-06-24T08:54:20.628Z"
 }

--- a/src/generated/buildInfo.ts
+++ b/src/generated/buildInfo.ts
@@ -1,8 +1,8 @@
 export const buildInfo = {
   "service": "receipt-assistant-frontend",
   "version": "0.0.0",
-  "gitSha": "f98f5dc9ba86a23e0de1ee3ed0faf6ef5e74c904",
-  "gitShortSha": "f98f5dc",
-  "gitBranch": "feat/near-dup-review-ui",
-  "builtAt": "2026-06-12T00:38:47.148Z"
+  "gitSha": "0917b02352d348372b92ad29317930eab639e106",
+  "gitShortSha": "0917b02",
+  "gitBranch": "feat/product-images-ui",
+  "builtAt": "2026-06-24T08:54:20.628Z"
 } as const;

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -1248,6 +1248,209 @@ export interface paths {
         };
         trace?: never;
     };
+    "/v1/products/{id}/image": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Stream the product's preferred image bytes
+         * @description Resolves preferred_asset_id and streams the file. 404 when the product is missing, no asset is preferred, the asset is retired, or the file is missing on disk. Frontend falls back to a category placeholder on 404 — never to a different candidate.
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Image bytes */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Product or image unavailable */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/products/{id}/assets": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List candidate images for a product */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            items: components["schemas"]["ProductAsset"][];
+                            next_cursor: string | null;
+                        };
+                    };
+                };
+                /** @description Not Found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        /**
+         * Upload a user-provided product image
+         * @description Multipart upload (field name `file`) — saves bytes to the product-assets bind-mount, inserts a product_assets row with tier=user_upload, and stamps preferred_asset_chosen_at + preferred_asset_id to the new asset (the upload IS the user's choice; Layer-3 lock). Re-uploading identical bytes returns the existing row 200 OK (UNIQUE on (product_id, content_hash)); new bytes return 201.
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "multipart/form-data": components["schemas"]["UploadProductAssetForm"];
+                };
+            };
+            responses: {
+                /** @description Dedup hit — existing asset returned */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ProductAsset"];
+                    };
+                };
+                /** @description New asset created */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ProductAsset"];
+                    };
+                };
+                /** @description Product not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+                /** @description Validation failed */
+                422: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/products/{id}/assets/{assetId}/image": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Stream an individual candidate asset's bytes
+         * @description Streams any candidate (not just preferred) so the UI picker can render thumbnails. Scoped by product_id to prevent cross-product asset_id enumeration. 404 if missing, retired, or the file is gone from disk.
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                    assetId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Asset bytes */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Not Found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/products/{id}/merge_into": {
         parameters: {
             query?: never;
@@ -4731,6 +4934,12 @@ export interface components {
             /** Format: date-time */
             retired_from_catalog_at: string | null;
             /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            preferred_asset_id: string | null;
+            image_url: string | null;
+            /**
              * @description User-defined JSON object; not schema-validated.
              * @default {}
              */
@@ -4741,6 +4950,50 @@ export interface components {
             created_at: string;
             /** Format: date-time */
             updated_at: string;
+        };
+        ProductAsset: {
+            /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            id: string;
+            /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            product_id: string;
+            /** @enum {string} */
+            tier: "manual_seed" | "user_upload" | "agent_fetch";
+            source_url: string | null;
+            local_path: string;
+            content_hash: string;
+            content_type: string;
+            width: number | null;
+            height: number | null;
+            bytes: number | null;
+            /** Format: date-time */
+            acquired_at: string;
+            /** Format: date-time */
+            last_seen_at: string;
+            agent_relevance: number | null;
+            agent_notes: string | null;
+            extraction_version: number;
+            user_rating: number | null;
+            user_uploaded: boolean;
+            user_notes: string | null;
+            /** Format: date-time */
+            retired_at: string | null;
+            /**
+             * @description User-defined JSON object; not schema-validated.
+             * @default {}
+             */
+            metadata: {
+                [key: string]: unknown;
+            };
+        };
+        UploadProductAssetForm: {
+            /** Format: binary */
+            file?: string;
         };
         UpdateProductRequest: {
             custom_name?: string | null;
@@ -4753,6 +5006,11 @@ export interface components {
             merchant_id?: string | null;
             /** Format: date-time */
             retired_from_catalog_at?: string | null;
+            /**
+             * Format: uuid
+             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
+             */
+            preferred_asset_id?: string | null;
         };
         MergeProductRequest: {
             /**

--- a/src/routes/_shell/owned/index.tsx
+++ b/src/routes/_shell/owned/index.tsx
@@ -7,9 +7,9 @@ import {
   daysHeld,
   perDay,
   fmtPerDay,
-  classGlyph,
   type OwnedStatus,
 } from '../../../lib/things';
+import { ProductImage } from '../../../components/ProductImage';
 import { cn } from '../../../lib/utils';
 
 export const Route = createFileRoute('/_shell/owned/')({
@@ -130,9 +130,7 @@ function OwnedRoute() {
                 className="overflow-hidden rounded-[14px] border-[0.5px] border-[var(--color-rule-soft)] bg-[var(--color-surface)] transition-colors hover:border-[var(--color-rule)]"
               >
                 <div className="relative flex aspect-[4/3] items-center justify-center bg-[var(--color-paper-deep)]">
-                  <span aria-hidden="true" className="text-[34px] text-[var(--color-ink-faint)]">
-                    {classGlyph(it.item_class)}
-                  </span>
+                  <ProductImage productId={it.product_id} itemClass={it.item_class} />
                   <span
                     className={cn(
                       'absolute left-2 top-2 rounded-full px-2 py-[2px] font-mono text-[7px] uppercase tracking-[0.1em] text-[var(--color-paper)]',

--- a/src/routes/_shell/product/$productId.tsx
+++ b/src/routes/_shell/product/$productId.tsx
@@ -2,7 +2,8 @@ import { createFileRoute, Link } from '@tanstack/react-router';
 import { useQuery } from '@tanstack/react-query';
 import { getProduct } from '../../../lib/api/products';
 import { listOwnedItemsExpanded } from '../../../lib/api/things';
-import { daysHeld, perDay, fmtPerDay, classGlyph } from '../../../lib/things';
+import { daysHeld, perDay, fmtPerDay } from '../../../lib/things';
+import { ProductImage } from '../../../components/ProductImage';
 import { brandLink } from '../../../lib/navLinks';
 import { useBack } from '../../../lib/useBack';
 import { cn } from '../../../lib/utils';
@@ -74,9 +75,7 @@ function ProductRoute() {
 
       {/* hero */}
       <div className="flex aspect-[5/3] items-center justify-center overflow-hidden rounded-[18px] border-[0.5px] border-[var(--color-rule-soft)] bg-[var(--color-paper-deep)]">
-        <span aria-hidden="true" className="text-[64px] text-[var(--color-ink-faint)]">
-          {classGlyph(product.item_class)}
-        </span>
+        <ProductImage productId={product.id} itemClass={product.item_class} />
       </div>
 
       <div>


### PR DESCRIPTION
## Summary
Implements product-image rendering in the frontend, mirroring the brand-icon path (#48). The backend `GET /v1/products/:id/image` is already live (returns `200 image/png` for a product with a `preferred_asset_id`, else `404`), and the committed `openapi.json` now carries the path.

## Changes
- **New `src/components/ProductImage.tsx`** — mirrors `MerchantIcon.tsx`: renders `<img src="/api/v1/products/:id/image">` (proxied through Vite), white bg + inset rule shadow for transparent PNGs, `loading="lazy"`. On `onError`, missing `productId`, or backend 404 it falls back to `classGlyph(item_class)` from `src/lib/things.ts`. **No inter-candidate cascade** — never falls back to a brand/merchant icon, only the class glyph.
- **`src/routes/_shell/owned/index.tsx`** — replaced the `aspect-[4/3]` tile's bare `classGlyph` span with `<ProductImage productId={it.product_id} itemClass={it.item_class} />`. Status pill unchanged.
- **`src/routes/_shell/product/$productId.tsx`** — replaced the hero's `classGlyph` span with `<ProductImage productId={product.id} itemClass={product.item_class} />`.
- **`src/lib/api-types.ts`** — regenerated via `npm run api:types` to pick up the new `/v1/products/{id}/image` path. Not hand-written.

## Field names verified
- `OwnedItemExpanded.product_id` (string, from base `OwnedItem`) and `OwnedItemExpanded.item_class` (`string | null`).
- `Product.id` (string) and `Product.item_class` (enum string).

## Verification
- `npm run api:types` — passed (new path present in regenerated types).
- `npm run build` (`tsc && vite build`) — passed, exit 0.

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)