### PR TITLE
feat: remove void UI, wire soft-delete/restore, drop voided status (#171)

### DIFF
--- a/src/components/BrandPage.tsx
+++ b/src/components/BrandPage.tsx
@@ -462,7 +462,6 @@ function RecentRow({
   onSelectReceipt?: (receiptId: string) => void;
 }) {
   const badge = statusBadge(row.status);
-  const isVoided = row.status === 'voided';
   const merchantLabel = row.merchant_custom_name ?? row.merchant_canonical_name;
   const body = (
     <>
@@ -488,10 +487,7 @@ function RecentRow({
         </p>
       </div>
       <span
-        className={cn(
-          'font-display italic font-medium text-[16px] tnum',
-          isVoided && 'line-through opacity-60',
-        )}
+        className="font-display italic font-medium text-[16px] tnum"
       >
         {(row.total_minor / 100).toLocaleString(undefined, {
           style: 'currency',

--- a/src/components/DeleteReceiptDialog.tsx
+++ b/src/components/DeleteReceiptDialog.tsx
@@ -65,7 +65,7 @@ const OPTION_DESCRIPTIONS: Record<
     tier: 'cascade',
     tag: 'reversible',
     title: 'Document + transaction',
-    help: 'Cascade soft-delete · voids the linked transaction with a reversing mirror entry (drafts are hard-deleted). A tombstone shows in the Ledger.',
+    help: 'Cascade soft-delete · soft-deletes the linked transaction (drafts are hard-deleted). A tombstone shows in the Ledger, restorable anytime.',
   },
   'cascade-hard': {
     glyph: '✕',

--- a/src/components/MerchantDetail.tsx
+++ b/src/components/MerchantDetail.tsx
@@ -558,7 +558,6 @@ function MerchantTxnRow({
   onSelect?: (id: string) => void;
 }) {
   const badge = statusBadge(tx.status);
-  const isVoided = tx.status === 'voided';
   // Body — a real <Link> (renders <a href>) so right-click → Open in
   // New Tab, Cmd-click, and hover URL preview all work. When no
   // navigation handler is wired up it falls back to a plain div.
@@ -579,10 +578,7 @@ function MerchantTxnRow({
           )}
         </p>
       </div>
-      <span className={cn(
-        'font-display italic font-medium text-[17px] tnum',
-        isVoided && 'line-through opacity-60',
-      )}>
+      <span className="font-display italic font-medium text-[17px] tnum">
         {(tx.total_minor / 100).toLocaleString(undefined, {
           style: 'currency',
           currency: tx.currency,

--- a/src/components/ReceiptDetail/index.tsx
+++ b/src/components/ReceiptDetail/index.tsx
@@ -3,10 +3,8 @@ import { brandLink } from '../../lib/navLinks';
 import {
   fetchReceiptDetail,
   extractProblemMessage,
-  getTransaction,
   postReExtractDocument,
   toReceiptView,
-  voidTransaction,
   restoreDocument,
   type BackendTransaction,
   type BackendTransactionItem,
@@ -16,7 +14,6 @@ import { statusBadge } from '../../lib/transactionStatus';
 import { cn } from '../../lib/utils';
 import type { Category } from '../../types';
 import EditReceiptModal from '../EditReceiptModal';
-import ConfirmActionDialog from '../ConfirmActionDialog';
 import DeleteReceiptDialog from '../DeleteReceiptDialog';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { qk } from '../../lib/queryKeys';
@@ -57,8 +54,8 @@ function md<T = unknown>(meta: Metadata | undefined, key: string): T | undefined
  *
  * Functional surface is unchanged from the previous Material-3 version:
  *   - Auto-polls every 5s while status is draft/error.
- *   - Edit / Void / Delete / Restore actions kept (the mockup shows just
- *     Edit + Delete; Void and Restore are conditional flows that show up
+ *   - Edit / Delete / Restore actions kept (the mockup shows just
+ *     Edit + Delete; Restore is a conditional flow that shows up
  *     for posted/reconciled and tombstoned receipts respectively).
  *   - Renders line items, location map, raw OCR text, extraction quality
  *     when those metadata sub-objects exist.
@@ -67,7 +64,7 @@ function md<T = unknown>(meta: Metadata | undefined, key: string): T | undefined
  */
 export default function ReceiptDetail({ receiptId, onBack, onAfterMutation }: ReceiptDetailProps) {
   const queryClient = useQueryClient();
-  const [activeDialog, setActiveDialog] = useState<'edit' | 'void' | 'delete' | null>(null);
+  const [activeDialog, setActiveDialog] = useState<'edit' | 'delete' | null>(null);
   const [restoreError, setRestoreError] = useState<string | null>(null);
   // Re-extract state machine. `idle` armed; `pending` (~30-60s — the
   // agent re-OCRs the image); `success` shows `changed_keys` toast;
@@ -101,7 +98,7 @@ export default function ReceiptDetail({ receiptId, onBack, onAfterMutation }: Re
   const invalidateReceipt = () =>
     queryClient.invalidateQueries({ queryKey: qk.receipt(receiptId) });
 
-  // ETag write-back invariant: a PATCH/void response carries a FRESH ETag.
+  // ETag write-back invariant: a PATCH response carries a FRESH ETag.
   // Write the updated view straight into the cache so a subsequent edit sends
   // the current If-Match. Invalidate-and-refetch would leave a stale-etag
   // window in which a fast second edit 412s — so this is setQueryData, not
@@ -109,24 +106,6 @@ export default function ReceiptDetail({ receiptId, onBack, onAfterMutation }: Re
   const handleUpdated = (txn: BackendTransaction, etag: string | null) => {
     queryClient.setQueryData(qk.receipt(receiptId), toReceiptView(txn, etag));
   };
-
-  const voidMut = useMutation({
-    mutationFn: async (reason: string) => {
-      // Defensive: if the cached view lacks an etag, re-fetch a fresh one.
-      let etag = receipt?.etag ?? null;
-      if (!etag) {
-        const fresh = await getTransaction(receipt!.id);
-        if (!fresh.etag) throw new Error('No ETag — reload and retry.');
-        etag = fresh.etag;
-      }
-      return voidTransaction(receipt!.id, reason, etag);
-    },
-    onSuccess: () => {
-      setActiveDialog(null);
-      invalidateReceipt();
-      onAfterMutation?.();
-    },
-  });
 
   const handleDeleted = () => {
     setActiveDialog(null);
@@ -245,13 +224,12 @@ export default function ReceiptDetail({ receiptId, onBack, onAfterMutation }: Re
   );
   const merchantLabel = receipt.payee ?? receipt.narration ?? 'Unknown';
 
-  const canDelete = receipt.status !== 'voided';
-  const canVoid = receipt.status === 'posted' || receipt.status === 'reconciled';
-  const canEdit = receipt.status !== 'voided';
-
   const primaryDoc = receipt.documents.find((d) => d.id === receipt.documentId) ?? receipt.documents[0];
   const docDeletedAt = (primaryDoc as { deleted_at?: string | null } | undefined)?.deleted_at ?? null;
   const isTombstoned = docDeletedAt != null;
+
+  const canDelete = !isTombstoned;
+  const canEdit = !isTombstoned;
 
   const badge = statusBadge(receipt.status);
   const lowConfidence = confidence != null && confidence < 0.6;
@@ -264,11 +242,9 @@ export default function ReceiptDetail({ receiptId, onBack, onAfterMutation }: Re
         deletedAt={docDeletedAt}
         isProcessing={isProcessing}
         canEdit={canEdit}
-        canVoid={canVoid}
         canDelete={canDelete}
         restoring={restoreMut.isPending}
         onEdit={() => setActiveDialog('edit')}
-        onVoid={() => setActiveDialog('void')}
         onDelete={() => setActiveDialog('delete')}
         onRestore={handleRestore}
       />
@@ -281,7 +257,7 @@ export default function ReceiptDetail({ receiptId, onBack, onAfterMutation }: Re
         category={receipt.category as Category | null}
         occurredOn={receipt.occurred_on}
         isProcessing={isProcessing}
-        voided={receipt.status === 'voided'}
+        tombstoned={isTombstoned}
         brandTo={
           // Merchant name in the hero → BrandPage (brand-level rollup
           // across all locations). The per-location detail is reachable
@@ -347,12 +323,12 @@ export default function ReceiptDetail({ receiptId, onBack, onAfterMutation }: Re
         />
       )}
 
-      {/* Re-extract affordance. Only on active (non-voided) receipts
+      {/* Re-extract affordance. Only on active (non-deleted) receipts
           that have a linked document. Wall-time is ~30-60s for vision
           OCR, so we make the pending state visible. */}
       {!isProcessing &&
         receipt.documentId &&
-        receipt.status !== 'voided' && (
+        !isTombstoned && (
           <div className="space-y-2">
             <button
               type="button"
@@ -412,28 +388,6 @@ export default function ReceiptDetail({ receiptId, onBack, onAfterMutation }: Re
         receipt={receipt}
         onUpdated={handleUpdated}
         onStale={invalidateReceipt}
-      />
-
-      <ConfirmActionDialog
-        isOpen={activeDialog === 'void'}
-        onClose={() => setActiveDialog(null)}
-        title="Void this receipt?"
-        message={
-          <>
-            <p>
-              Voiding creates a reversing entry in the ledger — the original transaction stays,
-              but its balance cancels out. Use this for posted receipts you can't simply delete.
-            </p>
-            <p className="mt-2 text-xs text-[var(--color-ink-muted)]">
-              This action can be reversed only by creating a new offsetting transaction.
-            </p>
-          </>
-        }
-        confirmLabel="Void receipt"
-        destructive
-        requireReason
-        reasonPlaceholder="Why are you voiding this? (optional)"
-        onConfirm={(reason) => voidMut.mutateAsync(reason).then(() => undefined)}
       />
 
       <DeleteReceiptDialog

--- a/src/components/ReceiptDetail/parts/AmountHero.tsx
+++ b/src/components/ReceiptDetail/parts/AmountHero.tsx
@@ -12,7 +12,7 @@ export function AmountHero({
   category,
   occurredOn,
   isProcessing,
-  voided,
+  tombstoned,
   brandTo,
 }: {
   amount: number;
@@ -22,7 +22,7 @@ export function AmountHero({
   category: Category | null;
   occurredOn: string;
   isProcessing: boolean;
-  voided: boolean;
+  tombstoned: boolean;
   /** Link target for the merchant name → BrandPage. Undefined renders a
    *  plain <h1> (no link) — e.g. while processing or with no brand. */
   brandTo?: ReturnType<typeof brandLink>;
@@ -37,7 +37,7 @@ export function AmountHero({
         className={cn(
           'font-display font-light tracking-tight tnum',
           'text-[3.25rem] sm:text-[4rem] leading-none',
-          voided && 'line-through text-[var(--color-ink-muted)]',
+          tombstoned && 'line-through text-[var(--color-ink-muted)]',
         )}
       >
         {isProcessing ? '—' : `$${amount.toFixed(2)}`}

--- a/src/components/ReceiptDetail/parts/TopBar.tsx
+++ b/src/components/ReceiptDetail/parts/TopBar.tsx
@@ -9,11 +9,9 @@ export function TopBar({
   deletedAt,
   isProcessing,
   canEdit,
-  canVoid,
   canDelete,
   restoring,
   onEdit,
-  onVoid,
   onDelete,
   onRestore,
 }: {
@@ -22,11 +20,9 @@ export function TopBar({
   deletedAt: string | null;
   isProcessing: boolean;
   canEdit: boolean;
-  canVoid: boolean;
   canDelete: boolean;
   restoring: boolean;
   onEdit: () => void;
-  onVoid: () => void;
   onDelete: () => void;
   onRestore: () => void;
 }) {
@@ -98,15 +94,6 @@ export function TopBar({
                       onEdit();
                     }}
                   />
-                  {canVoid && (
-                    <MenuItem
-                      label="Void receipt"
-                      onClick={() => {
-                        setMenuOpen(false);
-                        onVoid();
-                      }}
-                    />
-                  )}
                   <MenuItem
                     label="Delete…"
                     disabled={!canDelete}

--- a/src/components/TransactionRowMenu.tsx
+++ b/src/components/TransactionRowMenu.tsx
@@ -35,7 +35,6 @@ export default function TransactionRowMenu({
 
   const canHardDelete =
     rawStatus === 'posted' ||
-    rawStatus === 'voided' ||
     rawStatus === 'draft' ||
     rawStatus === 'error';
   const canUnreconcile = rawStatus === 'reconciled';

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -397,7 +397,7 @@ export interface paths {
                 query?: {
                     from?: string;
                     to?: string;
-                    include_voided?: boolean | null;
+                    include_deleted?: boolean | null;
                     cursor?: string;
                     limit?: number;
                 };
@@ -456,9 +456,10 @@ export interface paths {
                     account_id?: string;
                     payee_contains?: string;
                     q?: string;
-                    status?: "draft" | "posted" | "voided" | "reconciled" | "error";
+                    status?: "draft" | "posted" | "reconciled" | "error";
                     trip_id?: string;
                     has_document?: boolean | null;
+                    include_deleted?: boolean | null;
                     source_ingest_id?: string;
                     flagged?: "near_dup";
                     sort?: "occurred_on" | "amount" | "created_at";
@@ -597,7 +598,7 @@ export interface paths {
         post?: never;
         /**
          * Delete a transaction
-         * @description Default: only draft/error transactions may be hard-deleted; posted/voided return 409 (must-void-instead). ?hard=true forces a hard delete of any non-reconciled transaction (postings + document_links cascade). Reconciled transactions always reject — unreconcile first.
+         * @description Default: reversible soft delete (sets deleted_at; the row drops out of every money query but is restorable via POST /:id/restore). ?hard=true forces a physical delete (postings + document_links cascade; irreversible). Reconciled transactions reject either way — unreconcile first.
          */
         delete: {
             parameters: {
@@ -621,7 +622,7 @@ export interface paths {
                     };
                     content?: never;
                 };
-                /** @description Must void instead (posted, no ?hard=true), or transaction is reconciled. */
+                /** @description Transaction is reconciled — unreconcile first. */
                 409: {
                     headers: {
                         [name: string]: unknown;
@@ -683,7 +684,7 @@ export interface paths {
         };
         trace?: never;
     };
-    "/v1/transactions/{id}/void": {
+    "/v1/transactions/{id}/restore": {
         parameters: {
             query?: never;
             header?: never;
@@ -692,7 +693,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** Void a posted transaction */
+        /**
+         * Restore a soft-deleted transaction
+         * @description Clears deleted_at so the transaction counts again. 404 if it wasn't deleted.
+         */
         post: {
             parameters: {
                 query?: never;
@@ -704,19 +708,24 @@ export interface paths {
                 };
                 cookie?: never;
             };
-            requestBody?: {
-                content: {
-                    "application/json": components["schemas"]["VoidTransactionRequest"];
-                };
-            };
+            requestBody?: never;
             responses: {
-                /** @description Mirror transaction created */
-                201: {
+                /** @description Restored transaction */
+                200: {
                     headers: {
                         [name: string]: unknown;
                     };
                     content: {
                         "application/json": components["schemas"]["Transaction"];
+                    };
+                };
+                /** @description Not found / not deleted */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
                     };
                 };
             };
@@ -901,7 +910,7 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** Bulk update/void/reconcile */
+        /** Bulk update/reconcile */
         post: {
             parameters: {
                 query?: never;
@@ -2792,7 +2801,7 @@ export interface paths {
         post?: never;
         /**
          * Delete a document. Soft-deletes by default; ?hard=true removes the row and quarantines the file under .trash/; ?cascade=true also handles linked transactions.
-         * @description Default: soft delete (sets deleted_at). ?hard=true: hard delete (row removed; file moved to <uploads_dir>/.trash/<timestamp>__<basename>, NOT unlinked); requires no remaining links unless ?cascade=true is also set. ?cascade=true: linked posted transactions are voided, draft/error transactions are hard-deleted, voided transactions are left intact, reconciled transactions abort the operation with 409. ?cascade=true&hard=true: every linked transaction is hard-deleted (postings cascade), the document row is removed, and the image file is moved to .trash/ (never unlinked). Reconciled transactions always block hard cascades — unreconcile first.
+         * @description Default: soft delete (sets deleted_at). ?hard=true: hard delete (row removed; file moved to <uploads_dir>/.trash/<timestamp>__<basename>, NOT unlinked); requires no remaining links unless ?cascade=true is also set. ?cascade=true: linked posted transactions are soft-deleted, draft/error transactions are hard-deleted, already-deleted transactions are left intact, reconciled transactions abort the operation with 409. ?cascade=true&hard=true: every linked transaction is hard-deleted (postings cascade), the document row is removed, and the image file is moved to .trash/ (never unlinked). Reconciled transactions always block hard cascades — unreconcile first.
          */
         delete: {
             parameters: {
@@ -4846,12 +4855,9 @@ export interface components {
             payee: string | null;
             narration: string | null;
             /** @enum {string} */
-            status: "draft" | "posted" | "voided" | "reconciled" | "error";
-            /**
-             * Format: uuid
-             * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
-             */
-            voided_by_id: string | null;
+            status: "draft" | "posted" | "reconciled" | "error";
+            /** Format: date-time */
+            deleted_at: string | null;
             /**
              * Format: uuid
              * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
@@ -5449,7 +5455,7 @@ export interface components {
             occurred_on: string;
             payee: string | null;
             /** @enum {string} */
-            status: "draft" | "posted" | "voided" | "reconciled" | "error";
+            status: "draft" | "posted" | "reconciled" | "error";
             total_minor: number;
             currency: string;
             /**
@@ -5945,7 +5951,7 @@ export interface components {
             occurred_on: string;
             payee: string | null;
             /** @enum {string} */
-            status: "draft" | "posted" | "voided" | "reconciled" | "error";
+            status: "draft" | "posted" | "reconciled" | "error";
             total_minor: number;
             currency: string;
             /**
@@ -5993,7 +5999,7 @@ export interface components {
             payee?: string;
             narration?: string;
             /** @enum {string} */
-            status?: "draft" | "posted" | "voided" | "reconciled" | "error";
+            status?: "draft" | "posted" | "reconciled" | "error";
             postings: components["schemas"]["NewPosting"][];
             document_ids?: string[];
             /**
@@ -6032,9 +6038,6 @@ export interface components {
                 [key: string]: unknown;
             };
         };
-        VoidTransactionRequest: {
-            reason?: string;
-        };
         NearDupReviewResponse: {
             /**
              * Format: uuid
@@ -6063,16 +6066,6 @@ export interface components {
                 id: string;
                 if_match: string;
                 patch: components["schemas"]["UpdateTransactionRequest"];
-            } | {
-                /** @enum {string} */
-                op: "void";
-                /**
-                 * Format: uuid
-                 * @example 01HXY9F0ABCDEFGHJKMNPQRSTV
-                 */
-                id: string;
-                if_match: string;
-                reason?: string;
             } | {
                 /** @enum {string} */
                 op: "reconcile";

--- a/src/lib/api/core.ts
+++ b/src/lib/api/core.ts
@@ -611,7 +611,7 @@ export async function getAccountRegister(
   opts: {
     from?: string;
     to?: string;
-    includeVoided?: boolean;
+    includeDeleted?: boolean;
     cursor?: string;
     limit?: number;
   } = {},
@@ -622,7 +622,7 @@ export async function getAccountRegister(
       query: {
         from: opts.from,
         to: opts.to,
-        include_voided: opts.includeVoided,
+        include_deleted: opts.includeDeleted,
         cursor: opts.cursor,
         limit: opts.limit,
       },

--- a/src/lib/api/transactions.ts
+++ b/src/lib/api/transactions.ts
@@ -182,19 +182,18 @@ export async function patchTransaction(
   };
 }
 
-export async function voidTransaction(
+/** Restore a soft-deleted transaction (clears deleted_at). #171 */
+export async function restoreTransaction(
   id: string,
-  reason: string,
   etag: string,
 ): Promise<BackendTransaction> {
-  const { data, error, response } = await client.POST('/v1/transactions/{id}/void', {
+  const { data, error, response } = await client.POST('/v1/transactions/{id}/restore', {
     params: {
       path: { id },
       header: { 'If-Match': etag },
     },
-    body: { reason },
   });
-  return unwrap('voidTransaction', data, error, response.status);
+  return unwrap('restoreTransaction', data, error, response.status);
 }
 
 export async function deleteTransaction(id: string, etag: string): Promise<void> {
@@ -213,8 +212,9 @@ export async function deleteTransaction(id: string, etag: string): Promise<void>
   }
 }
 
-/** Force a hard delete of a posted/voided/draft/error transaction
- *  (postings + document_links cascade via FK). Reconciled is still
+/** Force a hard (physical) delete of a transaction — postings +
+ *  document_links cascade via FK. The default deleteTransaction is a
+ *  reversible soft delete; this is irreversible. Reconciled is still
  *  rejected with 409; caller must `unreconcileTransaction` first. */
 export async function hardDeleteTransaction(id: string, etag: string): Promise<void> {
   const { error, response } = await client.DELETE('/v1/transactions/{id}', {

--- a/src/lib/transactionStatus.ts
+++ b/src/lib/transactionStatus.ts
@@ -26,8 +26,6 @@ export function statusBadge(raw: RawTransactionStatus): StatusBadge | null {
       return null;
     case 'reconciled':
       return { label: 'Reconciled', tone: 'green' };
-    case 'voided':
-      return { label: 'Voided', tone: 'red', strikethrough: true };
     case 'error':
       return { label: 'Extraction failed', tone: 'red', retryable: true };
   }

--- a/src/lib/transactionsFilterState.ts
+++ b/src/lib/transactionsFilterState.ts
@@ -55,7 +55,6 @@ export const DATE_PRESET_LABEL: Record<DatePreset, string> = {
 export const STATUS_OPTIONS: { value: RawTransactionStatus; label: string }[] = [
   { value: 'draft', label: 'Draft' },
   { value: 'posted', label: 'Posted' },
-  { value: 'voided', label: 'Voided' },
   { value: 'reconciled', label: 'Reconciled' },
   { value: 'error', label: 'Error' },
 ];
@@ -168,7 +167,7 @@ export function isFilterActive(filters: FilterState, q: string): boolean {
 // keys from the querystring entirely.
 
 const datePresetSchema = z.enum(['month', 'all', 'last_30d', 'last_90d', 'this_year', 'custom']);
-const statusSchema = z.enum(['draft', 'posted', 'voided', 'reconciled', 'error']);
+const statusSchema = z.enum(['draft', 'posted', 'reconciled', 'error']);
 const sortIdSchema = z.enum(SORT_OPTIONS.map((o) => o.id) as [string, ...string[]]);
 
 // Every field is `.optional().catch(default)`: the `.catch` wraps the

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,7 +22,6 @@ export type TransactionType = typeof TRANSACTION_TYPES[number];
 export type RawTransactionStatus =
   | 'draft'
   | 'posted'
-  | 'voided'
   | 'reconciled'
   | 'error';
 


### PR DESCRIPTION
Frontend slice completing the void removal (backend #173/#174).

- Removes the Void action + dialog + `voidTransaction` client (`POST /:id/void` is gone); adds `restoreTransaction`.
- Delete now maps to the backend's default **soft delete**; the existing document cascade delete → tombstone → restore flow covers receipts.
- Drops the `voided` status everywhere (RawTransactionStatus, status badge, Ledger filter, BrandPage/MerchantDetail strikethrough); gates edit/delete/re-extract on `deleted_at` instead.
- `include_voided` → `include_deleted`; AmountHero `voided` prop → `tombstoned`; delete-dialog copy fixed.

tsc + vite build clean. Browser evidence on the mini attached to #171.

🤖 Generated with [Claude Code](https://claude.com/claude-code)