### PR TITLE
feat(items): adaptive two-level line-item list (parent_line_no + product_variant)

### DIFF
--- a/src/components/ReceiptDetail/index.tsx
+++ b/src/components/ReceiptDetail/index.tsx
@@ -217,8 +217,10 @@ export default function ReceiptDetail({ receiptId, onBack, onAfterMutation }: Re
     ? receipt.items
     : (legacyItems ?? []).map((i, idx) => ({
         line_no: idx + 1,
+        parent_line_no: null,
         raw_name: i.name,
         normalized_name: null,
+        product_variant: null,
         quantity: i.quantity ?? 1,
         unit: null,
         unit_price_minor: i.unit_price != null ? Math.round(i.unit_price * 100) : null,

--- a/src/components/ReceiptDetail/parts/LineItemsCard.tsx
+++ b/src/components/ReceiptDetail/parts/LineItemsCard.tsx
@@ -1,3 +1,5 @@
+import { useMemo, useState } from 'react';
+import { ChevronDown, ChevronRight } from 'lucide-react';
 import { cn } from '../../../lib/utils';
 import type { BackendTransactionItem } from '../../../lib/api';
 
@@ -19,10 +21,208 @@ const ITEM_CLASS_LABEL: Record<BackendTransactionItem['item_class'], string> = {
   other: 'other',
 };
 
-function formatMinor(minor: number | null, currency: string): string {
+// Above this many top-level product lines a receipt counts as "large":
+// the analytical breakdown never bulk-expands (#162 / FE#135 large-receipt
+// guard). Individual lines can still be tapped open.
+const LARGE_RECEIPT_THRESHOLD = 12;
+
+function formatMinor(minor: number | null | undefined, currency: string): string {
   if (minor == null) return '—';
   const sym = currency === 'USD' ? '$' : '';
-  return `${sym}${(minor / 100).toFixed(2)}`;
+  const neg = minor < 0;
+  const abs = (Math.abs(minor) / 100).toFixed(2);
+  // U+2212 MINUS SIGN reads better than hyphen for signed money.
+  return `${neg ? '−' : ''}${sym}${abs}`;
+}
+
+/** All-in per-line amount actually charged: effective_total when the backend
+ *  distributed tax/tip/discount, else the printed line total. */
+function allInMinor(item: BackendTransactionItem): number {
+  return item.effective_total_minor ?? item.line_total_minor;
+}
+
+type BreakdownRow = { label: string; minor: number | null; kind: 'base' | 'add' | 'sub' };
+
+/** Analytical level-2: how the printed list price becomes the all-in charge.
+ *  Returns null when there is nothing to disclose (no tax/tip/discount share
+ *  and the effective total equals the list price). */
+function breakdown(item: BackendTransactionItem): BreakdownRow[] | null {
+  const tax = item.tax_minor ?? 0;
+  const tip = item.tip_share_minor ?? 0;
+  const discount = item.discount_share_minor ?? 0;
+  const effective = allInMinor(item);
+  const nothing =
+    tax === 0 &&
+    tip === 0 &&
+    discount === 0 &&
+    effective === item.line_total_minor;
+  if (nothing) return null;
+  const rows: BreakdownRow[] = [
+    { label: 'List price', minor: item.line_total_minor, kind: 'base' },
+  ];
+  if (tax !== 0) rows.push({ label: 'Tax share', minor: item.tax_minor, kind: 'add' });
+  if (tip !== 0) rows.push({ label: 'Tip share', minor: item.tip_share_minor, kind: 'add' });
+  if (discount !== 0)
+    rows.push({ label: 'Discount share', minor: item.discount_share_minor, kind: 'sub' });
+  return rows;
+}
+
+function ItemClassPill({ item }: { item: BackendTransactionItem }) {
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-medium leading-none',
+        ITEM_CLASS_STYLE[item.item_class],
+      )}
+    >
+      {ITEM_CLASS_LABEL[item.item_class]}
+    </span>
+  );
+}
+
+function ProductLine({
+  item,
+  currency,
+  isChild,
+  open,
+  onToggle,
+}: {
+  item: BackendTransactionItem;
+  currency: string;
+  isChild: boolean;
+  open: boolean;
+  onToggle: (() => void) | null;
+}) {
+  const name = item.normalized_name?.trim() || item.raw_name;
+  const cur = item.currency || currency;
+  const rows = breakdown(item);
+  const disclosable = rows != null && onToggle != null;
+  const variant = item.product_variant?.trim();
+  const unresolved = item.tags?.includes('variant-price-unresolved') ?? false;
+  const showQty =
+    item.unit_price_minor != null && item.quantity != null && item.quantity !== 1;
+
+  const RowInner = (
+    <div
+      className={cn(
+        'grid grid-cols-[1fr_auto] items-start gap-4 px-5 py-3',
+        // Semantic hierarchy is expressed with indentation + a hairline
+        // ledger rule, never a chevron (#162 semantic level-2).
+        isChild && 'pl-11 pr-5',
+      )}
+    >
+      <div className="min-w-0">
+        <div className="flex items-center gap-2 flex-wrap">
+          {isChild && (
+            <span
+              aria-hidden
+              className="text-[var(--color-ink-faint)] -ml-4 mr-0.5 select-none"
+            >
+              &#8627;
+            </span>
+          )}
+          <span
+            className={cn(
+              'truncate',
+              isChild
+                ? 'text-[13px] text-[var(--color-ink-soft)]'
+                : 'text-sm font-medium text-[var(--color-ink)]',
+            )}
+          >
+            {name}
+          </span>
+          {!isChild && <ItemClassPill item={item} />}
+        </div>
+
+        {/* Semantic level-2: free customizations, printed inline & muted. */}
+        {variant && (
+          <div className="mt-0.5 text-[11.5px] leading-snug text-[var(--color-ink-muted)] italic">
+            {variant}
+          </div>
+        )}
+        {unresolved && (
+          <div className="mt-0.5 text-[10px] tracking-[0.06em] uppercase text-[var(--color-ink-faint)]">
+            add-on price not itemized on receipt
+          </div>
+        )}
+        {showQty && (
+          <div className="mt-0.5 text-[11px] text-[var(--color-ink-muted)] tnum">
+            {item.quantity} &times; {formatMinor(item.unit_price_minor, cur)}
+          </div>
+        )}
+      </div>
+
+      <div className="flex items-center gap-1.5">
+        <span
+          className={cn(
+            'font-mono tracking-tight tnum',
+            isChild ? 'text-[12.5px] text-[var(--color-ink-soft)]' : 'text-[13.5px] font-semibold',
+          )}
+        >
+          {formatMinor(allInMinor(item), cur)}
+        </span>
+        {disclosable &&
+          (open ? (
+            <ChevronDown size={15} className="text-[var(--color-ink-faint)]" />
+          ) : (
+            <ChevronRight size={15} className="text-[var(--color-ink-faint)]" />
+          ))}
+      </div>
+    </div>
+  );
+
+  return (
+    <li>
+      {disclosable ? (
+        <button
+          type="button"
+          onClick={onToggle}
+          aria-expanded={open}
+          className="w-full text-left hover:bg-[var(--color-paper-deep)]/25 transition-colors"
+        >
+          {RowInner}
+        </button>
+      ) : (
+        RowInner
+      )}
+
+      {/* Analytical level-2: list price → tax / tip / discount share →
+          all-in. Collapsed until tapped; suppressed in bulk on large
+          receipts (#162 adaptive disclosure). */}
+      {disclosable && open && rows && (
+        <div
+          className={cn(
+            'bg-[var(--color-paper)] border-t border-[var(--color-rule-soft)] px-5 py-2.5',
+            isChild ? 'pl-11' : '',
+          )}
+        >
+          <dl className="space-y-1">
+            {rows.map((r) => (
+              <div key={r.label} className="flex items-baseline justify-between gap-4">
+                <dt className="text-[11.5px] text-[var(--color-ink-muted)]">{r.label}</dt>
+                <dd
+                  className={cn(
+                    'font-mono text-[11.5px] tnum',
+                    r.kind === 'add' && 'text-[var(--color-ink-soft)]',
+                    r.kind === 'sub' && 'text-[var(--color-accent)]',
+                  )}
+                >
+                  {r.kind === 'add' ? '+ ' : ''}
+                  {formatMinor(r.minor, cur)}
+                </dd>
+              </div>
+            ))}
+            <div className="flex items-baseline justify-between gap-4 pt-1 mt-1 border-t border-[var(--color-rule-soft)]">
+              <dt className="text-[11.5px] font-medium text-[var(--color-ink)]">All-in</dt>
+              <dd className="font-mono text-[12px] font-semibold tnum">
+                {formatMinor(allInMinor(item), cur)}
+              </dd>
+            </div>
+          </dl>
+        </div>
+      )}
+    </li>
+  );
 }
 
 export function LineItemsCard({
@@ -32,54 +232,161 @@ export function LineItemsCard({
   items: BackendTransactionItem[];
   currency: string;
 }) {
+  const { topLevel, childrenOf, adjustments } = useMemo(() => {
+    const isProduct = (i: BackendTransactionItem) =>
+      (i.line_type ?? 'product') === 'product';
+    const products = items.filter(isProduct);
+    const productLineNos = new Set(products.map((p) => p.line_no));
+
+    const childrenOf = new Map<number, BackendTransactionItem[]>();
+    const topLevel: BackendTransactionItem[] = [];
+    for (const p of products) {
+      const parent = p.parent_line_no;
+      // Attach to a parent only when the parent is a real product line in
+      // this receipt; orphans (and flat legacy rows) render top-level.
+      if (parent != null && parent !== p.line_no && productLineNos.has(parent)) {
+        const arr = childrenOf.get(parent) ?? [];
+        arr.push(p);
+        childrenOf.set(parent, arr);
+      } else {
+        topLevel.push(p);
+      }
+    }
+    const adjustments = items.filter((i) => !isProduct(i));
+    return { topLevel, childrenOf, adjustments };
+  }, [items]);
+
+  const isLarge = topLevel.length > LARGE_RECEIPT_THRESHOLD;
+
+  // Per-line analytical disclosure state (set of open line_nos).
+  const [openLines, setOpenLines] = useState<Set<number>>(new Set());
+  const toggleLine = (lineNo: number) =>
+    setOpenLines((prev) => {
+      const next = new Set(prev);
+      if (next.has(lineNo)) next.delete(lineNo);
+      else next.add(lineNo);
+      return next;
+    });
+
+  // Which product lines actually have a breakdown to disclose.
+  const disclosableLineNos = useMemo(() => {
+    const s = new Set<number>();
+    for (const p of items) {
+      if ((p.line_type ?? 'product') === 'product' && breakdown(p) != null) {
+        s.add(p.line_no);
+      }
+    }
+    return s;
+  }, [items]);
+
+  const allOpen =
+    disclosableLineNos.size > 0 &&
+    [...disclosableLineNos].every((n) => openLines.has(n));
+
+  const toggleAll = () =>
+    setOpenLines(allOpen ? new Set() : new Set(disclosableLineNos));
+
   return (
     <div className="rounded-[18px] border border-[var(--color-rule)] bg-[var(--color-surface)] overflow-hidden">
-      <div className="px-5 py-4 border-b border-[var(--color-rule)] flex items-baseline justify-between">
+      <div className="px-5 py-4 border-b border-[var(--color-rule)] flex items-baseline justify-between gap-3">
         <h3 className="font-display font-medium text-lg leading-none">
-          Items <span className="text-[var(--color-ink-muted)]">({items.length})</span>
+          Items <span className="text-[var(--color-ink-muted)]">({topLevel.length})</span>
         </h3>
-        <span className="text-[10px] tracking-[0.16em] uppercase text-[var(--color-ink-muted)]">
-          from transaction_items
-        </span>
+        {/* Bulk breakdown toggle — collapsed by default, and withheld
+            entirely on large receipts so the analytical layer stays
+            per-line-tap only (large-receipt guard). */}
+        {!isLarge && disclosableLineNos.size > 0 && (
+          <button
+            type="button"
+            onClick={toggleAll}
+            aria-pressed={allOpen}
+            className="flex items-center gap-1 text-[10px] tracking-[0.14em] uppercase text-[var(--color-ink-muted)] hover:text-[var(--color-ink)] transition-colors"
+          >
+            {allOpen ? 'Hide breakdown' : 'Show breakdown'}
+            {allOpen ? <ChevronDown size={13} /> : <ChevronRight size={13} />}
+          </button>
+        )}
       </div>
+
       <ul className="divide-y divide-[var(--color-rule-soft)]">
-        {items.map((item) => {
-          const name = item.normalized_name?.trim() || item.raw_name;
+        {topLevel.map((parent) => {
+          const kids = childrenOf.get(parent.line_no) ?? [];
           return (
-            <li
-              key={item.line_no}
-              className="grid grid-cols-[1fr_auto] items-start gap-4 px-5 py-3"
-            >
-              <div className="min-w-0">
-                <div className="flex items-center gap-2">
-                  <span className="text-sm font-medium truncate">{name}</span>
-                  <span
-                    className={cn(
-                      'inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-medium leading-none',
-                      ITEM_CLASS_STYLE[item.item_class],
-                    )}
+            <li key={parent.line_no} className="p-0">
+              <ul>
+                <ProductLine
+                  item={parent}
+                  currency={currency}
+                  isChild={false}
+                  open={openLines.has(parent.line_no)}
+                  onToggle={
+                    disclosableLineNos.has(parent.line_no)
+                      ? () => toggleLine(parent.line_no)
+                      : null
+                  }
+                />
+                {kids.map((kid) => (
+                  <div
+                    key={kid.line_no}
+                    className="border-t border-[var(--color-rule-soft)]"
                   >
-                    {ITEM_CLASS_LABEL[item.item_class]}
-                  </span>
-                  {item.line_type !== 'product' && (
-                    <span className="text-[10px] text-[var(--color-ink-muted)] uppercase tracking-wider">
-                      {item.line_type}
-                    </span>
-                  )}
-                </div>
-                {item.unit_price_minor != null && item.quantity !== 1 && (
-                  <div className="mt-0.5 text-[11px] text-[var(--color-ink-muted)] tnum">
-                    {item.quantity} × {formatMinor(item.unit_price_minor, item.currency || currency)}
+                    <ProductLine
+                      item={kid}
+                      currency={currency}
+                      isChild
+                      open={openLines.has(kid.line_no)}
+                      onToggle={
+                        disclosableLineNos.has(kid.line_no)
+                          ? () => toggleLine(kid.line_no)
+                          : null
+                      }
+                    />
                   </div>
-                )}
-              </div>
-              <span className="font-mono font-semibold text-[13.5px] tracking-tight tnum">
-                {formatMinor(item.line_total_minor, item.currency || currency)}
-              </span>
+                ))}
+              </ul>
             </li>
           );
         })}
       </ul>
+
+      {/* Adjustments / Totals — tax, discounts, fees. Excluded from the
+          Items (N) count above (#162). */}
+      {adjustments.length > 0 && (
+        <div className="border-t border-[var(--color-rule)] bg-[var(--color-paper)]/40">
+          <div className="px-5 pt-3 pb-1.5">
+            <span className="text-[10px] tracking-[0.16em] uppercase text-[var(--color-ink-muted)]">
+              Adjustments &amp; Totals
+            </span>
+          </div>
+          <ul className="divide-y divide-[var(--color-rule-soft)]">
+            {adjustments.map((adj) => {
+              const name = adj.normalized_name?.trim() || adj.raw_name;
+              const cur = adj.currency || currency;
+              return (
+                <li
+                  key={`adj-${adj.line_no}`}
+                  className="grid grid-cols-[1fr_auto] items-baseline gap-4 px-5 py-2.5"
+                >
+                  <span className="text-[13px] text-[var(--color-ink-soft)] flex items-center gap-2">
+                    {name}
+                    <span className="text-[10px] uppercase tracking-wider text-[var(--color-ink-faint)]">
+                      {adj.line_type}
+                    </span>
+                  </span>
+                  <span
+                    className={cn(
+                      'font-mono text-[13px] tnum',
+                      adj.line_total_minor < 0 && 'text-[var(--color-accent)]',
+                    )}
+                  >
+                    {formatMinor(adj.line_total_minor, cur)}
+                  </span>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -4788,8 +4788,12 @@ export interface components {
         } | null;
         TransactionItem: {
             line_no: number;
+            /** @default null */
+            parent_line_no: number | null;
             raw_name: string;
             normalized_name: string | null;
+            /** @default null */
+            product_variant: string | null;
             quantity: number | null;
             unit: string | null;
             unit_price_minor: number | null;


### PR DESCRIPTION
## Summary

Fixes #135.

Renders receipt line-items as a faithful two-level **adaptive-disclosure** list, consuming the new `parent_line_no` + `product_variant` fields from the backend contract.

**Depends on TINKPA/receipt-assistant#162** — the `openapi.json` contract flows downstream (backend zod → committed spec → frontend codegen). The backend PR must merge **and** deploy to the mini (and the two fixtures re-extracted) before this renders against real data. Until then, `api-types.ts` here was regenerated from the backend `feat/two-level-line-items` local spec.

## Adaptive disclosure — NOT blanket expand

- **Semantic level-2 always visible by default (no click):** paid modifiers render as indented child rows nested under their parent dish (indentation + type weight + a ↳ ledger glyph, no chevron for the semantic level); free customizations print inline from `product_variant` under the item name.
- **Analytical level-2 collapsed until tapped:** the per-line list-price / tax-share / tip-share / discount-share breakdown is revealed on tap via a chevron. Only the all-in `effective_total_minor` shows inline by default.
- **Large-receipt guard:** when a receipt has >~12 top-level product lines, the analytical breakdown starts collapsed regardless, and the card-level "Show breakdown" bulk toggle is withheld.
- **Adjustments split:** `line_type` `tax` / `discount` rows move to a separate "Adjustments & Totals" group and are dropped from the "Items (N)" count.

## What changed

- **`src/components/ReceiptDetail/parts/LineItemsCard.tsx`** — rewritten (+350 lines) into the adaptive two-level list: `parent_line_no` grouping (orphan/flat legacy rows fall back to top-level), nested priced children, inline `product_variant`, per-line analytical breakdown behind a chevron, large-receipt guard, Adjustments group, and a subtle note surfacing the `variant-price-unresolved` tag.
- **`src/components/ReceiptDetail/index.tsx`** — added `parent_line_no` + `product_variant` to the legacy `metadata.items` fallback.
- **`src/lib/api-types.ts`** — regenerated from the backend `feat/two-level-line-items` local openapi spec to add the two fields. (The `api:types` script still defaults to GitHub `main`; it will pick these up automatically once #162 merges. The local override was **not** committed.)

## How it was verified (true headless, no visible window)

Playwright `launchPersistentContext`, `channel: 'chrome'`, `headless: true`, isolated `mkdtemp --user-data-dir`, viewport 900×1400 @2x, browser closed + vite killed after, no stray processes. Served from a plain-HTTP vite dev server (`VITE_DEV_HTTPS=false`, `127.0.0.1:5199`); the API was fully mocked at the browser layer via route interception on `/api/` with the canonical oracle `items[]`. No backend, no prod DB touched.

All ACs pass against both live fixtures:

- **CoCo Ichibanya** — `Items (3)`; Fried Chicken Curry carries 3 cleaned priced children (Large Rice / Spice Level 4 / Fish Cutlet, all-in $1.08 / $0.86 / $3.23), no `(curry modifier)` / `(curry topping)` anywhere in the body text; per-line breakdown appears only on tap; Tax $1.93 in "Adjustments & Totals", excluded from the count.
- **3CAT** — `Items (2)`; Avomango Sweet Dew shows `Less Sugar, Ice Blended` variant inline + 2 priced children ($1.25 / $0.75); Mochi Mango shows its variant + an "add-on price not itemized on receipt" note (`variant-price-unresolved`); Taxes & Fees $0.51 and Snackpass Credit −$5.00 in Adjustments.
- **Large-receipt guard** — a 14-product mocked receipt shows `Items (14)`, no bulk "Show breakdown" toggle, nothing expanded on load.

Screenshots (headless): `coco-01-default`, `coco-02-breakdown-tapped`, `3cat-01-collapsed`, `3cat-02-breakdown-tapped`, `big-01-guard`. `tsc --noEmit` exit 0; `vite build` succeeded.

## Open items

- The frontend `api:types` codegen picks up `parent_line_no` / `product_variant` from GitHub `main` only **after** #162 merges. Re-run `npm run api:types` post-merge to confirm the committed `api-types.ts` matches the merged spec (it should be identical).
- Live click-through against the real re-extracted fixtures should happen on the mini's frontend URL after the full Ship chain (see the backend PR's deploy-order note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
