### PR TITLE
fix: render HTML receipt documents in the Original receipt fold (#137)

### DIFF
--- a/src/components/ReceiptDetail/index.tsx
+++ b/src/components/ReceiptDetail/index.tsx
@@ -336,6 +336,10 @@ export default function ReceiptDetail({ receiptId, onBack, onAfterMutation }: Re
         <OriginalReceiptCollapsible
           documentId={receipt.documentId}
           kind={primaryDoc?.kind ?? null}
+          mimeType={
+            (primaryDoc as { mime_type?: string | null } | undefined)
+              ?.mime_type ?? null
+          }
           sourceMeta={
             (primaryDoc as { source_meta?: Record<string, unknown> | null } | undefined)
               ?.source_meta ?? null

--- a/src/components/ReceiptDetail/parts/OriginalReceiptCollapsible.tsx
+++ b/src/components/ReceiptDetail/parts/OriginalReceiptCollapsible.tsx
@@ -42,14 +42,24 @@ function EmailHeaderStrip({
 export function OriginalReceiptCollapsible({
   documentId,
   kind,
+  mimeType,
   sourceMeta,
 }: {
   documentId: string;
   kind?: string | null;
+  mimeType?: string | null;
   sourceMeta?: Record<string, unknown> | null;
 }) {
   const [open, setOpen] = useState(false);
   const isEmail = kind === 'receipt_email';
+  // A raw HTML document (portal invoice, saved web confirmation) renders
+  // through the same sanitized /rendered endpoint as email. Gate on the
+  // normalized base mime_type — independent of `kind` (an HTML doc
+  // classifies as receipt_pdf) — so it never falls to the non-sandboxed
+  // /content viewer. Strip the charset param and accept application/
+  // xhtml+xml so near-miss mimes still take the safe path. #137.
+  const baseMime = (mimeType ?? '').split(';')[0]?.trim().toLowerCase() ?? '';
+  const isHtml = baseMime === 'text/html' || baseMime === 'application/xhtml+xml';
   const isPdf = kind === 'receipt_pdf' || kind === 'statement_pdf';
   const sender = (sourceMeta?.sender as string | undefined) ?? null;
   const subject = (sourceMeta?.subject as string | undefined) ?? null;
@@ -97,6 +107,20 @@ export function OriginalReceiptCollapsible({
                 style={{ height: 520 }}
               />
             </div>
+          ) : isHtml ? (
+            /* Raw text/html receipt (portal invoice / saved confirmation).
+               Same containment as the email path: the backend serves the
+               sanitized markup with a strict CSP, and this iframe is
+               sandboxed (no scripts, no same-origin) as the second layer.
+               Fixed height + internal scroll since page heights vary. */
+            <iframe
+              src={documentRenderedUrl(documentId)}
+              title="Original receipt"
+              sandbox=""
+              referrerPolicy="no-referrer"
+              className="block w-full rounded-[10px] border border-[var(--color-rule)] bg-white"
+              style={{ height: 520 }}
+            />
           ) : isPdf ? (
             <div className="space-y-3">
               {/* PDFs can't render in an <img> tag — embed the browser's

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -2894,7 +2894,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Decoded + sanitized HTML body of a receipt_email document, for the frontend 'Original email' fold. Served with a strict CSP; render inside a sandboxed iframe. */
+        /** Sanitized HTML rendering of a document for the frontend's 'Original receipt / email' fold: a decoded receipt_email (.eml) body or a sanitized raw text/html document (#137). Served with a strict CSP; render inside a sandboxed iframe. */
         get: {
             parameters: {
                 query?: never;
@@ -2906,7 +2906,7 @@ export interface paths {
             };
             requestBody?: never;
             responses: {
-                /** @description Sanitized email HTML */
+                /** @description Sanitized HTML (email body or text/html document) */
                 200: {
                     headers: {
                         [name: string]: unknown;
@@ -2915,7 +2915,7 @@ export interface paths {
                         "text/html": string;
                     };
                 };
-                /** @description Not found / no file */
+                /** @description Not found / no file / empty render */
                 404: {
                     headers: {
                         [name: string]: unknown;
@@ -2924,7 +2924,7 @@ export interface paths {
                         "application/problem+json": components["schemas"]["ProblemDetails"];
                     };
                 };
-                /** @description Document is not an email (kind != receipt_email) */
+                /** @description Document has no HTML rendering (neither receipt_email nor text/html); code document-not-renderable */
                 422: {
                     headers: {
                         [name: string]: unknown;
@@ -4729,6 +4729,7 @@ export interface components {
              */
             id: string;
             kind: string;
+            mime_type?: string | null;
             source_meta?: {
                 [key: string]: unknown;
             } | null;


### PR DESCRIPTION
Frontend slice of **#137**, closing the cross-repo fix. Depends on TINKPA/receipt-assistant#172 (merged) which exposes `mime_type` on the transaction-detail document and makes `/rendered` serve `text/html`.

## What was broken
An HTML receipt's "Original receipt" fold rendered blank: `OriginalReceiptCollapsible` had only `receipt_email` (sandboxed iframe on `/rendered`), `receipt_pdf` (iframe on `/content`), and an `<img src=/content>` fallback — and an `<img>` can't load `text/html`, so `onError` hid it.

## Changes
- **`OriginalReceiptCollapsible`**: new `mimeType` prop and an **HTML branch** (before the PDF branch) that renders `/rendered` in a `sandbox=""` iframe — identical containment to the email path.
- Gates on the **normalized base `mime_type`** (strips the charset param, accepts `application/xhtml+xml`), independent of `kind`. This is also a security boundary: an HTML doc classifies as `receipt_pdf`, so gating on mime keeps it on the sanitized `/rendered` path instead of the non-sandboxed `/content` PDF iframe (see #172's `/content` hardening for the backstop).
- `ReceiptDetail` passes the document's `mime_type` through; `api-types` regenerated against the merged contract.

## Verification
- `tsc && vite build` clean.
- Backend already verified live on the mini: `/rendered` for the Tekmetric doc returns 200 sanitized HTML (all `<script>`/`<iframe>`/`<style>` stripped, table data preserved). Post-deploy browser evidence (sandboxed fold renders, no script execution) attached to #137.

🤖 Generated with [Claude Code](https://claude.com/claude-code)